### PR TITLE
Release v5.0.3

### DIFF
--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
 from .const import (
+    APPLIANCE_AC,
     APPLIANCE_DW,
     APPLIANCE_FR,
     APPLIANCE_FRE,
@@ -144,6 +145,31 @@ _COOLING_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
         icon="mdi:leaf",
         attr_key="energySavingStatus",
     ),
+    # Active-mode flags (0/1). Read-only mirrors of the boost/special modes; the
+    # engine also folds these into the derived modeZ1/modeZ2 (ref.py). Live-confirmed
+    # present on the real fridge (quickModeZ1/quickModeZ2/intelligenceMode/holidayMode).
+    HonBinarySensorEntityDescription(
+        key="quick_cool",
+        icon="mdi:snowflake",
+        attr_key="quickModeZ1",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+    HonBinarySensorEntityDescription(
+        key="quick_freeze",
+        icon="mdi:snowflake-variant",
+        attr_key="quickModeZ2",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+    HonBinarySensorEntityDescription(
+        key="auto_set",
+        icon="mdi:auto-mode",
+        attr_key="intelligenceMode",
+    ),
+    HonBinarySensorEntityDescription(
+        key="holiday_mode",
+        icon="mdi:palm-tree",
+        attr_key="holidayMode",
+    ),
 )
 
 # Oven (OV).
@@ -196,6 +222,23 @@ _HOOD_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     ),
 )
 
