### PR TITLE
Release v2.4.2

### DIFF
--- a/custom_components/haier_hon/__init__.py
+++ b/custom_components/haier_hon/__init__.py
@@ -20,6 +20,22 @@ async def _async_close_client(client) -> None:
         _LOGGER.warning("Errore chiusura HonClient: %s", err)
 
 
+def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Rimuove dal registry le entità legacy non più fornite dall'integrazione.
+
+    Lo switch "Alimentazione" (unique_id '<id>_power') è stato rimosso nel
+    refactor 2.3/2.4: senza questa pulizia resterebbe nel registry come entità
+    orfana, in stato 'unavailable' con il badge '?' su ogni elettrodomestico.
+    """
+    from homeassistant.helpers import entity_registry as er
+
+    registry = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if (reg_entry.unique_id or "").endswith("_power"):
+            registry.async_remove(reg_entry.entity_id)
+            _LOGGER.info("Rimossa entità legacy 'Alimentazione': %s", reg_entry.entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Configura l'integrazione Haier hOn partendo da un Config Entry."""
     from .hon_client import HonClient, _requires_reauth
@@ -80,6 +96,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "client": hon_client,
         }
         stored = True
+
+        # Pulizia entità legacy (es. switch "Alimentazione" rimosso): non deve
+        # mai bloccare il setup, quindi assorbiamo eventuali errori del registry.
+        try:
+            _remove_legacy_entities(hass, entry)
+        except Exception as err:
+            _LOGGER.debug("Pulizia entità legacy non riuscita: %s", err)
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except asyncio.CancelledError:

--- a/custom_components/haier_hon/base_entity.py
+++ b/custom_components/haier_hon/base_entity.py
@@ -33,6 +33,20 @@ class HonBaseEntity(CoordinatorEntity):
     def _appliance(self):
         return self._appliance_data.get("appliance")
 
+    def _coordinator_store(self, name: str) -> dict:
+        """Store volatile condiviso tra le entità, tenuto sul coordinator.
+
+        A differenza di coordinator.data (ricreato a ogni refresh), un attributo
+        sul coordinator sopravvive agli aggiornamenti, così entità diverse dello
+        stesso device possono condividere stato effimero (es. il programma
+        scelto dal select ma non ancora avviato, letto poi dal button "Avvia").
+        """
+        store = getattr(self.coordinator, name, None)
+        if not isinstance(store, dict):
+            store = {}
+            setattr(self.coordinator, name, store)
+        return store
+
     @property
     def device_info(self) -> DeviceInfo:
         data = self._appliance_data

