### PR TITLE
Release v5.0.4

### DIFF
--- a/.github/scripts/release-policy.sh
+++ b/.github/scripts/release-policy.sh
@@ -112,3 +112,51 @@ delete_remote_tag() {
 
   git push origin ":refs/tags/${tag}" || true
 }
+
+# Existence probes that DISTINGUISH absent from error. A transient auth/network
+# failure must never be silently read as "does not exist" (which would defeat the
+# immutability/preflight gates). Echo: present|absent|error.
+
+remote_tag_state() {
+  local tag="${1:-}"
+  local rc=0
+  # git ls-remote --exit-code: 0 = ref found, 2 = no matching ref, other = failure.
+  git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1 || rc=$?
+  case "${rc}" in
+    0) echo "present" ;;
+    2) echo "absent" ;;
+    *) echo "error" ;;
+  esac
+}
+
+remote_release_state() {
+  local tag="${1:-}"
+  local out
+  local rc=0
+  out="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" 2>&1)" || rc=$?
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "present"
+  elif printf '%s' "${out}" | grep -qi 'HTTP 404\|Not Found'; then
+    echo "absent"
+  else
+    echo "error"
+  fi
+}
+
+# Hard gates: die on "present" AND on "error" (fail closed). Used where the only
+# acceptable state to proceed is a confirmed "absent".
+assert_release_tag_absent() {
+  local tag="${1:-}"
+  case "$(remote_tag_state "${tag}")" in
+    present) die "Tag ${tag} already exists and is immutable." ;;
+    error)   die "Could not determine whether tag ${tag} exists (git ls-remote failed); aborting." ;;
+  esac
+}
+
+assert_release_absent() {
+  local tag="${1:-}"
+  case "$(remote_release_state "${tag}")" in
+    present) die "Release ${tag} already exists." ;;
+    error)   die "Could not determine whether release ${tag} exists (gh api failed); aborting." ;;
+  esac
+}

