### PR TITLE
Release v4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Other hOn-compatible Haier appliances should work — feel free to test and repo
 
 ## Prerequisites
 
-- Home Assistant 2024.1 or newer
+- Home Assistant 2024.12.0 or newer
 - Python 3.11+
 - Internet connection (cloud API only, no local option)
 - Haier hOn app account credentials
@@ -148,6 +148,12 @@ data:
 ```
 
 ## Troubleshooting
+
+> **Debug logging:** open the integration and choose **Configure** to toggle
+> **Enable debug logging** (integration) and **Enable MQTT realtime debug**
+> independently. Both persist across restarts. See
+> [`docs/discovery-debugging.md`](docs/discovery-debugging.md) and
+> [`docs/mqtt-realtime-logging.md`](docs/mqtt-realtime-logging.md).
 
 ### Authentication Failed
 

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -22,6 +22,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import (
     APPLIANCE_TD,
     ATTR_LEVEL,
+    CONF_ENABLE_DEBUG,
+    CONF_ENABLE_MQTT_DEBUG,
     DOMAIN,
     PLATFORMS,
     SCAN_INTERVAL,
@@ -32,6 +34,7 @@ from .logging_utils import (
     MQTT_LOG_LEVELS,
     apply_integration_log_level,
     apply_mqtt_log_level,
+    reset_integration_log_level,
     silence_mqtt_noise,
 )
 
@@ -96,6 +99,47 @@ def _async_register_services(hass: HomeAssistant) -> None:
             _handle_set_log_level,
             schema=level_schema,
         )
+
+
+@callback
+def _apply_debug_options(entry: ConfigEntry) -> None:
+    """Allinea i livelli di log ai due toggle persistiti in entry.options.
+
+    enable_debug=True  -> logger dell'integrazione a DEBUG; False -> NOTSET
+                          (tornano a ereditare il livello configurato in HA).
+    enable_mqtt_debug=True -> logger MQTT realtime a DEBUG; False -> WARNING
+                          (silenziato).
+
+    Il livello MQTT si applica DOPO quello dell'integrazione, così il livello
+    esplicito del figlio MQTT vince sulla cascata del padre: attivare il DEBUG
+    dell'integrazione NON riaccende il rumore realtime se il toggle MQTT è off.
+    NB i logger sono globali al processo (vedi OptionsFlowHandler): con piu'
+    entry vince l'ultima che cambia. Disattivare enable_debug azzera anche un
+    eventuale override manuale fatto col service set_log_level.
+    """
+    if entry.options.get(CONF_ENABLE_DEBUG, False):
+        apply_integration_log_level(logging.DEBUG)
+    else:
+        reset_integration_log_level()
+    if entry.options.get(CONF_ENABLE_MQTT_DEBUG, False):
+        apply_mqtt_log_level(logging.DEBUG)
+    else:
+        silence_mqtt_noise()
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Ri-applica a caldo i livelli di log quando i toggle cambiano (no reload).
+
+    Un reload butterebbe giù auth e canale MQTT solo per cambiare un livello di
+    log; qui ri-applichiamo i livelli al volo, come fanno i service esistenti.
+    """
+    _LOGGER.debug(
+        "Options debug: opzioni aggiornate entry=%s enable_debug=%s enable_mqtt_debug=%s",
+        entry.entry_id,
+        entry.options.get(CONF_ENABLE_DEBUG, False),
+        entry.options.get(CONF_ENABLE_MQTT_DEBUG, False),
+    )
+    _apply_debug_options(entry)
 
 
 def _redact_email(email: str | None) -> str | None:
@@ -321,6 +365,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
         await _async_close_client(hon_client)
         raise
+
+    # Setup riuscito: applica i toggle di debug persistiti e registra un listener
+    # che li ri-applica a caldo quando cambiano (async_on_unload rimuove il
+    # listener allo scarico dell'entry, senza un reload).
+    _apply_debug_options(entry)
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     return True
 
 

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -102,7 +102,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
 
 
 @callback
-def _apply_debug_options(entry: ConfigEntry) -> None:
+def _apply_debug_options(entry: ConfigEntry, *, reset_when_off: bool = True) -> None:
     """Allinea i livelli di log ai due toggle persistiti in entry.options.
 
     enable_debug=True  -> logger dell'integrazione a DEBUG; False -> NOTSET
@@ -114,16 +114,28 @@ def _apply_debug_options(entry: ConfigEntry) -> None:
     esplicito del figlio MQTT vince sulla cascata del padre: attivare il DEBUG
     dell'integrazione NON riaccende il rumore realtime se il toggle MQTT è off.
     NB i logger sono globali al processo (vedi OptionsFlowHandler): con piu'
-    entry vince l'ultima che cambia. Disattivare enable_debug azzera anche un
-    eventuale override manuale fatto col service set_log_level.
+    entry (raro, multi-account) i livelli sono condivisi e cambiare le opzioni di
+    una entry li ri-applica in base a QUELLA entry, potendo azzerare il debug
+    attivo di un'altra. L'installazione tipica e' a singolo account.
+
+    reset_when_off=True (default, usato dal listener delle opzioni): un toggle
+    OFF AZZERA il livello (NOTSET / WARNING), così disattivarlo dalla UI ha
+    effetto immediato e cancella anche un eventuale override manuale fatto col
+    service set_log_level. reset_when_off=False (usato in async_setup_entry): un
+    toggle OFF NON tocca i logger, così un DEBUG dell'integrazione impostato a
+    runtime coi service sopravvive ai re-setup/retry (es. login instabile) invece
+    di essere ri-azzerato a ogni tentativo; il silenziamento MQTT di default alla
+    prima registrazione resta comunque garantito da _async_register_services (che
+    pero', su un reload dell'unica entry che rimuove e ri-registra i service,
+    ri-silenzia anche un eventuale livello MQTT alzato a runtime).
     """
     if entry.options.get(CONF_ENABLE_DEBUG, False):
         apply_integration_log_level(logging.DEBUG)
-    else:
+    elif reset_when_off:
         reset_integration_log_level()
     if entry.options.get(CONF_ENABLE_MQTT_DEBUG, False):
         apply_mqtt_log_level(logging.DEBUG)
-    else:
+    elif reset_when_off:
         silence_mqtt_noise()
 
 
@@ -233,6 +245,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # registra il service di debug. Fatto PRIMA del setup di pyhOn così il
     # logger è già a WARNING quando il client MQTT inizia a (ri)connettersi.
     _async_register_services(hass)
+
+    # Applica SUBITO i toggle di debug persistiti, ma DOPO _async_register_services
+    # (che alla prima registrazione silenzia il rumore MQTT di default) così il
+    # toggle MQTT persistito, se attivo, vince su quel silenziamento. Applicarli
+    # qui e non a fine setup fa sì che il livello DEBUG copra anche il percorso di
+    # setup (login, discovery, primo refresh): è proprio ciò che si vuole tracciare
+    # quando si attiva il debug per problemi di discovery. reset_when_off=False: un
+    # toggle OFF non deve ri-azzerare un DEBUG impostato a runtime coi service, che
+    # deve sopravvivere ai retry di un setup che fallisce (il silenziamento MQTT di
+    # default resta garantito da _async_register_services).
+    _apply_debug_options(entry, reset_when_off=False)
 
     # FIX: la chiave salvata dal config_flow è "email", non "username"
     email = entry.data.get("email")
@@ -366,10 +389,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await _async_close_client(hon_client)
         raise
 
-    # Setup riuscito: applica i toggle di debug persistiti e registra un listener
-    # che li ri-applica a caldo quando cambiano (async_on_unload rimuove il
-    # listener allo scarico dell'entry, senza un reload).
-    _apply_debug_options(entry)
+    # Setup riuscito: registra un listener che ri-applica a caldo i toggle di
+    # debug quando cambiano (async_on_unload rimuove il listener allo scarico
+    # dell'entry, senza un reload). I livelli sono già stati applicati a inizio
+    # setup; qui resta solo da agganciare l'aggiornamento a caldo.
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     return True
 

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
+from .const import CONF_ENABLE_DEBUG, CONF_ENABLE_MQTT_DEBUG, DOMAIN
 from .hon_client import HonClient, _requires_reauth
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,6 +90,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Gestisce il config flow per Haier hOn Extended."""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Espone il flow Opzioni (i due toggle di debug)."""
+        # NB: niente @callback qui per non dipendere da homeassistant.core.callback
+        # (non richiesto per correttezza; l'harness di test non lo fornisce).
+        return OptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -188,6 +197,49 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required("password"): str}),
             errors=errors,
             description_placeholders={"email": email},
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Opzioni dell'integrazione: due toggle di debug indipendenti.
+
+    HA 2024.11+: NON impostare self.config_entry nell'__init__ (deprecato e
+    iniettato automaticamente). I default sono letti da self.config_entry.options
+    (False sulle installazioni che non hanno mai salvato opzioni). I valori sono
+    applicati a caldo da _apply_debug_options via l'options update listener: NB
+    i logger sono globali al processo, quindi con piu' account vince l'ultimo che
+    cambia (caso tipico = singolo account).
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_ENABLE_DEBUG: bool(user_input.get(CONF_ENABLE_DEBUG, False)),
+                    CONF_ENABLE_MQTT_DEBUG: bool(
+                        user_input.get(CONF_ENABLE_MQTT_DEBUG, False)
+                    ),
+                },
+            )
+
+        options = self.config_entry.options
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_ENABLE_DEBUG,
+                        default=options.get(CONF_ENABLE_DEBUG, False),
+                    ): bool,
+                    vol.Required(
+                        CONF_ENABLE_MQTT_DEBUG,
+                        default=options.get(CONF_ENABLE_MQTT_DEBUG, False),
+                    ): bool,
+                }
+            ),
         )
 
 

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -203,7 +203,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Opzioni dell'integrazione: due toggle di debug indipendenti.
 
-    HA 2024.11+: NON impostare self.config_entry nell'__init__ (deprecato e
+    HA 2024.12.0+: NON impostare self.config_entry nell'__init__ (deprecato e
     iniettato automaticamente). I default sono letti da self.config_entry.options
     (False sulle installazioni che non hanno mai salvato opzioni). I valori sono
     applicati a caldo da _apply_debug_options via l'options update listener: NB

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -63,6 +63,14 @@ SERVICE_SET_MQTT_LOG_LEVEL = "set_mqtt_log_level"
 SERVICE_SET_LOG_LEVEL = "set_log_level"
 ATTR_LEVEL = "level"
 
+# Chiavi opzione (entry.options) dei due toggle di debug esposti nella schermata
+# Configura/Opzioni dell'integrazione. Persistono tra i riavvii e vengono applicati
+# a caldo (vedi _apply_debug_options in __init__). enable_debug -> logger
+# dell'integrazione a DEBUG (NOTSET quando off); enable_mqtt_debug -> logger MQTT
+# realtime a DEBUG (silenziato a WARNING quando off). I due toggle sono indipendenti.
+CONF_ENABLE_DEBUG = "enable_debug"
+CONF_ENABLE_MQTT_DEBUG = "enable_mqtt_debug"
+
 # ─── Attributi condizionatore ─────────────────────────────────────────────────
 # Confermati dai diagnostics del device AS35PBPHRA-PRE
 AC_ATTR_MODE         = "settings.machMode"

--- a/custom_components/addhon/logging_utils.py
+++ b/custom_components/addhon/logging_utils.py
@@ -62,3 +62,15 @@ def apply_integration_log_level(level: int) -> None:
 def silence_mqtt_noise() -> None:
     """Applica il livello di default: silenzia i tentativi di riconnessione."""
     apply_mqtt_log_level(DEFAULT_MQTT_LOG_LEVEL)
+
+
+def reset_integration_log_level() -> None:
+    """Riporta i logger dell'integrazione a NOTSET (ereditano il livello di HA).
+
+    Usato quando il toggle "Abilita log di debug" viene disattivato: invece di
+    forzare un livello fisso (es. WARNING) si rimuove l'override, così i logger
+    tornano a ereditare il livello configurato da Home Assistant. NON tocca i
+    logger MQTT (restano gestiti da silence_mqtt_noise / set_mqtt_log_level).
+    """
+    for name in INTEGRATION_DEBUG_LOGGERS:
+        logging.getLogger(name).setLevel(logging.NOTSET)

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "4.0.0"
+  "version": "4.1.0"
 }

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -27,5 +27,20 @@
       "reauth_successful": "Re-authentication was successful.",
       "reauth_account_mismatch": "The new credentials must belong to the same hOn account."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Debug options",
+        "data": {
+          "enable_debug": "Enable debug logging",
+          "enable_mqtt_debug": "Enable MQTT realtime debug"
+        },
+        "data_description": {
+          "enable_debug": "Raise this integration's log level to DEBUG (sign in, device discovery, polling, commands). Turn off to return to Home Assistant's configured level. MQTT realtime noise stays suppressed unless its own toggle is on.",
+          "enable_mqtt_debug": "Make the MQTT realtime channel very verbose. Normally keep this off; it only covers this integration's MQTT logger, not the underlying AWS IoT libraries (use Home Assistant's logger config for those)."
+        }
+      }
+    }
   }
 }

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -27,5 +27,20 @@
       "reauth_successful": "Ri-autenticazione completata.",
       "reauth_account_mismatch": "Le nuove credenziali devono appartenere allo stesso account hOn."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opzioni di debug",
+        "data": {
+          "enable_debug": "Abilita log di debug",
+          "enable_mqtt_debug": "Abilita debug MQTT realtime"
+        },
+        "data_description": {
+          "enable_debug": "Porta il livello di log dell'integrazione a DEBUG (accesso, rilevamento dispositivi, polling, comandi). Disattiva per tornare al livello configurato in Home Assistant. Il rumore MQTT realtime resta silenziato a meno che non attivi il suo toggle.",
+          "enable_mqtt_debug": "Rende molto verboso il canale MQTT realtime. Di norma tienilo disattivato; copre solo il logger MQTT di questa integrazione, non le librerie AWS IoT sottostanti (per quelle usa la configurazione logger di Home Assistant)."
+        }
+      }
+    }
   }
 }

--- a/docs/discovery-debugging.md
+++ b/docs/discovery-debugging.md
@@ -5,7 +5,14 @@ devices, or existing devices disappear after a reload.
 
 ## Enable integration debug logs
 
-From Home Assistant Developer Tools -> Actions:
+The simplest, persistent way is the UI toggle: open the integration, choose
+**Configure**, and turn on **Enable debug logging**. It survives restarts and
+raises the integration loggers to DEBUG (MQTT realtime noise stays suppressed
+unless you also enable its own toggle). Turn it off to return to Home
+Assistant's configured level.
+
+For a one-off (non-persistent) change instead, use the service from Developer
+Tools -> Actions:
 
 ```yaml
 action: addhon.set_log_level