--- a/custom_components/haier_hon/button.py
+++ b/custom_components/haier_hon/button.py
@@ -10,13 +10,14 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
-from .const import APPLIANCE_WASH_GROUP, DOMAIN, PROGRAM_PARAM_NAMES
+from .const import (
+    APPLIANCE_WASH_GROUP,
+    DOMAIN,
+    PROGRAM_PARAM_NAMES,
+    PROGRAM_PENDING_STORE,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-# Deve combaciare con select.PENDING_STORE: programma scelto dal select ma non
-# ancora avviato. Lo applichiamo a startProgram al momento dell'avvio.
-PENDING_STORE = "pending_programs"
 
 
 async def async_setup_entry(
@@ -94,7 +95,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
 
         # Avvio: applichiamo il programma scelto dal select (se presente).
         # Lo leggiamo qui sull'event loop di HA e lo passiamo dentro _inner.
-        store = self._coordinator_store(PENDING_STORE)
+        store = self._coordinator_store(PROGRAM_PENDING_STORE)
         pending_program = (
             store.get(self._appliance_id)
             if self._command_name == "startProgram"
@@ -111,11 +112,26 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             f"Disponibili: {list(commands.keys())}"
                         )
                     params = getattr(command, "parameters", {})
-                    if pending_program is not None and isinstance(params, dict):
-                        for pname in PROGRAM_PARAM_NAMES:
-                            if pname in params:
-                                params[pname].value = pending_program
-                                break
+                    if pending_program is not None:
+                        # Fail-safe: se non riusciamo ad attaccare il programma
+                        # scelto a startProgram, NON avviamo (eviteremmo di far
+                        # partire un programma diverso da quello selezionato).
+                        applied = False
+                        if isinstance(params, dict):
+                            for pname in PROGRAM_PARAM_NAMES:
+                                if pname in params:
+                                    params[pname].value = pending_program
+                                    applied = True
+                                    break
+                        if not applied:
+                            available = (
+                                list(params.keys()) if isinstance(params, dict) else params
+                            )
+                            raise RuntimeError(
+                                "Programma selezionato non applicabile a "
+                                f"'{self._command_name}': nessun parametro "
+                                f"{PROGRAM_PARAM_NAMES} tra {available}"
+                            )
                     for name, value in self._command_parameters.items():
                         if name in params:
                             params[name].value = value

--- a/custom_components/haier_hon/button.py
+++ b/custom_components/haier_hon/button.py
@@ -10,9 +10,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
-from .const import APPLIANCE_WASH_GROUP, DOMAIN
+from .const import APPLIANCE_WASH_GROUP, DOMAIN, PROGRAM_PARAM_NAMES
 
 _LOGGER = logging.getLogger(__name__)
+
+# Deve combaciare con select.PENDING_STORE: programma scelto dal select ma non
+# ancora avviato. Lo applichiamo a startProgram al momento dell'avvio.
+PENDING_STORE = "pending_programs"
 
 
 async def async_setup_entry(
@@ -87,6 +91,15 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
         client = self._hon_client
         if not appliance or not client:
             raise HomeAssistantError("Button: appliance o client non disponibile")
+
+        # Avvio: applichiamo il programma scelto dal select (se presente).
+        # Lo leggiamo qui sull'event loop di HA e lo passiamo dentro _inner.
+        store = self._coordinator_store(PENDING_STORE)
+        pending_program = (
+            store.get(self._appliance_id)
+            if self._command_name == "startProgram"
+            else None
+        )
         try:
             def _do():
                 async def _inner():
@@ -98,6 +111,11 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             f"Disponibili: {list(commands.keys())}"
                         )
                     params = getattr(command, "parameters", {})
+                    if pending_program is not None and isinstance(params, dict):
+                        for pname in PROGRAM_PARAM_NAMES:
+                            if pname in params:
+                                params[pname].value = pending_program
+                                break
                     for name, value in self._command_parameters.items():
                         if name in params:
                             params[name].value = value
@@ -106,6 +124,10 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                 client.run_command_sync(_inner())
 
             await self.hass.async_add_executor_job(_do)
+            # Avvio riuscito: il programma è ora "reale", svuotiamo la scelta in
+            # attesa così il select torna a riflettere lo stato del device.
+            if pending_program is not None:
+                store.pop(self._appliance_id, None)
             _LOGGER.info("Button: comando '%s' inviato", self._command_name)
             await self._async_request_command_refresh()
         except Exception as err:

--- a/custom_components/haier_hon/const.py
+++ b/custom_components/haier_hon/const.py
@@ -19,6 +19,11 @@ APPLIANCE_WD = "WD"       # Lavasciuga
 # Raggruppa tutti gli elettrodomestici lavatrice/asciugatrice/lavasciuga
 APPLIANCE_WASH_GROUP = (APPLIANCE_WM, APPLIANCE_TD, APPLIANCE_WD)
 
+# Nomi dei parametri che, nei comandi hOn, contengono il codice/nome del
+# programma. Condivisi tra il select (sorgente opzioni + scelta) e il button
+# "Avvia programma" (applica il programma scelto a startProgram).
+PROGRAM_PARAM_NAMES = ("program", "prCode")
+
 # ─── Attributi condizionatore ─────────────────────────────────────────────────
 # Confermati dai diagnostics del device AS35PBPHRA-PRE
 AC_ATTR_MODE         = "settings.machMode"

--- a/custom_components/haier_hon/const.py
+++ b/custom_components/haier_hon/const.py
@@ -24,6 +24,11 @@ APPLIANCE_WASH_GROUP = (APPLIANCE_WM, APPLIANCE_TD, APPLIANCE_WD)
 # "Avvia programma" (applica il programma scelto a startProgram).
 PROGRAM_PARAM_NAMES = ("program", "prCode")
 
+# Chiave dello store volatile (tenuto sul coordinator) che conserva il programma
+# scelto dal select ma non ancora avviato; il button "Avvia programma" lo applica
+# a startProgram. Unica fonte di verità condivisa tra select.py e button.py.
+PROGRAM_PENDING_STORE = "pending_programs"
+
 # ─── Attributi condizionatore ─────────────────────────────────────────────────
 # Confermati dai diagnostics del device AS35PBPHRA-PRE
 AC_ATTR_MODE         = "settings.machMode"

--- a/custom_components/haier_hon/manifest.json
+++ b/custom_components/haier_hon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pyhon==0.17.5"
   ],
-  "version": "2.4.0"
+  "version": "2.4.1"
 }