--- a/.github/scripts/release-policy.sh
+++ b/.github/scripts/release-policy.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 RELEASE_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-beta)?$'
+# Unprotected trigger tag that starts a release. It deliberately does NOT match
+# the protected v*.*.* ruleset, so it can be created/deleted freely; the real
+# vX.Y.Z tag is created once on the squash commit by post-merge-release.
+PR_TAG_REGEX='^pr-v[0-9]+\.[0-9]+\.[0-9]+(-beta)?$'
 
 die() {
   echo "::error::$*" >&2
@@ -25,6 +29,20 @@ validate_release_tag() {
 
 is_beta_tag() {
   [[ "${1:-}" == *-beta ]]
+}
+
+is_pr_tag() {
+  [[ "${1:-}" =~ ${PR_TAG_REGEX} ]]
+}
+
+# pr-vX.Y.Z -> vX.Y.Z (the release tag that will be CREATED at merge).
+release_tag_from_pr_tag() {
+  local pr_tag="${1:-}"
+
+  if ! is_pr_tag "${pr_tag}"; then
+    die "Invalid trigger tag '${pr_tag}'. Expected pr-vX.Y.Z or pr-vX.Y.Z-beta."
+  fi
+  printf '%s\n' "${pr_tag#pr-}"
 }
 
 version_from_tag() {

--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -92,30 +92,21 @@ jobs:
             exit 0
           fi
 
+          # The vX.Y.Z tag is immutable (the ruleset blocks update + deletion), so
+          # it must NOT exist yet: we only ever CREATE it, once, here.
           if gh release view "${TAG}" >/dev/null 2>&1; then
             die "Release ${TAG} already exists; refusing to overwrite it."
           fi
-
-          # Publish the tag on the squash commit. Force-push so this does NOT
-          # silently depend on the delete succeeding: a plain (non-forced) tag
-          # push is rejected as non-fast-forward when a stale tag still points
-          # elsewhere, which would abort AFTER dev was already fast-forwarded
-          # and leave a release-less partial state.
-          git tag -f "${TAG}" "${MERGE_SHA}"
-          if ! git push origin --force "refs/tags/${TAG}"; then
-            # Some rulesets forbid force-updating v* tags but allow delete+create.
-            notice "Force-updating tag ${TAG} was rejected; retrying via delete + create."
-            git push origin ":refs/tags/${TAG}" || true
-            git push origin "refs/tags/${TAG}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            die "Tag ${TAG} already exists; refusing to release onto a pre-existing (stale) tag. Resolve manually."
           fi
 
-          # Backstop: never cut a release against a stale tag. Fail loudly if the
-          # published tag did not land on the squash commit.
-          PUBLISHED_TAG_SHA="$(git ls-remote --tags origin "refs/tags/${TAG}" | awk 'NR==1{print $1}')"
-          [[ "${PUBLISHED_TAG_SHA}" == "${MERGE_SHA}" ]] \
-            || die "Tag ${TAG} did not publish onto the squash commit ${MERGE_SHA} (remote: ${PUBLISHED_TAG_SHA:-<absent>}); aborting before release."
-
-          RELEASE_ARGS=(release create "${TAG}" --target "${MERGE_SHA}" --title "${TAG}" --verify-tag --generate-notes)
+          # Create the tag AND publish the release in one step. `gh release create`
+          # with a not-yet-existing tag CREATES it at --target (the squash commit) =
+          # a tag CREATION, which the immutable-tag ruleset allows. We never run
+          # `git tag -f`, force-push, or delete on a v* tag. (No --verify-tag: that
+          # would require the tag to pre-exist; we want gh to create it.)
+          RELEASE_ARGS=(release create "${TAG}" --target "${MERGE_SHA}" --title "${TAG}" --generate-notes)
           if is_beta_tag "${TAG}"; then
             RELEASE_ARGS+=(--prerelease)
           fi

--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -93,13 +93,11 @@ jobs:
           fi
 
           # The vX.Y.Z tag is immutable (the ruleset blocks update + deletion), so
-          # it must NOT exist yet: we only ever CREATE it, once, here.
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            die "Release ${TAG} already exists; refusing to overwrite it."
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            die "Tag ${TAG} already exists; refusing to release onto a pre-existing (stale) tag. Resolve manually."
-          fi
+          # it must NOT exist yet: we only ever CREATE it, once, here. These gates
+          # FAIL CLOSED: a transient auth/network error aborts rather than being
+          # misread as "absent" (which would let us try to publish onto a stale tag).
+          assert_release_absent "${TAG}"
+          assert_release_tag_absent "${TAG}"
 
           # Create the tag AND publish the release in one step. `gh release create`
           # with a not-yet-existing tag CREATES it at --target (the squash commit) =

--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -66,13 +66,18 @@ jobs:
 
           # v* tags are immutable: refuse to start a release whose version is already
           # published or already tagged (we may only ever CREATE a fresh v* tag).
-          if gh release view "${TAG}" >/dev/null 2>&1; then
+          # The probes distinguish absent from error, so a transient failure is NOT
+          # misread as "absent" (fail closed).
+          REL_STATE="$(remote_release_state "${TAG}")"
+          TAG_STATE="$(remote_tag_state "${TAG}")"
+          if [[ "${REL_STATE}" == "present" || "${TAG_STATE}" == "present" ]]; then
             delete_remote_tag "${TRIGGER}"
-            die "Release ${TAG} already exists."
+            die "Version ${TAG} already exists (release=${REL_STATE}, tag=${TAG_STATE}); pick a new version."
           fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            delete_remote_tag "${TRIGGER}"
-            die "Tag ${TAG} already exists and is immutable; pick a new version."
+          if [[ "${REL_STATE}" == "error" || "${TAG_STATE}" == "error" ]]; then
+            # Transient query failure: do NOT open a PR and do NOT delete the trigger,
+            # so re-pushing ${TRIGGER} retries cleanly.
+            die "Could not verify whether ${TAG} already exists (release=${REL_STATE}, tag=${TAG_STATE}); aborting."
           fi
 
           OPEN_PR="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"

--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -1,9 +1,13 @@
 name: Release Intake
 
+# Started by pushing an UNPROTECTED pr-vX.Y.Z tag on dev. That tag does NOT match
+# the protected v*.*.* ruleset, so it can be created/deleted freely. This workflow
+# never creates or moves a v* tag: the authoritative vX.Y.Z tag is CREATED ONCE on
+# the squash commit by post-merge-release (a tag creation, which the ruleset allows).
 on:
   push:
     tags:
-      - "*"
+      - "pr-v*"
 
 permissions:
   contents: write
@@ -20,103 +24,95 @@ env:
 jobs:
   open-release-pr:
     name: open-release-pr
+    # Skip the tag-DELETION push event (this workflow deletes the pr-v* trigger
+    # tag itself; without this guard that deletion would re-trigger the job).
+    if: ${{ github.event.deleted != true }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout tag
+      - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
 
-      - name: Validate tag and open PR
+      - name: Validate trigger tag and open release PR
         shell: bash
         run: |
           set -euo pipefail
           source .github/scripts/release-policy.sh
 
-          TAG="${GITHUB_REF_NAME}"
+          TRIGGER="${GITHUB_REF_NAME}"
 
-          if ! is_release_tag "${TAG}"; then
-            echo "::error::Invalid release tag '${TAG}'. Allowed formats are vX.Y.Z and vX.Y.Z-beta."
-            delete_remote_tag "${TAG}"
+          if ! is_pr_tag "${TRIGGER}"; then
+            echo "::error::Invalid trigger '${TRIGGER}'. Push pr-vX.Y.Z (or pr-vX.Y.Z-beta) on dev to start a release."
+            delete_remote_tag "${TRIGGER}"
             exit 1
           fi
 
-          git fetch --force origin dev main "refs/tags/${TAG}:refs/tags/${TAG}"
-
-          TAG_SHA="$(git rev-list -n 1 "${TAG}")"
-          DEV_SHA="$(git rev-parse origin/dev)"
-          MAIN_SHA="$(git rev-parse origin/main)"
+          TAG="$(release_tag_from_pr_tag "${TRIGGER}")"
           RELEASE_VERSION="$(version_from_tag "${TAG}")"
-          CURRENT_VERSION="$(manifest_version_at_ref "${TAG_SHA}")"
 
-          if [[ "${TAG_SHA}" == "${MAIN_SHA}" && "${DEV_SHA}" == "${MAIN_SHA}" && "${CURRENT_VERSION}" == "${RELEASE_VERSION}" ]]; then
-            notice "Tag ${TAG} already points at the synchronized main/dev release commit."
-            exit 0
-          fi
+          git fetch --force origin dev main "refs/tags/${TRIGGER}:refs/tags/${TRIGGER}"
 
-          if [[ "${TAG_SHA}" != "${DEV_SHA}" ]]; then
-            echo "::error::Tag ${TAG} must point to HEAD of dev (${DEV_SHA}), but points to ${TAG_SHA}."
-            delete_remote_tag "${TAG}"
+          TRIGGER_SHA="$(git rev-list -n 1 "${TRIGGER}")"
+          DEV_SHA="$(git rev-parse origin/dev)"
+
+          if [[ "${TRIGGER_SHA}" != "${DEV_SHA}" ]]; then
+            echo "::error::${TRIGGER} must point to HEAD of dev (${DEV_SHA}), but points to ${TRIGGER_SHA}."
+            delete_remote_tag "${TRIGGER}"
             exit 1
           fi
 
+          # v* tags are immutable: refuse to start a release whose version is already
+          # published or already tagged (we may only ever CREATE a fresh v* tag).
           if gh release view "${TAG}" >/dev/null 2>&1; then
+            delete_remote_tag "${TRIGGER}"
             die "Release ${TAG} already exists."
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            delete_remote_tag "${TRIGGER}"
+            die "Tag ${TAG} already exists and is immutable; pick a new version."
           fi
 
           OPEN_PR="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // ""')"
           if [[ -n "${OPEN_PR}" ]]; then
             PR_BODY="$(gh pr view "${OPEN_PR}" --json body --jq '.body')"
             export PR_BODY
-
-            if PR_TAG="$(extract_pr_marker release-tag)" && PR_SOURCE_SHA="$(extract_pr_marker release-source-sha)"; then
-              if [[ "${PR_TAG}" == "${TAG}" && "${PR_SOURCE_SHA}" == "${TAG_SHA}" && "${DEV_SHA}" == "${TAG_SHA}" ]]; then
-                notice "Release PR #${OPEN_PR} for ${TAG} already exists."
-                exit 0
-              fi
+            if PR_TAG="$(extract_pr_marker release-tag)" && [[ "${PR_TAG}" == "${TAG}" ]]; then
+              notice "Release PR #${OPEN_PR} for ${TAG} already open."
+              delete_remote_tag "${TRIGGER}"
+              exit 0
             fi
-
-            die "An open dev -> main PR already exists (#${OPEN_PR}). Close or merge it before pushing a new release tag."
+            delete_remote_tag "${TRIGGER}"
+            die "An open dev -> main PR already exists (#${OPEN_PR}). Close or merge it before starting a new release."
           fi
 
+          # Align the version source on dev with the requested release. dev is not
+          # protected, so this normal commit + push is fine.
+          CURRENT_VERSION="$(manifest_version_at_ref "${DEV_SHA}")"
           if [[ "${CURRENT_VERSION}" != "${RELEASE_VERSION}" ]]; then
             notice "Updating manifest.json from ${CURRENT_VERSION} to ${RELEASE_VERSION} for ${TAG}."
-
             git checkout -B dev origin/dev
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
             set_manifest_version "${RELEASE_VERSION}"
-
             if ! git diff --quiet -- custom_components/addhon/manifest.json; then
               git add custom_components/addhon/manifest.json
               git commit -m "chore: set manifest version ${RELEASE_VERSION}"
               git push origin HEAD:refs/heads/dev
             fi
-
-            TAG_SHA="$(git rev-parse HEAD)"
-            DEV_SHA="$(git rev-parse HEAD)"
-
-            # The "release tag policy" ruleset blocks deleting/updating
-            # refs/tags/v*.*.*; the delete+recreate needed to move the tag onto
-            # the bump commit fails ("fatal error in commit_refs"). Do NOT move
-            # the tag here. Drop the now-stale tag (it points at the pre-bump,
-            # manifest-mismatched commit) if the ruleset allows it, but tolerate
-            # failure so the PR is still opened. The authoritative published tag
-            # is (re)created on the squash commit by post-merge-release at merge.
-            git push origin ":refs/tags/${TAG}" || true
-            notice "Bumped manifest on dev (${DEV_SHA}); stale tag ${TAG} dropped (tolerated if blocked). Published ${TAG} is created on the squash commit at merge."
           else
-            assert_manifest_matches_tag "${TAG_SHA}" "${TAG}"
+            assert_manifest_matches_tag "${DEV_SHA}" "${TAG}"
           fi
+
+          # The trigger tag has done its job. Remove it (unprotected -> allowed).
+          delete_remote_tag "${TRIGGER}"
 
           BODY="$(cat <<EOF
           Automated release PR for \`${TAG}\`.
 
           <!-- release-tag: ${TAG} -->
-          <!-- release-source-sha: ${TAG_SHA} -->
           EOF
           )"
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 **A custom Home Assistant integration for controlling Haier appliances via the hOn cloud API. It discovers your paired appliances, exposes them as Home Assistant entities, and routes control commands to the supported types**
 
-[![Release](https://img.shields.io/github/v/release/telard-pixel/addhOn?logo=github&label=release)](https://github.com/telard-pixel/addhOn/releases)
-[![CI](https://img.shields.io/github/actions/workflow/status/telard-pixel/addhOn/ci.yml?branch=dev&label=CI&logo=github)](https://github.com/telard-pixel/addhOn/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/tis24dev/addhOn?logo=github&label=release)](https://github.com/tis24dev/addhOn/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/tis24dev/addhOn/ci.yml?branch=dev&label=CI&logo=github)](https://github.com/tis24dev/addhOn/actions/workflows/ci.yml)
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?logo=homeassistant&logoColor=white)](https://hacs.xyz/)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.12%2B-41BDF5.svg?logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Last commit](https://img.shields.io/github/last-commit/telard-pixel/addhOn?logo=github)](https://github.com/telard-pixel/addhOn/commits)
+[![Last commit](https://img.shields.io/github/last-commit/tis24dev/addhOn?logo=github)](https://github.com/tis24dev/addhOn/commits)
 
 </div>
 
@@ -39,7 +39,7 @@
 1. **Clone or download** this integration to your Home Assistant custom integrations folder:
 
 ```bash
-git clone https://github.com/telard-pixel/addhOn.git
+git clone https://github.com/tis24dev/addhOn.git
 cp -r addhOn/custom_components/addhon /path/to/config/custom_components/addhon
 ```
 

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -142,7 +142,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
             description_placeholders={
-                "docs_url": "https://github.com/telard-pixel/addhOn"
+                "docs_url": "https://github.com/tis24dev/addhOn"
             },
         )
 

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.0.3"
+  "version": "5.0.4"
 }

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -2,12 +2,12 @@
   "domain": "addhon",
   "name": "addhOn",
   "codeowners": [
-    "@telard-pixel"
+    "@tis24dev"
   ],
   "config_flow": true,
-  "documentation": "https://github.com/telard-pixel/addhOn",
+  "documentation": "https://github.com/tis24dev/addhOn",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/telard-pixel/addhOn/issues",
+  "issue_tracker": "https://github.com/tis24dev/addhOn/issues",
   "requirements": [
     "awsiotsdk>=1.21.0",
     "yarl>=1.8",


### PR DESCRIPTION
Automated release PR for `v5.0.4`.

<!-- release-tag: v5.0.4 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 5.0.4

* **Documentation**
  * Updated repository and documentation links to reflect organizational changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the integration version to 5.0.4, updates all repository URLs from `telard-pixel/addhOn` to `tis24dev/addhOn`, and refactors the release pipeline to use short-lived unprotected `pr-v*` trigger tags instead of directly operating on the protected `v*` tags.

- **Version & URL chores**: `manifest.json` version incremented to `5.0.4`, codeowner, documentation, and issue-tracker URLs updated to the new org; `README.md` and `config_flow.py` docs URLs updated to match.
- **Release pipeline refactor**: `release-intake.yml` now triggers on `pr-v*` tags (unprotected, freely deletable) and derives the `vX.Y.Z` target from them; the `post-merge-release` workflow creates the immutable `v*` tag exactly once via `gh release create --target`, replacing the old force-push/delete-and-recreate logic.
- **Fail-closed existence probes**: New `remote_tag_state` and `remote_release_state` helpers in `release-policy.sh` distinguish absent from error so a transient network failure is never silently misread as \"tag not present\", preserving release immutability guarantees.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the release pipeline refactor is well-designed, the version bump and URL updates are correct, and no functional regressions were introduced.

All changed code is either trivial metadata (version, URLs) or a deliberate simplification of the release workflow that replaces fragile force-push logic with a cleaner create-once pattern backed by fail-closed existence probes. The logic is sound and well-commented throughout.

No files require special attention. The minor portability note in release-policy.sh does not affect the GitHub Actions runtime environment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/release-policy.sh | Adds PR-tag helpers and fail-closed existence probes; grep uses a GNU-only BRE alternation (`\|`) that works on ubuntu-latest but is not POSIX portable. |
| .github/workflows/post-merge-release.yml | Replaces force-push/backstop logic with cleaner assert-absent gates; drops --verify-tag (intentional: gh creates the tag at --target) and removes now-unneeded SHA backstop check. |
| .github/workflows/release-intake.yml | Triggers narrowed to `pr-v*` tags; added deletion-event guard; PR idempotency check simplified to tag name only; trigger tag deleted after PR is opened. |
| custom_components/addhon/manifest.json | Version bumped from 5.0.3 to 5.0.4; codeowner and all GitHub URLs updated to new org (tis24dev). |
| README.md | Badge and clone URLs updated from telard-pixel to tis24dev; no functional changes. |
| custom_components/addhon/config_flow.py | Single docs_url string updated to new org; no logic changes. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Intake as release-intake.yml
    participant Policy as release-policy.sh
    participant PMR as post-merge-release.yml

    Dev->>GH: git push pr-vX.Y.Z (unprotected trigger tag)
    GH->>Intake: push event (tag: pr-vX.Y.Z)
    Intake->>Policy: is_pr_tag(), release_tag_from_pr_tag()
    Intake->>Policy: remote_release_state(vX.Y.Z) — fail closed
    Intake->>Policy: remote_tag_state(vX.Y.Z) — fail closed
    alt Version mismatch on dev
        Intake->>GH: git push — bump manifest.json on dev
    end
    Intake->>GH: delete_remote_tag(pr-vX.Y.Z)
    Intake->>GH: gh pr create (dev → main, body: release-tag: vX.Y.Z)
    Dev->>GH: Merge PR (squash)
    GH->>PMR: pull_request closed event
    PMR->>Policy: assert_release_absent(vX.Y.Z) — fail closed
    PMR->>Policy: assert_release_tag_absent(vX.Y.Z) — fail closed
    PMR->>GH: gh release create vX.Y.Z --target MERGE_SHA
    Note over GH: Immutable vX.Y.Z tag CREATED once on squash commit
    PMR->>GH: git push dev ← MERGE_SHA (force-with-lease)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Intake as release-intake.yml
    participant Policy as release-policy.sh
    participant PMR as post-merge-release.yml

    Dev->>GH: git push pr-vX.Y.Z (unprotected trigger tag)
    GH->>Intake: push event (tag: pr-vX.Y.Z)
    Intake->>Policy: is_pr_tag(), release_tag_from_pr_tag()
    Intake->>Policy: remote_release_state(vX.Y.Z) — fail closed
    Intake->>Policy: remote_tag_state(vX.Y.Z) — fail closed
    alt Version mismatch on dev
        Intake->>GH: git push — bump manifest.json on dev
    end
    Intake->>GH: delete_remote_tag(pr-vX.Y.Z)
    Intake->>GH: gh pr create (dev → main, body: release-tag: vX.Y.Z)
    Dev->>GH: Merge PR (squash)
    GH->>PMR: pull_request closed event
    PMR->>Policy: assert_release_absent(vX.Y.Z) — fail closed
    PMR->>Policy: assert_release_tag_absent(vX.Y.Z) — fail closed
    PMR->>GH: gh release create vX.Y.Z --target MERGE_SHA
    Note over GH: Immutable vX.Y.Z tag CREATED once on squash commit
    PMR->>GH: git push dev ← MERGE_SHA (force-with-lease)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["ci(release): fail-closed release/tag exi..."](https://github.com/tis24dev/addhon/commit/016c9712422f21cedd4bd575e305735324c227b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38805548)</sub>

<!-- /greptile_comment -->