### PR TITLE
Release v2.4.0

### DIFF
--- a/custom_components/haier_hon/manifest.json
+++ b/custom_components/haier_hon/manifest.json
@@ -1,11 +1,15 @@
 {
   "domain": "haier_hon",
   "name": "Haier hOn (Extended)",
-  "codeowners": ["@telard-pixel"],
+  "codeowners": [
+    "@telard-pixel"
+  ],
   "config_flow": true,
   "documentation": "https://github.com/telard-pixel/haier_hon",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/telard-pixel/haier_hon/issues",
-  "requirements": ["pyhon==0.17.5"],
-  "version": "2.3-rc1"
+  "requirements": [
+    "pyhon==0.17.5"
+  ],
+  "version": "2.4.0"
 }


### PR DESCRIPTION
Automated release PR for `v2.4.0`.

<!-- release-tag: v2.4.0 -->
<!-- release-source-sha: 2fc65a9c57534426eec08a8ba298f82227cfc5e0 -->

Merge this PR with squash only. The post-merge workflow will move `dev` to the squash commit, recreate `v2.4.0` on that commit, and publish the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.4.0 of the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->