### PR TITLE
Release v2.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate with hassfest
         uses: home-assistant/actions/hassfest@master
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate with HACS
         uses: hacs/action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -q
+
+  hassfest:
+    name: hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate with hassfest
+        uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: hacs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate with HACS
+        uses: hacs/action@main
+        with:
+          category: integration
+          # This integration is distributed as a custom HACS repo and is not in
+          # the official home-assistant/brands repo; ignore that publish-only
+          # check so the gate validates structure/hacs.json/version, not branding.
+          ignore: brands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -41,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Validate with hassfest
         uses: home-assistant/actions/hassfest@master
@@ -51,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Validate with HACS
         uses: hacs/action@main

--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -96,10 +96,24 @@ jobs:
             die "Release ${TAG} already exists; refusing to overwrite it."
           fi
 
-          # Create the published tag on the squash commit, then publish.
+          # Publish the tag on the squash commit. Force-push so this does NOT
+          # silently depend on the delete succeeding: a plain (non-forced) tag
+          # push is rejected as non-fast-forward when a stale tag still points
+          # elsewhere, which would abort AFTER dev was already fast-forwarded
+          # and leave a release-less partial state.
           git tag -f "${TAG}" "${MERGE_SHA}"
-          git push origin ":refs/tags/${TAG}" || true
-          git push origin "refs/tags/${TAG}"
+          if ! git push origin --force "refs/tags/${TAG}"; then
+            # Some rulesets forbid force-updating v* tags but allow delete+create.
+            notice "Force-updating tag ${TAG} was rejected; retrying via delete + create."
+            git push origin ":refs/tags/${TAG}" || true
+            git push origin "refs/tags/${TAG}"
+          fi
+
+          # Backstop: never cut a release against a stale tag. Fail loudly if the
+          # published tag did not land on the squash commit.
+          PUBLISHED_TAG_SHA="$(git ls-remote --tags origin "refs/tags/${TAG}" | awk 'NR==1{print $1}')"
+          [[ "${PUBLISHED_TAG_SHA}" == "${MERGE_SHA}" ]] \
+            || die "Tag ${TAG} did not publish onto the squash commit ${MERGE_SHA} (remote: ${PUBLISHED_TAG_SHA:-<absent>}); aborting before release."
 
           RELEASE_ARGS=(release create "${TAG}" --target "${MERGE_SHA}" --title "${TAG}" --verify-tag --generate-notes)
           if is_beta_tag "${TAG}"; then

--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}

--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout trusted base policy
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release Asset
+
+# Build the HACS distribution zip and attach it to the published release.
+# HACS downloads this single asset (named to match `filename` in hacs.json)
+# instead of cloning the repo tree, because `zip_release` is enabled there.
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-asset-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  attach-zip:
+    name: attach-zip
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Build integration zip
+        run: |
+          set -euo pipefail
+          # Zip the CONTENTS of the integration dir (manifest.json at the zip
+          # root), which is what HACS expects to extract into
+          # custom_components/haier_hon/.
+          cd custom_components/haier_hon
+          zip -r "${{ runner.temp }}/haier_hon.zip" . -x '*.pyc' -x '*/__pycache__/*'
+
+      - name: Upload zip to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # --clobber makes a re-run idempotent (replaces the asset rather than
+          # failing if it already exists).
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ runner.temp }}/haier_hon.zip" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
       - name: Build integration zip
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout released tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -38,9 +38,12 @@ jobs:
       - name: Upload zip to release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pass the (attacker-influenceable) tag name via env and reference it
+          # as a shell var, never interpolated directly into the run script.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           # --clobber makes a re-run idempotent (replaces the asset rather than
           # failing if it already exists).
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$RELEASE_TAG" \
             "${{ runner.temp }}/haier_hon.zip" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .codex-worklog.md
 .codex-worklog-*.md
+BUG_FINDINGS.md
 __pycache__/
 *.py[cod]

--- a/custom_components/haier_hon/manifest.json
+++ b/custom_components/haier_hon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pyhon==0.17.5"
   ],
-  "version": "2.4.6"
+  "version": "2.5.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,8 @@
 {
   "name": "Haier hOn (Extended)",
   "homeassistant": "2024.11.0",
+  "zip_release": true,
+  "filename": "haier_hon.zip",
+  "hide_default_branch": true,
   "render_readme": true
 }


### PR DESCRIPTION
Automated release PR for `v2.5.0`.

<!-- release-tag: v2.5.0 -->
<!-- release-source-sha: eb244a32f7e4de16d91652a4aabcfac238735fa4 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI for pull requests and development pushes, running automated tests, hassfest checks, and integration validation.
  * Introduced automated “Release Asset” packaging and upload of `haier_hon.zip` for published version tags.
  * Improved release tag publishing reliability with safer update/verification to prevent stale tags.
  * Pinned checkout actions across release-related workflows for more consistent execution.
  * Updated integration manifest version to **2.5.0**.
  * Adjusted distribution settings in HACS (zip release, asset filename, hide default branch).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->