--- a/docs/mqtt-realtime-logging.md
+++ b/docs/mqtt-realtime-logging.md
@@ -1,13 +1,13 @@
 # MQTT realtime logging
 
-The integration pulls device data by polling. On top of that, the bundled
-`pyhOn` library also opens an **MQTT realtime channel** (AWS IoT) to receive
+The integration pulls device data by polling. On top of that, the integration's
+native client also opens an **MQTT realtime channel** (AWS IoT) to receive
 instant push updates. That channel is optional: if it never connects, sensors
 still update every poll cycle.
 
 ## Why the log was noisy
 
-`pyhOn`'s MQTT client logs one INFO line for every (re)connect attempt
+The native MQTT client logs one INFO line for every (re)connect attempt
 (`Lifecycle Attempting Connect`, `Connection Failure`, `Disconnection`, ...).
 When the realtime push slot is **contended**, those attempts fail in a loop and
 flood the log. This is expected and **not a bug**: the data is still correct,
@@ -15,9 +15,9 @@ delivered by polling. See [Background](#background-why-it-flaps) below.
 
 ## Default behaviour: silenced
 
-At setup the integration lowers the `pyhon.connection.mqtt` logger to
-`WARNING`, so the reconnect chatter is hidden while real warnings/errors still
-come through. Nothing else changes; polling is unaffected.
+At setup the integration lowers the `custom_components.addhon.client.transport.mqtt`
+logger to `WARNING`, so the reconnect chatter is hidden while real warnings/errors
+still come through. Nothing else changes; polling is unaffected.
 
 ## Enable debug logging (on demand)
 
@@ -25,7 +25,12 @@ For missing devices or discovery issues, start with
 [Discovery debugging](discovery-debugging.md). MQTT is optional and does not
 control device enumeration.
 
-When you need to inspect the realtime channel, raise the level with the
+The simplest way is the persistent UI toggle: open the integration, choose
+**Configure**, and turn on **Enable MQTT realtime debug**. It survives restarts
+and only covers this integration's MQTT logger (not the underlying AWS IoT
+libraries). Turn it off to silence the channel again.
+
+When you prefer a one-off (non-persistent) change, raise the level with the
 dedicated service:
 
 ```yaml
@@ -44,9 +49,10 @@ data:
   level: warning
 ```
 
