### PR TITLE
Fix release intake for synchronized tags

### DIFF
--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -48,8 +48,10 @@ jobs:
           TAG_SHA="$(git rev-list -n 1 "${TAG}")"
           DEV_SHA="$(git rev-parse origin/dev)"
           MAIN_SHA="$(git rev-parse origin/main)"
+          RELEASE_VERSION="$(version_from_tag "${TAG}")"
+          CURRENT_VERSION="$(manifest_version_at_ref "${TAG_SHA}")"
 
-          if [[ "${TAG_SHA}" == "${MAIN_SHA}" && "${DEV_SHA}" == "${MAIN_SHA}" ]]; then
+          if [[ "${TAG_SHA}" == "${MAIN_SHA}" && "${DEV_SHA}" == "${MAIN_SHA}" && "${CURRENT_VERSION}" == "${RELEASE_VERSION}" ]]; then
             notice "Tag ${TAG} already points at the synchronized main/dev release commit."
             exit 0
           fi
@@ -78,9 +80,6 @@ jobs:
 
             die "An open dev -> main PR already exists (#${OPEN_PR}). Close or merge it before pushing a new release tag."
           fi
-
-          RELEASE_VERSION="$(version_from_tag "${TAG}")"
-          CURRENT_VERSION="$(manifest_version_at_ref "${TAG_SHA}")"
 
           if [[ "${CURRENT_VERSION}" != "${RELEASE_VERSION}" ]]; then
             notice "Updating manifest.json from ${CURRENT_VERSION} to ${RELEASE_VERSION} for ${TAG}."


### PR DESCRIPTION
Maintenance PR for release automation. This fixes the case where a release tag is created while dev and main are synchronized but manifest.json still needs to be bumped from the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release intake workflow synchronization validation to perform early version consistency checks between release tags and corresponding manifest file versions, ensuring that release tags are correctly identified as out-of-sync when version numbers differ, preventing incorrect release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->