+# Air conditioner (AC): status alarms/processes (0/1). Capability-gated like every
+# binary sensor. Live-confirmed present on the real AC (filterChangeStatusLocal,
+# ch2oCleaningStatus).
+_AC_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
+    HonBinarySensorEntityDescription(
+        key="filter_change",
+        attr_key="filterChangeStatusLocal",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    HonBinarySensorEntityDescription(
+        key="ch2o_cleaning",
+        icon="mdi:molecule",
+        attr_key="ch2oCleaningStatus",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+)
+
 # Water heater (WH).
 _WATER_HEATER_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     HonBinarySensorEntityDescription(
@@ -215,6 +258,7 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
     APPLIANCE_WM: _WASH_BINARY,
     APPLIANCE_WD: _WASH_BINARY,
     APPLIANCE_TD: _DRY_BINARY,
+    APPLIANCE_AC: _AC_BINARY,
     # Tier 2 (read-only). FR/FRE reuse the fridge set, HOB the hob set.
     APPLIANCE_REF: _COOLING_BINARY,
     APPLIANCE_FR: _COOLING_BINARY,

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -97,14 +97,6 @@ AC_SWING_V_ON        = "8"                        # 8 = vertical oscillation
 AC_SWING_MODE_ON     = "on"
 AC_SWING_MODE_OFF    = "off"
 AC_ATTR_ON_OFF       = "settings.onOffStatus"
-# ecoMode exists only in startProgram (NOT in settings), confirmed from diagnostics
-AC_ATTR_ECO          = "startProgram.ecoMode"
-AC_ATTR_RAPID        = "settings.rapidMode"
-# silentSleepStatus is the real name; muteStatus is separate (display mute)
-AC_ATTR_SLEEP        = "settings.silentSleepStatus"
-AC_ATTR_SILENT       = "settings.muteStatus"
-AC_ATTR_SELF_CLEAN   = "settings.selfCleaningStatus"
-AC_ATTR_LIGHT        = "settings.lightStatus"
 AC_ATTR_COMPRESSOR_FREQ = "compressorFrequency"
 AC_ATTR_TOTAL_ENERGY = "totalElectricityUsed"
 # Air quality (direct attributes, confirmed on Roberto's AC)

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -103,7 +103,6 @@ AC_ATTR_RAPID        = "settings.rapidMode"
 # silentSleepStatus is the real name; muteStatus is separate (display mute)
 AC_ATTR_SLEEP        = "settings.silentSleepStatus"
 AC_ATTR_SILENT       = "settings.muteStatus"
-AC_ATTR_FILTER       = "settings.filterChangeStatusCloud"
 AC_ATTR_SELF_CLEAN   = "settings.selfCleaningStatus"
 AC_ATTR_LIGHT        = "settings.lightStatus"
 AC_ATTR_COMPRESSOR_FREQ = "compressorFrequency"

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -268,3 +268,36 @@ RVC_POWER_MAP = {
     "1": "turbo",
     "2": "quiet",
 }
+
+# Washing-machine stain type (stainType -> app StainTypes enum; codes from the
+# decompiled app, aligned with Andre0512/hon). 0 = none selected. Rendered
+# per-language via the sensor state translations; unmapped codes -> None.
+STAIN_TYPE_MAP = {
+    "0": "none",
+    "1": "wine",
+    "2": "grass",
+    "3": "soil",
+    "4": "blood",
+    "5": "milk",
+    "6": "cooking_oil",
+    "7": "tea",
+    "8": "coffee",
+    "9": "ice_cream",
+    "10": "lip_gloss",
+    "11": "curry",
+    "12": "milk_tea",
+    "13": "rust",
+    "14": "blue_ink",
+    "15": "perfume",
+    "16": "shoe_cream",
+    "17": "oil_pastel",
+    "18": "blueberry",
+    "19": "sweat",
+    "20": "egg",
+    "21": "ketchup",
+    "22": "baby_food",
+    "23": "soy_sauce",
+    "24": "bean_paste",
+    "25": "chili_sauce",
+    "26": "fruit",
+}

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.0.2"
+  "version": "5.0.3"
 }

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -63,6 +63,7 @@ from .const import (
     MACHINE_MODE_MAP,
     RVC_POWER_MAP,
     RVC_STATE_MAP,
+    STAIN_TYPE_MAP,
     TD_ATTR_CYCLES,
     TUMBLE_DRYER_PHASE_MAP,
     WASHING_PHASE_MAP,
@@ -190,6 +191,13 @@ def _phase_dry(raw) -> str | None:
     return TUMBLE_DRYER_PHASE_MAP.get(str(raw))
 
 
+def _stain(raw) -> str | None:
+    """stainType -> stain ENUM key (None if missing/unknown)."""
+    if raw is None:
+        return None
+    return STAIN_TYPE_MAP.get(str(raw))
+
+
 _PROGRAM_NAME = HonSensorEntityDescription(
     key="program_name",
     icon="mdi:format-list-bulleted",
@@ -258,6 +266,14 @@ _WASH_EXTRA: tuple[HonSensorEntityDescription, ...] = (
         key="dirty_level",
         icon="mdi:liquid-spot",
         attr_key=WM_ATTR_DIRT_LEVEL,
+    ),
+    HonSensorEntityDescription(
+        key="stain_type",
+        icon="mdi:liquid-spot",
+        attr_key="stainType",
+        device_class=SensorDeviceClass.ENUM,
+        options=sorted(set(STAIN_TYPE_MAP.values())),
+        value_fn=_stain,
     ),
 )
 

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -286,6 +286,11 @@ _DRYER: tuple[HonSensorEntityDescription, ...] = (
     _DELAY,
     _ERRORS,
     HonSensorEntityDescription(
+        key="temp_level",
+        icon="mdi:thermometer-lines",
+        attr_key="tempLevel",
+    ),
+    HonSensorEntityDescription(
         key="total_washes",
         attr_key=TD_ATTR_CYCLES,
         state_class=SensorStateClass.TOTAL_INCREASING,

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -140,6 +140,38 @@
       "dirty_level": {
         "name": "Soil level"
       },
+      "stain_type": {
+        "name": "Stain type",
+        "state": {
+          "none": "None",
+          "wine": "Wine",
+          "grass": "Grass",
+          "soil": "Soil",
+          "blood": "Blood",
+          "milk": "Milk",
+          "cooking_oil": "Cooking oil",
+          "tea": "Tea",
+          "coffee": "Coffee",
+          "ice_cream": "Ice cream",
+          "lip_gloss": "Lip gloss",
+          "curry": "Curry",
+          "milk_tea": "Milk tea",
+          "rust": "Rust",
+          "blue_ink": "Blue ink",
+          "perfume": "Perfume",
+          "shoe_cream": "Shoe cream",
+          "oil_pastel": "Oil pastel",
+          "blueberry": "Blueberry",
+          "sweat": "Sweat",
+          "egg": "Egg",
+          "ketchup": "Ketchup",
+          "baby_food": "Baby food",
+          "soy_sauce": "Soy sauce",
+          "bean_paste": "Bean paste",
+          "chili_sauce": "Chili sauce",
+          "fruit": "Fruit"
+        }
+      },
       "temp_indoor": {
         "name": "Indoor temperature"
       },

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -358,6 +358,24 @@
       "energy_saving": {
         "name": "Energy saving"
       },
+      "quick_cool": {
+        "name": "Super cool"
+      },
+      "quick_freeze": {
+        "name": "Super freeze"
+      },
+      "auto_set": {
+        "name": "Auto-set"
+      },
+      "holiday_mode": {
+        "name": "Holiday mode"
+      },
+      "filter_change": {
+        "name": "Filter change"
+      },
+      "ch2o_cleaning": {
+        "name": "Formaldehyde cleaning"
+      },
       "light": {
         "name": "Light"
       },

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -128,6 +128,9 @@
       "dry_level": {
         "name": "Dry level"
       },
+      "temp_level": {
+        "name": "Temperature level"
+      },
       "spin_speed": {
         "name": "Spin speed"
       },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -140,6 +140,38 @@
       "dirty_level": {
         "name": "Livello Sporco"
       },
+      "stain_type": {
+        "name": "Tipo Macchia",
+        "state": {
+          "none": "Nessuna",
+          "wine": "Vino",
+          "grass": "Erba",
+          "soil": "Terra",
+          "blood": "Sangue",
+          "milk": "Latte",
+          "cooking_oil": "Olio da cucina",
+          "tea": "Tè",
+          "coffee": "Caffè",
+          "ice_cream": "Gelato",
+          "lip_gloss": "Lucidalabbra",
+          "curry": "Curry",
+          "milk_tea": "Tè al latte",
+          "rust": "Ruggine",
+          "blue_ink": "Inchiostro blu",
+          "perfume": "Profumo",
+          "shoe_cream": "Lucido da scarpe",
+          "oil_pastel": "Pastello a olio",
+          "blueberry": "Mirtillo",
+          "sweat": "Sudore",
+          "egg": "Uovo",
+          "ketchup": "Ketchup",
+          "baby_food": "Pappa",
+          "soy_sauce": "Salsa di soia",
+          "bean_paste": "Pasta di fagioli",
+          "chili_sauce": "Salsa piccante",
+          "fruit": "Frutta"
+        }
+      },
       "temp_indoor": {
         "name": "Temperatura Interna"
       },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -128,6 +128,9 @@
       "dry_level": {
         "name": "Livello Asciugatura"
       },
+      "temp_level": {
+        "name": "Livello Temperatura"
+      },
       "spin_speed": {
         "name": "Centrifuga"
       },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -358,6 +358,24 @@
       "energy_saving": {
         "name": "Risparmio Energetico"
       },
+      "quick_cool": {
+        "name": "Super Cool"
+      },
+      "quick_freeze": {
+        "name": "Super Freeze"
+      },
+      "auto_set": {
+        "name": "Auto-Set"
+      },
+      "holiday_mode": {
+        "name": "Modalità Vacanza"
+      },
+      "filter_change": {
+        "name": "Cambio Filtro"
+      },
+      "ch2o_cleaning": {
+        "name": "Pulizia Formaldeide"
+      },
       "light": {
         "name": "Luce"
       },

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -186,18 +186,18 @@ class PerTypeTableTest(unittest.TestCase):
         self.assertEqual(
             self._keys("WM"),
             ["state", "remaining_time", "program_name", "program_phase", "spin_speed",
-             "wash_temperature", "dirty_level", "loading_percentage", "delay_time",
-             "errors", "total_washes", "total_water", "total_energy", "current_energy",
-             "current_water"],
+             "wash_temperature", "dirty_level", "stain_type", "loading_percentage",
+             "delay_time", "errors", "total_washes", "total_water", "total_energy",
+             "current_energy", "current_water"],
         )
 
     def test_wd_is_wm_plus_dry_level(self) -> None:
         self.assertEqual(
             self._keys("WD"),
             ["state", "remaining_time", "program_name", "program_phase", "spin_speed",
-             "wash_temperature", "dirty_level", "dry_level", "loading_percentage",
-             "delay_time", "errors", "total_washes", "total_water", "total_energy",
-             "current_energy", "current_water"],
+             "wash_temperature", "dirty_level", "stain_type", "dry_level",
+             "loading_percentage", "delay_time", "errors", "total_washes", "total_water",
+             "total_energy", "current_energy", "current_water"],
         )
 
     def test_td_keys(self) -> None:

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -204,7 +204,7 @@ class PerTypeTableTest(unittest.TestCase):
         self.assertEqual(
             self._keys("TD"),
             ["state", "remaining_time", "program_name", "program_phase", "dry_level",
-             "loading_percentage", "delay_time", "errors", "total_washes"],
+             "loading_percentage", "delay_time", "errors", "temp_level", "total_washes"],
         )
 
     def test_td_has_no_water_or_energy(self) -> None:
@@ -250,7 +250,7 @@ class SensorBuildTest(unittest.IsolatedAsyncioTestCase):
             {e._attr_unique_id for e in added},
             {"td-1_state", "td-1_remaining_time", "td-1_program_name",
              "td-1_program_phase", "td-1_dry_level", "td-1_loading_percentage",
-             "td-1_delay_time", "td-1_errors", "td-1_total_washes"},
+             "td-1_delay_time", "td-1_errors", "td-1_temp_level", "td-1_total_washes"},
         )
         cycles = next(e for e in added if e._attr_unique_id == "td-1_total_washes")
         self.assertEqual(cycles.native_value, 42.0)  # reads programsCounter

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -325,6 +325,13 @@ class Tier2GatingTest(unittest.IsolatedAsyncioTestCase):
         tl = next(e for e in added if e._attr_unique_id == "x-1_temp_level")
         self.assertEqual(tl.native_value, 4.0)
 