-The change is **not persistent**: after a Home Assistant restart the channel is
-silenced again (debug is opt-in per session). The built-in
-`logger.set_level` action with `pyhon.connection.mqtt: debug` does the same.
+The service change is **not persistent**: after a Home Assistant restart the
+channel is silenced again (the service is opt-in per session; use the Configure
+toggle above for a persistent setting). The built-in `logger.set_level` action
+with `custom_components.addhon.client.transport.mqtt: debug` does the same.
 
 ## Background: why it flaps
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "addhOn",
-  "homeassistant": "2024.11.0",
+  "homeassistant": "2024.12.0",
   "zip_release": true,
   "filename": "addhon.zip",
   "hide_default_branch": true,

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -98,6 +98,7 @@ def _install_stubs() -> None:
                 self.default = kwargs.get("default")
 
         vol.Required = Required
+        vol.In = lambda container=None, *args, **kwargs: container
         vol._addhon_capturing = True
 
 
@@ -127,11 +128,29 @@ class _FakeEntry:
         self.options = options or {}
 
 
+class _FakeServices:
+    """Minimal hass.services for exercising _async_register_services."""
+
+    def __init__(self) -> None:
+        self._registered: set[tuple[str, str]] = set()
+
+    def has_service(self, domain, service) -> bool:
+        return (domain, service) in self._registered
+
+    def async_register(self, domain, service, handler, schema=None) -> None:
+        self._registered.add((domain, service))
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.services = _FakeServices()
+
+
 def _make_options_flow(entry):
     from custom_components.addhon.config_flow import OptionsFlowHandler
 
     flow = OptionsFlowHandler()
