### PR TITLE
Update release intake manifest automation

### DIFF
--- a/.github/scripts/release-policy.sh
+++ b/.github/scripts/release-policy.sh
@@ -41,6 +41,22 @@ manifest_version_at_ref() {
     | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])'
 }
 
+set_manifest_version() {
+  local version="${1:-}"
+
+  python3 - "${version}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+version = sys.argv[1]
+path = Path("custom_components/haier_hon/manifest.json")
+data = json.loads(path.read_text())
+data["version"] = version
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+}
+
 assert_manifest_matches_tag() {
   local ref="${1:-}"
   local tag="${2:-}"

--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -49,8 +49,6 @@ jobs:
           DEV_SHA="$(git rev-parse origin/dev)"
           MAIN_SHA="$(git rev-parse origin/main)"
 
-          assert_manifest_matches_tag "${TAG_SHA}" "${TAG}"
-
           if [[ "${TAG_SHA}" == "${MAIN_SHA}" && "${DEV_SHA}" == "${MAIN_SHA}" ]]; then
             notice "Tag ${TAG} already points at the synchronized main/dev release commit."
             exit 0
@@ -68,7 +66,45 @@ jobs:
 
           OPEN_PR="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"
           if [[ -n "${OPEN_PR}" ]]; then
+            PR_BODY="$(gh pr view "${OPEN_PR}" --json body --jq '.body')"
+            export PR_BODY
+
+            if PR_TAG="$(extract_pr_marker release-tag)" && PR_SOURCE_SHA="$(extract_pr_marker release-source-sha)"; then
+              if [[ "${PR_TAG}" == "${TAG}" && "${PR_SOURCE_SHA}" == "${TAG_SHA}" && "${DEV_SHA}" == "${TAG_SHA}" ]]; then
+                notice "Release PR #${OPEN_PR} for ${TAG} already exists."
+                exit 0
+              fi
+            fi
+
             die "An open dev -> main PR already exists (#${OPEN_PR}). Close or merge it before pushing a new release tag."
+          fi
+
+          RELEASE_VERSION="$(version_from_tag "${TAG}")"
+          CURRENT_VERSION="$(manifest_version_at_ref "${TAG_SHA}")"
+
+          if [[ "${CURRENT_VERSION}" != "${RELEASE_VERSION}" ]]; then
+            notice "Updating manifest.json from ${CURRENT_VERSION} to ${RELEASE_VERSION} for ${TAG}."
+
+            git checkout -B dev origin/dev
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            set_manifest_version "${RELEASE_VERSION}"
+
+            if ! git diff --quiet -- custom_components/haier_hon/manifest.json; then
+              git add custom_components/haier_hon/manifest.json
+              git commit -m "chore: set manifest version ${RELEASE_VERSION}"
+              git push origin HEAD:refs/heads/dev
+            fi
+
+            TAG_SHA="$(git rev-parse HEAD)"
+            DEV_SHA="$(git rev-parse HEAD)"
+
+            git tag -f "${TAG}" "${TAG_SHA}"
+            git push origin ":refs/tags/${TAG}"
+            git push origin "refs/tags/${TAG}"
+          else
+            assert_manifest_matches_tag "${TAG_SHA}" "${TAG}"
           fi
 
           BODY="$(cat <<EOF

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -20,19 +20,21 @@ v1.2.3
 v1.2.3-beta
 ```
 
-The integration version in `custom_components/haier_hon/manifest.json` must
-match the tag without the leading `v`. For example, tag `v1.2.3-beta` requires
-manifest version `1.2.3-beta`.
+The release tag is the source of truth for the integration version. When the tag
+is pushed, the intake workflow updates
+`custom_components/haier_hon/manifest.json` on `dev` to match the tag without
+the leading `v`. For example, tag `v1.2.3-beta` writes manifest version
+`1.2.3-beta`.
 
 ## Operator Flow
 
 1. Work only on `dev`.
-2. Update `manifest.json` to the intended version.
-3. Create the release tag on the current `dev` HEAD.
-4. Push the tag.
-5. Let the workflow open the automatic `dev -> main` pull request.
-6. Merge that PR with squash only.
-7. The post-merge workflow moves `dev` to the squash commit, recreates the tag
+2. Create the release tag on the current `dev` HEAD.
+3. Push the tag.
+4. Let the workflow update `manifest.json` and open the automatic `dev -> main`
+   pull request.
+5. Merge that PR with squash only.
+6. The post-merge workflow moves `dev` to the squash commit, recreates the tag
    on that commit, and publishes the GitHub release.
 
 ## Bootstrap
@@ -89,5 +91,5 @@ fall back to `GITHUB_TOKEN`, but a dedicated token is preferred because:
 
 ## Current Repository Caveat
 
-Historical tags such as `2.3`, `2.3-rc1`, `2.2`, and `Dev1.0` do not match this
-policy. They are kept as history; the new validation applies to future tags.
+Historical tags before this workflow do not use the leading `v` prefix. They are
+kept as history; the new validation applies to future tags.


### PR DESCRIPTION
Maintenance PR for release automation. This is not a release PR and intentionally has no release markers. It updates release-intake so future release tags automatically update manifest.json from the tag version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow documentation to clarify accepted tag formats and process flow.

* **Chores**
  * Enhanced automated release intake workflow to synchronize manifest versioning with tag versions.
  * Improved tag and manifest validation logic in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->