--- a/custom_components/haier_hon/manifest.json
+++ b/custom_components/haier_hon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pyhon==0.17.5"
   ],
-  "version": "2.4.1"
+  "version": "2.4.2"
 }

--- a/custom_components/haier_hon/select.py
+++ b/custom_components/haier_hon/select.py
@@ -10,7 +10,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
-from .const import APPLIANCE_WASH_GROUP, DOMAIN, PROGRAM_PARAM_NAMES
+from .const import (
+    APPLIANCE_WASH_GROUP,
+    DOMAIN,
+    PROGRAM_PARAM_NAMES,
+    PROGRAM_PENDING_STORE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,8 +28,6 @@ PROGRAM_SELECT_COMMANDS = ("settings", "setProgram", "setProgramme", "programSet
 # programma solo via startProgram restavano senza select (entità orfana
 # "unavailable").
 PROGRAM_SOURCE_COMMANDS = PROGRAM_SELECT_COMMANDS + ("startProgram",)
-# Chiave dello store condiviso col button "Avvia programma".
-PENDING_STORE = "pending_programs"
 
 
 async def async_setup_entry(
@@ -130,7 +133,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
     def current_option(self) -> str | None:
         # 1) Scelta in attesa di avvio ("imposta e basta"): la mostriamo subito,
         #    finché l'utente non avvia il ciclo col pulsante "Avvia programma".
-        pending = self._coordinator_store(PENDING_STORE).get(self._appliance_id)
+        pending = self._coordinator_store(PROGRAM_PENDING_STORE).get(self._appliance_id)
         if pending is not None:
             label = self._program_map.get(str(pending))
             if label is not None:
@@ -149,8 +152,15 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
             "program",
         ):
             val = self._get_attr(key)
-            if val is not None and str(val) in self._program_map:
-                return self._program_map[str(val)]
+            if val is None:
+                continue
+            token = str(val)
+            # token può essere un codice (chiave della mappa) oppure già
+            # un'etichetta (es. programName espone il nome del programma).
+            if token in self._program_map:
+                return self._program_map[token]
+            if token in self._program_reverse:
+                return token
         return None
 
     async def async_select_option(self, option: str) -> None:
@@ -161,7 +171,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         # Selezionare un programma non deve mai far partire l'elettrodomestico;
         # l'avvio avviene col pulsante "Avvia programma", che legge questo
         # programma in attesa e lo applica al comando startProgram.
-        self._coordinator_store(PENDING_STORE)[self._appliance_id] = code
+        self._coordinator_store(PROGRAM_PENDING_STORE)[self._appliance_id] = code
         _LOGGER.info(
             "Select: programma '%s' (code=%s) impostato; avvialo con 'Avvia programma'",
             option, code,

--- a/custom_components/haier_hon/select.py
+++ b/custom_components/haier_hon/select.py
@@ -10,12 +10,21 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
-from .const import APPLIANCE_WASH_GROUP, DOMAIN
+from .const import APPLIANCE_WASH_GROUP, DOMAIN, PROGRAM_PARAM_NAMES
 
 _LOGGER = logging.getLogger(__name__)
 
-PROGRAM_PARAM_NAMES = ("program", "prCode")
+# Comandi "safe" (non avviano un ciclo) da cui leggere/scrivere il programma.
 PROGRAM_SELECT_COMMANDS = ("settings", "setProgram", "setProgramme", "programSettings")
+# Comandi da cui ATTINGERE l'elenco programmi. Includiamo anche startProgram
+# come sorgente di metadati: la selezione è disaccoppiata dall'avvio (vedi
+# async_select_option), quindi leggere le opzioni da startProgram NON fa partire
+# l'elettrodomestico. Senza questo, le lavatrici/asciugatrici che espongono il
+# programma solo via startProgram restavano senza select (entità orfana
+# "unavailable").
+PROGRAM_SOURCE_COMMANDS = PROGRAM_SELECT_COMMANDS + ("startProgram",)
+# Chiave dello store condiviso col button "Avvia programma".
+PENDING_STORE = "pending_programs"
 
 
 async def async_setup_entry(
@@ -60,7 +69,8 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
 
     @classmethod
     def supports_appliance(cls, appliance) -> bool:
-        """Ritorna True solo se esiste un comando programma non-start."""
+        """True se esiste un comando (incluso startProgram) con un parametro
+        programma valorizzato da cui costruire l'elenco delle opzioni."""
         command_info = cls._find_program_command(appliance)
         if command_info is None:
             return False
@@ -72,7 +82,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         if appliance is None:
             return None
         commands = appliance.commands if isinstance(appliance.commands, dict) else {}
-        for command_name in PROGRAM_SELECT_COMMANDS:
+        for command_name in PROGRAM_SOURCE_COMMANDS:
             command = commands.get(command_name)
             if command is None:
                 continue
@@ -118,53 +128,42 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        # FIX: controllare esplicitamente is not None invece di usare 'or' che scarta 0
-        code = None
+        # 1) Scelta in attesa di avvio ("imposta e basta"): la mostriamo subito,
+        #    finché l'utente non avvia il ciclo col pulsante "Avvia programma".
+        pending = self._coordinator_store(PENDING_STORE).get(self._appliance_id)
+        if pending is not None:
+            label = self._program_map.get(str(pending))
+            if label is not None:
+                return label
+
+        # 2) Stato reale dal device. Proviamo sia il nome programma sia il codice
+        #    (prCode/program) e usiamo il primo che corrisponde a un'opzione nota.
+        #    FIX: controllare is not None invece di 'or' che scarterebbe lo 0.
         for key in (
+            "programName",
             "settings.program",
             "settings.prCode",
             "startProgram.program",
             "startProgram.prCode",
             "prCode",
+            "program",
         ):
             val = self._get_attr(key)
-            if val is not None:
-                code = val
-                break
-        
-        if code is None:
-            return None
-        return self._program_map.get(str(code))
+            if val is not None and str(val) in self._program_map:
+                return self._program_map[str(val)]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         code = self._program_reverse.get(option)
         if code is None:
             raise HomeAssistantError(f"Select: programma '{option}' non trovato nella mappa")
-        appliance = self._appliance
-        client = self._hon_client
-        if not appliance or not client:
-            raise HomeAssistantError("Select: appliance o client non disponibile")
-        try:
-            def _do():
-                async def _inner():
-                    command_info = self._find_program_command(appliance)
-                    if command_info is None:
-                        commands = appliance.commands if isinstance(appliance.commands, dict) else {}
-                        raise RuntimeError(
-                            "Comando selezione programma sicuro non trovato. "
-                            f"Disponibili: {list(commands.keys())}"
-                        )
-                    command_name, command, param_name = command_info
-                    command.parameters[param_name].value = code
-                    await command.send()
-
-                client.run_command_sync(_inner())
-
-            await self.hass.async_add_executor_job(_do)
-            _LOGGER.info("Select: programma '%s' (code=%s) inviato", option, code)
-            await self._async_request_command_refresh()
-        except Exception as err:
-            _LOGGER.error("Select: errore selezione programma '%s': %s", option, err, exc_info=True)
-            raise HomeAssistantError(
-                f"Select: errore selezione programma '{option}': {err}"
-            ) from err
+        # "Imposta e basta": memorizziamo la scelta SENZA inviare alcun comando.
+        # Selezionare un programma non deve mai far partire l'elettrodomestico;
+        # l'avvio avviene col pulsante "Avvia programma", che legge questo
+        # programma in attesa e lo applica al comando startProgram.
+        self._coordinator_store(PENDING_STORE)[self._appliance_id] = code
+        _LOGGER.info(
+            "Select: programma '%s' (code=%s) impostato; avvialo con 'Avvia programma'",
+            option, code,
+        )
+        self.async_write_ha_state()

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -1,6 +1,7 @@
 """Regression tests for the restored program select and power cleanup.
 
-Copre la fix Opzione B (release 2.4.0 vs 2.2):
+Copre la fix Opzione B (regressione comparsa nella release pubblica 2.4.0,
+l'ultima funzionante era la 2.2):
 - il select "Programma" torna a essere creato/disponibile anche quando il
   programma è esposto solo via startProgram;
 - selezionare un programma NON avvia il ciclo (imposta e basta);
@@ -315,6 +316,45 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual("Cotone", entity.current_option)
 
+    async def test_current_option_matches_human_label_from_device(self) -> None:
+        from custom_components.haier_hon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        # Il device espone direttamente il NOME del programma, non il codice.
+        coordinator = FakeCoordinator(
+            _washer({"startProgram": start}, attributes={"programName": "Sintetici"})
+        )
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        self.assertEqual("Sintetici", entity.current_option)
+
+    async def test_start_button_keeps_pending_when_program_not_applicable(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.haier_hon.button import HonProgramCommandButton
+
+        # startProgram senza parametro programma: il programma scelto non è
+        # applicabile, quindi NON si avvia e la scelta in attesa resta.
+        start = RecordingCommand({"onOffStatus": Param("1")})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        coordinator.pending_programs = {"washer-1": "2"}
+        button = HonProgramCommandButton(
+            coordinator,
+            "washer-1",
+            FakeClient(),
+            command_name="startProgram",
+            unique_suffix="start_program",
+            name_suffix="Avvia programma",
+            icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        with self.assertRaisesRegex(HomeAssistantError, "non applicabile"):
+            await button.async_press()
+
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+
     async def test_unknown_option_raises(self) -> None:
         from homeassistant.exceptions import HomeAssistantError
         from custom_components.haier_hon.select import HonProgramSelect
@@ -352,6 +392,12 @@ class LegacyPowerCleanupTest(unittest.TestCase):
             RegEntry("select.washer_programma", "washer-1_program"),
             RegEntry("sensor.washer_energia_totale", "washer-1_total_energy"),
         ])
+        # Patch limitata al test: ripristina le funzioni globali del registry
+        # anche in caso di fallimento, per non sporcare gli altri test.
+        self.addCleanup(setattr, er, "async_get", er.async_get)
+        self.addCleanup(
+            setattr, er, "async_entries_for_config_entry", er.async_entries_for_config_entry
+        )
         er.async_get = lambda hass: registry
         er.async_entries_for_config_entry = lambda reg, entry_id: list(reg._entries)
 

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -1,0 +1,365 @@
+"""Regression tests for the restored program select and power cleanup.
+
+Copre la fix Opzione B (release 2.4.0 vs 2.2):
+- il select "Programma" torna a essere creato/disponibile anche quando il
+  programma è esposto solo via startProgram;
+- selezionare un programma NON avvia il ciclo (imposta e basta);
+- il pulsante "Avvia programma" applica il programma scelto e svuota la scelta;
+- lo switch legacy "Alimentazione" (_power) viene rimosso dal registry.
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import enum
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_homeassistant_stubs() -> None:
+    homeassistant = _ensure_module("homeassistant")
+
+    config_entries = _ensure_module("homeassistant.config_entries")
+
+    class ConfigEntry:
+        pass
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+    config_entries.ConfigEntry = getattr(config_entries, "ConfigEntry", ConfigEntry)
+    config_entries.ConfigFlow = getattr(config_entries, "ConfigFlow", ConfigFlow)
+
+    core = _ensure_module("homeassistant.core")
+
+    class HomeAssistant:
+        pass
+
+    core.HomeAssistant = getattr(core, "HomeAssistant", HomeAssistant)
+
+    exceptions = _ensure_module("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        pass
+
+    class ConfigEntryNotReady(HomeAssistantError):
+        pass
+
+    class ConfigEntryAuthFailed(HomeAssistantError):
+        pass
+
+    exceptions.HomeAssistantError = getattr(exceptions, "HomeAssistantError", HomeAssistantError)
+    exceptions.ConfigEntryNotReady = getattr(
+        exceptions, "ConfigEntryNotReady", ConfigEntryNotReady
+    )
+    exceptions.ConfigEntryAuthFailed = getattr(
+        exceptions, "ConfigEntryAuthFailed", ConfigEntryAuthFailed
+    )
+
+    helpers = _ensure_module("homeassistant.helpers")
+    entity = _ensure_module("homeassistant.helpers.entity")
+    entity.DeviceInfo = getattr(entity, "DeviceInfo", dict)
+
+    entity_platform = _ensure_module("homeassistant.helpers.entity_platform")
+    entity_platform.AddEntitiesCallback = getattr(
+        entity_platform, "AddEntitiesCallback", object
+    )
+
+    entity_registry = _ensure_module("homeassistant.helpers.entity_registry")
+    # Default no-op; i test che servono li sovrascrivono.
+    entity_registry.async_get = getattr(
+        entity_registry, "async_get", lambda hass: None
+    )
+    entity_registry.async_entries_for_config_entry = getattr(
+        entity_registry, "async_entries_for_config_entry", lambda registry, entry_id: []
+    )
+
+    update_coordinator = _ensure_module("homeassistant.helpers.update_coordinator")
+
+    class CoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+            self.hass = getattr(coordinator, "hass", None)
+
+        def async_write_ha_state(self) -> None:
+            self.state_writes = getattr(self, "state_writes", 0) + 1
+
+    class DataUpdateCoordinator:
+        pass
+
+    class UpdateFailed(Exception):
+        pass
+
+    update_coordinator.CoordinatorEntity = getattr(
+        update_coordinator, "CoordinatorEntity", CoordinatorEntity
+    )
+    update_coordinator.DataUpdateCoordinator = getattr(
+        update_coordinator, "DataUpdateCoordinator", DataUpdateCoordinator
+    )
+    update_coordinator.UpdateFailed = getattr(update_coordinator, "UpdateFailed", UpdateFailed)
+
+    components = _ensure_module("homeassistant.components")
+    button_module = _ensure_module("homeassistant.components.button")
+    switch_module = _ensure_module("homeassistant.components.switch")
+    select_module = _ensure_module("homeassistant.components.select")
+
+    class SwitchEntity:
+        pass
+
+    class ButtonEntity:
+        pass
+
+    class SelectEntity:
+        pass
+
+    button_module.ButtonEntity = getattr(button_module, "ButtonEntity", ButtonEntity)
+    switch_module.SwitchEntity = getattr(switch_module, "SwitchEntity", SwitchEntity)
+    select_module.SelectEntity = getattr(select_module, "SelectEntity", SelectEntity)
+
+    homeassistant.config_entries = config_entries
+    homeassistant.core = core
+    homeassistant.exceptions = exceptions
+    homeassistant.helpers = helpers
+    homeassistant.components = components
+    helpers.entity = entity
+    helpers.entity_platform = entity_platform
+    helpers.entity_registry = entity_registry
+    helpers.update_coordinator = update_coordinator
+    components.button = button_module
+    components.switch = switch_module
+    components.select = select_module
+
+
+_install_homeassistant_stubs()
+
+
+class FakeClient:
+    def run_command_sync(self, coro) -> None:
+        asyncio.run(coro)
+
+
+class FakeCoordinator:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+        self.hass = None
+        self.refreshes = 0
+        self.last_update_success = True
+        self.last_exception = None
+
+    async def async_refresh(self) -> None:
+        self.refreshes += 1
+
+    async def async_request_refresh(self) -> None:
+        self.refreshes += 1
+
+
+class FakeHass:
+    def __init__(self, data: dict | None = None) -> None:
+        self.data = data or {}
+
+    async def async_add_executor_job(self, func, *args):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(func, *args).result(timeout=5)
+
+
+class Param:
+    def __init__(self, value=None, values=None) -> None:
+        self.value = value
+        self.values = values
+
+
+class RecordingCommand:
+    def __init__(self, parameters=None) -> None:
+        self.parameters = parameters or {}
+        self.send_calls = 0
+
+    async def send(self) -> None:
+        self.send_calls += 1
+
+
+class FakeEntry:
+    def __init__(self, entry_id: str = "entry-1") -> None:
+        self.entry_id = entry_id
+
+
+def _washer(commands: dict, attributes: dict | None = None) -> dict:
+    return {
+        "washer-1": {
+            "type": "WM",
+            "name": "Washer",
+            "appliance": types.SimpleNamespace(commands=commands),
+            "attributes": attributes or {},
+            "settings": {},
+        }
+    }
+
+
+class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    async def test_select_created_for_start_program_only_appliance(self) -> None:
+        from custom_components.haier_hon.const import DOMAIN
+        from custom_components.haier_hon import select
+
+        commands = {
+            "startProgram": RecordingCommand(
+                {"program": Param(values={"1": "Cotone", "2": "Sintetici"})}
+            )
+        }
+        coordinator = FakeCoordinator(_washer(commands))
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}})
+        added: list = []
+
+        await select.async_setup_entry(hass, FakeEntry(), added.extend)
+
+        self.assertEqual(1, len(added))
+        self.assertEqual("Washer - Programma", added[0]._attr_name)
+        self.assertEqual(["Cotone", "Sintetici"], added[0]._attr_options)
+
+    async def test_select_option_records_pending_without_starting(self) -> None:
+        from custom_components.haier_hon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        await entity.async_select_option("Sintetici")
+
+        # Nessun comando inviato: selezionare NON avvia l'elettrodomestico.
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+        # Il parametro del comando NON è stato toccato in fase di selezione.
+        self.assertIsNone(start.parameters["program"].value)
+        # La scelta è memorizzata e riflessa subito da current_option.
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+        self.assertEqual("Sintetici", entity.current_option)
+
+    async def test_start_button_applies_pending_and_clears_it(self) -> None:
+        from custom_components.haier_hon.select import HonProgramSelect
+        from custom_components.haier_hon.button import HonProgramCommandButton
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+
+        select_entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(select_entity)
+        button = HonProgramCommandButton(
+            coordinator,
+            "washer-1",
+            FakeClient(),
+            command_name="startProgram",
+            unique_suffix="start_program",
+            name_suffix="Avvia programma",
+            icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        await select_entity.async_select_option("Sintetici")
+        await button.async_press()
+
+        # Il programma scelto è stato applicato a startProgram ed effettivamente avviato.
+        self.assertEqual("2", start.parameters["program"].value)
+        self.assertEqual(1, start.send_calls)
+        # La scelta in attesa è stata svuotata: il select torna allo stato device.
+        self.assertEqual({}, coordinator.pending_programs)
+        self.assertEqual(1, coordinator.refreshes)
+
+    async def test_stop_button_ignores_pending_program(self) -> None:
+        from custom_components.haier_hon.button import HonProgramCommandButton
+
+        stop = RecordingCommand({"onOffStatus": Param("1")})
+        coordinator = FakeCoordinator(_washer({"stopProgram": stop}))
+        coordinator.pending_programs = {"washer-1": "2"}
+        button = HonProgramCommandButton(
+            coordinator,
+            "washer-1",
+            FakeClient(),
+            command_name="stopProgram",
+            unique_suffix="stop_program",
+            name_suffix="Ferma programma",
+            icon="mdi:stop-circle",
+            command_parameters={"onOffStatus": "0"},
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        self.assertEqual(1, stop.send_calls)
+        # Lo stop non deve consumare né usare la scelta programma in attesa.
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+
+    async def test_current_option_reads_device_state_when_no_pending(self) -> None:
+        from custom_components.haier_hon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}, attributes={"prCode": "1"}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        self.assertEqual("Cotone", entity.current_option)
+
+    async def test_unknown_option_raises(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.haier_hon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        with self.assertRaisesRegex(HomeAssistantError, "non trovato"):
+            await entity.async_select_option("Inesistente")
+
+
+class LegacyPowerCleanupTest(unittest.TestCase):
+    def test_removes_only_power_entities(self) -> None:
+        from homeassistant.helpers import entity_registry as er
+        from custom_components.haier_hon import _remove_legacy_entities
+
+        class RegEntry:
+            def __init__(self, entity_id, unique_id):
+                self.entity_id = entity_id
+                self.unique_id = unique_id
+
+        class FakeRegistry:
+            def __init__(self, entries):
+                self._entries = list(entries)
+                self.removed: list = []
+
+            def async_remove(self, entity_id):
+                self.removed.append(entity_id)
+
+        registry = FakeRegistry([
+            RegEntry("switch.washer_alimentazione", "washer-1_power"),
+            RegEntry("switch.washer_pausa", "washer-1_pause"),
+            RegEntry("select.washer_programma", "washer-1_program"),
+            RegEntry("sensor.washer_energia_totale", "washer-1_total_energy"),
+        ])
+        er.async_get = lambda hass: registry
+        er.async_entries_for_config_entry = lambda reg, entry_id: list(reg._entries)
+
+        _remove_legacy_entities(FakeHass(), FakeEntry())
+
+        # Solo l'entità "Alimentazione" (_power) viene rimossa; le altre restano.
+        self.assertEqual(["switch.washer_alimentazione"], registry.removed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Automated release PR for `v2.4.2`.

<!-- release-tag: v2.4.2 -->
<!-- release-source-sha: bea2ce18b4ddd4143fad4d33cd47b11558f7ee3e -->

Merge this PR with squash only. The post-merge workflow will move `dev` to the squash commit, recreate `v2.4.2` on that commit, and publish the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed legacy power entities from Home Assistant registry during setup.

* **New Features**
  * Program selection workflow improved: selecting a program now stores it as pending before executing.
  * Start button now applies pending program selections when pressed.

**Version:** 2.4.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->