-    flow.config_entry = entry  # in HA 2024.11+ this is auto-provided; set it for tests
+    flow.config_entry = entry  # in HA 2024.12.0+ this is auto-provided; set it for tests
     flow.calls = {}
 
     def _show_form(*, step_id, data_schema=None, **kwargs):
@@ -280,6 +299,103 @@ class ResetHelperTest(unittest.TestCase):
             self.assertEqual(logging.getLogger(name).level, logging.NOTSET)
 
 
+class RegisterThenApplyOrderTest(unittest.TestCase):
+    """Helper-composition guard (NOT the production-order guard): proves that
+    _async_register_services default-silences the MQTT logger on first
+    registration, and that a LATER _apply_debug_options with the MQTT toggle ON
+    overrides it back to DEBUG. The PRODUCTION call order inside async_setup_entry
+    is pinned separately and behaviorally by SetupEntryOrderingTest and (in
+    source) by WiringTest.test_debug_options_applied_before_setup_path.
+    """
+
+    def setUp(self) -> None:
+        names = ("custom_components.addhon", "custom_components.addhon.client.transport.mqtt")
+        self._saved = {n: logging.getLogger(n).level for n in names}
+
+    def tearDown(self) -> None:
+        for name, level in self._saved.items():
+            logging.getLogger(name).setLevel(level)
+
+    def test_register_silences_then_apply_on_overrides(self) -> None:
+        from custom_components.addhon import (
+            _apply_debug_options,
+            _async_register_services,
+        )
+
+        mqtt_logger = logging.getLogger(
+            "custom_components.addhon.client.transport.mqtt"
+        )
+        mqtt_logger.setLevel(logging.DEBUG)  # start dirty to prove the silence ran
+
+        hass = _FakeHass()
+        # First registration silences MQTT to WARNING.
+        _async_register_services(hass)
+        self.assertEqual(mqtt_logger.level, logging.WARNING)
+
+        # A later apply with MQTT debug ON overrides back to DEBUG.
+        _apply_debug_options(_FakeEntry({CONF_ENABLE_MQTT_DEBUG: True}))
+        self.assertEqual(mqtt_logger.level, logging.DEBUG)
+
+
+class SetupEntryOrderingTest(unittest.IsolatedAsyncioTestCase):
+    """Behavioral guard that drives the REAL async_setup_entry far enough to
+    observe production behavior. async_setup_entry bails at the missing-email
+    check (returns False) AFTER _async_register_services + the early
+    _apply_debug_options run, so HonClient is imported but never constructed and
+    no login happens. The real .hon_client is NOT stubbed: importing it is part of
+    what this exercises (a stub would mask an import-time regression there).
+    """
+
+    def setUp(self) -> None:
+        names = ("custom_components.addhon", "custom_components.addhon.client.transport.mqtt")
+        self._saved = {n: logging.getLogger(n).level for n in names}
+
+    def tearDown(self) -> None:
+        for name, level in self._saved.items():
+            logging.getLogger(name).setLevel(level)
+
+    async def test_setup_escalates_toggles_after_default_silence(self) -> None:
+        # PRODUCTION-ORDER guard: with both toggles ON, async_setup_entry must end
+        # with MQTT at DEBUG. That only holds if register-services (default silence
+        # -> WARNING) runs BEFORE the early apply (-> DEBUG). A swapped order would
+        # leave MQTT at WARNING. This is exactly what RegisterThenApplyOrderTest
+        # CANNOT catch (it sequences the calls itself).
+        from custom_components.addhon import async_setup_entry
+
+        mqtt_logger = logging.getLogger("custom_components.addhon.client.transport.mqtt")
+        intg_logger = logging.getLogger("custom_components.addhon")
+        mqtt_logger.setLevel(logging.NOTSET)
+        intg_logger.setLevel(logging.NOTSET)
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: True, CONF_ENABLE_MQTT_DEBUG: True})
+        entry.data = {}  # no email -> returns False right after the early apply
+
+        result = await async_setup_entry(_FakeHass(), entry)
+        self.assertFalse(result)
+        self.assertEqual(mqtt_logger.level, logging.DEBUG)
+        self.assertEqual(intg_logger.level, logging.DEBUG)
+
+    async def test_setup_off_does_not_clobber_runtime_debug(self) -> None:
+        # Regression guard (refuter HIGH): with the persisted toggle OFF, a re-setup
+        # (HA retry / reload) must NOT reset a DEBUG level set at runtime via the
+        # addhon.set_log_level service. The setup-path apply uses reset_when_off=False
+        # so an OFF toggle only leaves the logger alone. The OLD full-reset behavior
+        # would clobber it to NOTSET on every retry.
+        from custom_components.addhon import async_setup_entry, _async_register_services
+
+        intg_logger = logging.getLogger("custom_components.addhon")
+
+        hass = _FakeHass()
+        _async_register_services(hass)  # services already exist (a prior attempt)
+        intg_logger.setLevel(logging.DEBUG)  # user ran set_log_level: debug at runtime
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: False, CONF_ENABLE_MQTT_DEBUG: False})
+        entry.data = {}
+        await async_setup_entry(hass, entry)
+
+        self.assertEqual(intg_logger.level, logging.DEBUG)  # survived the re-setup
+
+
 class WiringTest(unittest.TestCase):
     """Source-level guards for the live-apply listener wiring in __init__.py."""
 