+    async def test_washer_stain_type_decodes(self) -> None:
+        # WM stain_type ENUM: code -> machine key, 0 -> none, unknown -> None.
+        for raw, expected in (("1", "wine"), ("0", "none"), ("26", "fruit"), ("99", None)):
+            added = await _build_sensors("WM", {"stainType": raw})
+            st = next(e for e in added if e._attr_unique_id == "x-1_stain_type")
+            self.assertEqual(st.native_value, expected)
+
 
 class Tier2BinaryGatingTest(unittest.IsolatedAsyncioTestCase):
     async def test_cooling_binary_gating(self) -> None:

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -330,6 +330,24 @@ class Tier2BinaryGatingTest(unittest.IsolatedAsyncioTestCase):
         door = next(e for e in added if e._attr_unique_id == "x-1_door_zone1")
         self.assertTrue(door.is_on)
 
+    async def test_cooling_binary_mode_flags(self) -> None:
+        # Read-only active-mode flags (quickModeZ1/Z2, intelligenceMode, holidayMode),
+        # capability-gated and decoded as 0/1. Live-confirmed present on the real fridge.
+        added = await _build_binary(
+            "REF",
+            {"quickModeZ1": "1", "quickModeZ2": "0", "intelligenceMode": "1", "holidayMode": "0"},
+        )
+        by_id = {e._attr_unique_id: e for e in added}
+        self.assertEqual(
+            set(by_id),
+            {"x-1_quick_cool", "x-1_quick_freeze", "x-1_auto_set",
+             "x-1_holiday_mode", "x-1_connectivity"},
+        )
+        self.assertTrue(by_id["x-1_quick_cool"].is_on)
+        self.assertFalse(by_id["x-1_quick_freeze"].is_on)
+        self.assertTrue(by_id["x-1_auto_set"].is_on)
+        self.assertFalse(by_id["x-1_holiday_mode"].is_on)
+
     async def test_hob_binary_only_present_zones(self) -> None:
         added = await _build_binary("IH", {"panStatusZ1": "1", "panStatusZ3": "0"})
         self.assertEqual(
@@ -342,6 +360,17 @@ class Tier2BinaryGatingTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({e._attr_unique_id for e in added}, {"x-1_child_lock", "x-1_connectivity"})
         lock = next(e for e in added if e._attr_unique_id == "x-1_child_lock")
         self.assertTrue(lock.is_on)
+
+    async def test_ac_binary_gating(self) -> None:
+        # AC gains a per-type binary set (filter change + formaldehyde cleaning),
+        # capability-gated like all binary sensors. Live-confirmed on the real AC.
+        added = await _build_binary("AC", {"filterChangeStatusLocal": "1", "ch2oCleaningStatus": "0"})
+        by_id = {e._attr_unique_id: e for e in added}
+        self.assertEqual(
+            set(by_id), {"x-1_filter_change", "x-1_ch2o_cleaning", "x-1_connectivity"}
+        )
+        self.assertTrue(by_id["x-1_filter_change"].is_on)
+        self.assertFalse(by_id["x-1_ch2o_cleaning"].is_on)
 
 
 class ConnectivityBinaryTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -319,6 +319,12 @@ class Tier2GatingTest(unittest.IsolatedAsyncioTestCase):
         state = next(e for e in added if e._attr_unique_id == "x-1_state")
         self.assertIsNone(state.native_value)
 
+    async def test_dryer_temp_level(self) -> None:
+        # TD gains a temperature-level sensor (tempLevel); live-confirmed on HD100.
+        added = await _build_sensors("TD", {"tempLevel": "4", "machMode": "1"})
+        tl = next(e for e in added if e._attr_unique_id == "x-1_temp_level")
+        self.assertEqual(tl.native_value, 4.0)
+
 
 class Tier2BinaryGatingTest(unittest.IsolatedAsyncioTestCase):
     async def test_cooling_binary_gating(self) -> None:


### PR DESCRIPTION
Automated release PR for `v5.0.3`.

<!-- release-tag: v5.0.3 -->
<!-- release-source-sha: 070e7b5e93e4d2e3e19c6c7a8cfd32b1e5dc3165 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 5.0.3

* **New Features**
  * Added air conditioner binary sensors for filter change status and formaldehyde cleaning status
  * Added refrigerator and freezer binary sensors for quick cool, quick freeze, auto-set, and holiday mode functions
  * Added stain type sensor for washing machines
  * Added temperature level sensor for tumble dryers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release adds read-only binary sensors and new sensors to several appliance types: AC gains filter-change and formaldehyde-cleaning binary sensors; refrigerators/freezers gain quick-cool, quick-freeze, auto-set, and holiday-mode binary sensors; washing machines gain a stain-type ENUM sensor; and tumble dryers gain a temperature-level sensor. The seven AC switch/mode constants removed from `const.py` were confirmed unused across the codebase.

- **New binary sensors** (`binary_sensor.py`): four mode-flag sensors for the cooling group (REF/FR/FRE) and two status sensors for AC, all properly capability-gated through the existing attribute-presence check.
- **New sensors** (`sensor.py` / `const.py`): a 27-value stain-type ENUM sensor for WM/WD (not capability-gated, following the existing `dirty_level` pattern) and a unitless temperature-level sensor for TD.
- **Tests** (`test_sensor_per_type.py`, `test_tier2_sensors.py`): snapshot tests updated for new key ordering; new behavioural tests added for stain decoding, temp-level reading, binary mode flags, and AC binary gating.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new entities follow established patterns, capability gating is in place for binary sensors, and tests cover the new decode paths.

The changes are purely additive: new read-only sensors and binary sensors for AC, cooling, and wash-group appliances. The removed AC constants were verified unused across the codebase. Binary sensors are capability-gated so absent attributes produce no orphaned entities. The stain_type and temp_level sensors follow the same non-gated pattern as existing wash-group sensors. Translation tables are complete and consistent with the STAIN_TYPE_MAP. Tests validate ENUM decoding, binary flag values, and capability gating end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/binary_sensor.py | Adds _AC_BINARY tuple (filter_change + ch2o_cleaning) and four mode-flag entries to _COOLING_BINARY; APPLIANCE_AC registered in BINARY_SENSORS dict; all entries properly capability-gated via the existing attribute-presence loop. |
| custom_components/addhon/sensor.py | Adds stain_type ENUM sensor to _WASH_EXTRA (non-gated, consistent with dirty_level) and a unitless temp_level sensor to _DRYER; imports STAIN_TYPE_MAP; _stain value_fn correctly returns None for unknown codes. |
| custom_components/addhon/const.py | Removes seven unused AC switch-attribute constants; adds STAIN_TYPE_MAP with 27 stain-type codes (0–26), all unique values matching the translation tables. |
| custom_components/addhon/translations/en.json | Adds sensor names and full state translation tables for stain_type (27 states), temp_level, and six new binary sensor names; translations are complete and consistent with const.py values. |
| custom_components/addhon/translations/it.json | Italian translations mirror en.json additions for stain_type, temp_level, and six new binary sensors; all 27 stain states are translated. |
| custom_components/addhon/manifest.json | Version bump from 5.0.2 to 5.0.3; no other changes. |
| tests/test_sensor_per_type.py | Snapshot tests updated to include stain_type in WM/WD key lists and temp_level in TD key list; positions match the order in the _WASHER/_WASHER_DRYER/_DRYER tuples. |
| tests/test_tier2_sensors.py | New behavioural tests: TD temp_level read, WM stain_type ENUM decoding (wine/none/fruit/unknown→None), cooling binary mode flags, and AC binary capability gating. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[async_setup_entry] --> B{Per appliance_id}
    B --> C[sensor.py]
    B --> D[binary_sensor.py]

    C --> C1{gated?}
    C1 -- "False (WM/WD/TD)" --> C2[Always create]
    C1 -- "True (Tier2)" --> C3{attr_key in attributes?}
    C3 -- Yes --> C2
    C3 -- No --> C4[Skip]

    C2 --> C5[WM/WD: stain_type ENUM\nvalue_fn=_stain\nSTAIN_TYPE_MAP 0-26]
    C2 --> C6[TD: temp_level\nattr_key=tempLevel\nfloat value]

    D --> D1{attr_key in attributes?}
    D1 -- Yes --> D2[Create binary sensor]
    D1 -- No --> D3[Skip]

    D2 --> D4[AC: filter_change\nch2o_cleaning]
    D2 --> D5[REF/FR/FRE: quick_cool\nquick_freeze\nauto_set\nholiday_mode]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[async_setup_entry] --> B{Per appliance_id}
    B --> C[sensor.py]
    B --> D[binary_sensor.py]

    C --> C1{gated?}
    C1 -- "False (WM/WD/TD)" --> C2[Always create]
    C1 -- "True (Tier2)" --> C3{attr_key in attributes?}
    C3 -- Yes --> C2
    C3 -- No --> C4[Skip]

    C2 --> C5[WM/WD: stain_type ENUM\nvalue_fn=_stain\nSTAIN_TYPE_MAP 0-26]
    C2 --> C6[TD: temp_level\nattr_key=tempLevel\nfloat value]

    D --> D1{attr_key in attributes?}
    D1 -- Yes --> D2[Create binary sensor]
    D1 -- No --> D3[Skip]

    D2 --> D4[AC: filter_change\nch2o_cleaning]
    D2 --> D5[REF/FR/FRE: quick_cool\nquick_freeze\nauto_set\nholiday_mode]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore: set manifest version 5.0.3"](https://github.com/tis24dev/addhon/commit/070e7b5e93e4d2e3e19c6c7a8cfd32b1e5dc3165) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38796773)</sub>

<!-- /greptile_comment -->