@@ -291,6 +407,55 @@ class WiringTest(unittest.TestCase):
         self.assertIn("reset_integration_log_level", src)
         self.assertIn("CONF_ENABLE_DEBUG", src)
         self.assertIn("CONF_ENABLE_MQTT_DEBUG", src)
+
+    def test_debug_options_applied_before_setup_path(self) -> None:
+        # The persisted toggles must be applied at the TOP of async_setup_entry so
+        # DEBUG covers the setup path (login/discovery/first refresh), and AFTER
+        # _async_register_services so its default MQTT silence does not clobber the
+        # MQTT toggle. Pin both orderings in source. (Match "(entry" without the
+        # closing paren so the reset_when_off kwarg does not break the search.)
+        src = INIT.read_text(encoding="utf-8")
+        setup_idx = src.index("async def async_setup_entry")
+        register_idx = src.index("_async_register_services(hass)", setup_idx)
+        apply_idx = src.index("_apply_debug_options(entry", setup_idx)
+        client_setup_idx = src.index("hon_client.setup_sync", setup_idx)
+        self.assertLess(
+            register_idx,
+            apply_idx,
+            "register services (default MQTT silence) must precede applying toggles",
+        )
+        self.assertLess(
+            apply_idx,
+            client_setup_idx,
+            "debug options must be applied before the hOn setup path",
+        )
+
+    def test_setup_applies_debug_options_exactly_once(self) -> None:
+        # The move replaced the end-of-setup call; there must be exactly ONE apply
+        # inside async_setup_entry (no leftover double-apply). Ignore comment lines
+        # so a comment mentioning the call cannot skew the count.
+        src = INIT.read_text(encoding="utf-8")
+        start = src.index("async def async_setup_entry")
+        end = src.index("async def async_unload_entry", start)
+        code = "\n".join(
+            ln for ln in src[start:end].splitlines() if not ln.lstrip().startswith("#")
+        )
+        self.assertEqual(code.count("_apply_debug_options("), 1)
+
+    def test_setup_apply_disables_reset_when_off(self) -> None:
+        # The setup-path apply must pass reset_when_off=False so an OFF toggle does
+        # not clobber a runtime-set debug level across retries (the listener path
+        # keeps the default reset semantics). Match the kwarg anywhere in the setup
+        # span to stay robust to reformatting (e.g. a trailing comma), but strip
+        # comment lines so the explanatory comment mentioning the kwarg cannot make
+        # this guard vacuous.
+        src = INIT.read_text(encoding="utf-8")
+        start = src.index("async def async_setup_entry")
+        end = src.index("async def async_unload_entry", start)
+        code = "\n".join(
+            ln for ln in src[start:end].splitlines() if not ln.lstrip().startswith("#")
+        )
+        self.assertIn("reset_when_off=False", code)
 
     def test_hacs_declares_min_ha_for_options_flow(self) -> None:
         # The OptionsFlow relies on HA auto-injecting self.config_entry, which only

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,307 @@
+"""Tests for the Options flow debug toggles (enable_debug, enable_mqtt_debug).
+
+Two independent, persisted toggles on the integration's Configure screen:
+- enable_debug      -> integration loggers to DEBUG (NOTSET when off).
+- enable_mqtt_debug -> MQTT realtime logger to DEBUG (WARNING/silence when off).
+
+Both reuse logging_utils helpers and are applied live (an options update listener,
+no reload). MQTT level is applied AFTER the integration level so the MQTT child's
+explicit level wins (enabling integration DEBUG does not flood MQTT).
+
+stdlib unittest with HA + voluptuous stubs (mirrors test_config_flow_reauth), and
+logging_utils loaded by file path (mirrors test_mqtt_log_level), so no real HA.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+COMPONENT = REPO_ROOT / "custom_components" / "addhon"
+LOGGING_UTILS_PATH = COMPONENT / "logging_utils.py"
+INIT = COMPONENT / "__init__.py"
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ha = _mod("homeassistant")
+
+    config_entries = _mod("homeassistant.config_entries")
+    config_entries.ConfigEntry = getattr(
+        config_entries, "ConfigEntry", type("ConfigEntry", (), {})
+    )
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+    config_entries.ConfigFlow = getattr(config_entries, "ConfigFlow", ConfigFlow)
+    config_entries.OptionsFlow = getattr(
+        config_entries, "OptionsFlow", type("OptionsFlow", (), {})
+    )
+
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+
+    data_entry_flow = _mod("homeassistant.data_entry_flow")
+    data_entry_flow.FlowResult = getattr(data_entry_flow, "FlowResult", dict)
+
+    exceptions = _mod("homeassistant.exceptions")
+    base_err = getattr(exceptions, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exceptions.HomeAssistantError = base_err
+    exceptions.ConfigEntryNotReady = getattr(
+        exceptions, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {})
+    )
+    exceptions.ConfigEntryAuthFailed = getattr(
+        exceptions, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {})
+    )
+
+    helpers = _mod("homeassistant.helpers")
+    update_coordinator = _mod("homeassistant.helpers.update_coordinator")
+    update_coordinator.DataUpdateCoordinator = getattr(
+        update_coordinator, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {})
+    )
+    update_coordinator.UpdateFailed = getattr(
+        update_coordinator, "UpdateFailed", type("UpdateFailed", (Exception,), {})
+    )
+
+    ha.config_entries = config_entries
+    ha.core = core
+    ha.exceptions = exceptions
+    ha.helpers = helpers
+    helpers.update_coordinator = update_coordinator
+
+    # voluptuous stub that captures `default` (the reauth stub does not). Only
+    # install when voluptuous is absent or is a stub (real voluptuous exposes Marker).
+    vol = sys.modules.get("voluptuous")
+    if vol is None or not hasattr(vol, "Marker"):
+        vol = _mod("voluptuous")
+        vol.Schema = lambda schema=None, **kwargs: schema
+
+        class Required:
+            def __init__(self, key, *args, **kwargs):
+                self.key = key
+                self.default = kwargs.get("default")
+
+        vol.Required = Required
+        vol._addhon_capturing = True
+
+
+_install_stubs()
+
+from custom_components.addhon.const import (  # noqa: E402
+    CONF_ENABLE_DEBUG,
+    CONF_ENABLE_MQTT_DEBUG,
+)
+
+
+def _load_logging_utils():
+    spec = importlib.util.spec_from_file_location(
+        "addhon_logging_utils_optionsflow", LOGGING_UTILS_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+lu = _load_logging_utils()
+
+
+class _FakeEntry:
+    def __init__(self, options=None) -> None:
+        self.entry_id = "entry-1"
+        self.options = options or {}
+
+
+def _make_options_flow(entry):
+    from custom_components.addhon.config_flow import OptionsFlowHandler
+
+    flow = OptionsFlowHandler()
+    flow.config_entry = entry  # in HA 2024.11+ this is auto-provided; set it for tests
+    flow.calls = {}
+
+    def _show_form(*, step_id, data_schema=None, **kwargs):
+        return {"type": "form", "step_id": step_id, "data_schema": data_schema}
+
+    def _create_entry(*, title, data):
+        flow.calls["create"] = {"title": title, "data": data}
+        return {"type": "create_entry", "title": title, "data": data}
+
+    flow.async_show_form = _show_form
+    flow.async_create_entry = _create_entry
+    return flow
+
+
+class OptionsFlowTest(unittest.IsolatedAsyncioTestCase):
+    async def test_init_shows_form_with_both_toggles(self) -> None:
+        flow = _make_options_flow(_FakeEntry())
+        result = await flow.async_step_init(None)
+        self.assertEqual("form", result["type"])
+        self.assertEqual("init", result["step_id"])
+        self.assertIsNotNone(result["data_schema"])
+
+    async def test_defaults_reflect_current_options(self) -> None:
+        vol = sys.modules["voluptuous"]
+        if not getattr(vol, "_addhon_capturing", False):
+            self.skipTest("real voluptuous: schema default not introspected")
+        flow = _make_options_flow(
+            _FakeEntry({CONF_ENABLE_DEBUG: True, CONF_ENABLE_MQTT_DEBUG: False})
+        )
+        result = await flow.async_step_init(None)
+        defaults = {req.key: req.default for req in result["data_schema"]}
+        self.assertEqual(defaults[CONF_ENABLE_DEBUG], True)
+        self.assertEqual(defaults[CONF_ENABLE_MQTT_DEBUG], False)
+
+    async def test_submit_stores_both_booleans(self) -> None:
+        flow = _make_options_flow(_FakeEntry())
+        result = await flow.async_step_init(
+            {CONF_ENABLE_DEBUG: True, CONF_ENABLE_MQTT_DEBUG: False}
+        )
+        self.assertEqual("create_entry", result["type"])
+        self.assertEqual("", result["title"])
+        self.assertEqual(
+            {CONF_ENABLE_DEBUG: True, CONF_ENABLE_MQTT_DEBUG: False},
+            flow.calls["create"]["data"],
+        )
+
+    async def test_submit_missing_keys_default_false(self) -> None:
+        flow = _make_options_flow(_FakeEntry())
+        await flow.async_step_init({})
+        self.assertEqual(
+            {CONF_ENABLE_DEBUG: False, CONF_ENABLE_MQTT_DEBUG: False},
+            flow.calls["create"]["data"],
+        )
+
+    def test_config_flow_exposes_options_flow(self) -> None:
+        from custom_components.addhon.config_flow import (
+            ConfigFlow,
+            OptionsFlowHandler,
+        )
+
+        handler = ConfigFlow.async_get_options_flow(_FakeEntry())
+        self.assertIsInstance(handler, OptionsFlowHandler)
+
+
+class ApplyDebugOptionsTest(unittest.TestCase):
+    """Behavioral test of the shared _apply_debug_options on the real loggers."""
+
+    def setUp(self) -> None:
+        names = ("custom_components.addhon", "custom_components.addhon.client.transport.mqtt")
+        self._saved = {n: logging.getLogger(n).level for n in names}
+
+    def tearDown(self) -> None:
+        for name, level in self._saved.items():
+            logging.getLogger(name).setLevel(level)
+
+    def _apply(self, entry):
+        from custom_components.addhon import _apply_debug_options
+
+        _apply_debug_options(entry)
+
+    def test_integration_toggle_on_sets_debug(self) -> None:
+        self._apply(_FakeEntry({CONF_ENABLE_DEBUG: True}))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.DEBUG
+        )
+
+    def test_integration_toggle_off_resets_to_notset(self) -> None:
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        self._apply(_FakeEntry({CONF_ENABLE_DEBUG: False}))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.NOTSET
+        )
+
+    def test_mqtt_toggle_independent_and_stays_quiet_under_integration_debug(self) -> None:
+        # Integration DEBUG ON but MQTT toggle OFF: the parent integration logger
+        # goes to DEBUG WHILE the MQTT child stays WARNING (its explicit level wins
+        # over the parent cascade). Asserting BOTH pins the real invariant and keeps
+        # the enable_debug=True half load-bearing.
+        self._apply(_FakeEntry({CONF_ENABLE_DEBUG: True, CONF_ENABLE_MQTT_DEBUG: False}))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.DEBUG
+        )
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon.client.transport.mqtt").level,
+            logging.WARNING,
+        )
+
+    def test_mqtt_toggle_on_sets_debug(self) -> None:
+        self._apply(_FakeEntry({CONF_ENABLE_MQTT_DEBUG: True}))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon.client.transport.mqtt").level,
+            logging.DEBUG,
+        )
+
+    def test_options_update_listener_reapplies_live(self) -> None:
+        # The update listener payload must re-apply levels live (no reload). Call it
+        # directly: it only touches loggers via _apply_debug_options.
+        import asyncio
+
+        from custom_components.addhon import _async_options_updated
+
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        asyncio.run(
+            _async_options_updated(None, _FakeEntry({CONF_ENABLE_DEBUG: False}))
+        )
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.NOTSET
+        )
+
+
+class ResetHelperTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {
+            n: logging.getLogger(n).level for n in lu.INTEGRATION_DEBUG_LOGGERS
+        }
+
+    def tearDown(self) -> None:
+        for name, level in self._saved.items():
+            logging.getLogger(name).setLevel(level)
+
+    def test_reset_integration_log_level_sets_notset(self) -> None:
+        for name in lu.INTEGRATION_DEBUG_LOGGERS:
+            logging.getLogger(name).setLevel(logging.DEBUG)
+        lu.reset_integration_log_level()
+        for name in lu.INTEGRATION_DEBUG_LOGGERS:
+            self.assertEqual(logging.getLogger(name).level, logging.NOTSET)
+
+
+class WiringTest(unittest.TestCase):
+    """Source-level guards for the live-apply listener wiring in __init__.py."""
+
+    def test_init_registers_options_listener_and_applies(self) -> None:
+        src = INIT.read_text(encoding="utf-8")
+        self.assertIn("_apply_debug_options", src)
+        self.assertIn("add_update_listener", src)
+        self.assertIn("async_on_unload", src)
+        self.assertIn("reset_integration_log_level", src)
+        self.assertIn("CONF_ENABLE_DEBUG", src)
+        self.assertIn("CONF_ENABLE_MQTT_DEBUG", src)
+
+    def test_hacs_declares_min_ha_for_options_flow(self) -> None:
+        # The OptionsFlow relies on HA auto-injecting self.config_entry, which only
+        # exists since HA 2024.12.0 (a bare OptionsFlow has no config_entry before
+        # that). Pin the declared minimum so it is not lowered below that.
+        import json
+
+        hacs = json.loads((REPO_ROOT / "hacs.json").read_text(encoding="utf-8"))
+        parts = tuple(int(p) for p in hacs["homeassistant"].split("."))
+        self.assertGreaterEqual(parts, (2024, 12, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Automated release PR for `v4.1.0`.

<!-- release-tag: v4.1.0 -->
<!-- release-source-sha: c8eb9adbc8e92c2899842247897d5a1d69572350 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two persistent debug logging toggles in the integration options: integration DEBUG logging and MQTT realtime DEBUG logging (independent).
  * Updates apply immediately when options change, without reloading the integration.

* **Documentation**
  * Updated the minimum Home Assistant requirement to **2024.12.0**.
  * Refreshed debugging guides with configuration-based steps and clarified which loggers are affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->