### PR TITLE
Release v5.0.5

### DIFF
--- a/.github/scripts/release-policy.sh
+++ b/.github/scripts/release-policy.sh
@@ -110,7 +110,12 @@ PY
 delete_remote_tag() {
   local tag="${1:-}"
 
-  git push origin ":refs/tags/${tag}" || true
+  # Best-effort cleanup of the unprotected trigger tag. Stays non-fatal, but a
+  # transient failure is surfaced as a warning: if the pr-vX.Y.Z tag is left
+  # behind, re-pushing the same trigger is a no-op (ref unchanged) and won't
+  # re-fire intake, so the leftover needs manual deletion before re-releasing.
+  git push origin ":refs/tags/${tag}" || \
+    echo "::warning::Failed to delete tag ${tag} (non-fatal); it may need manual cleanup before this version can be re-released."
 }
 
 # Existence probes that DISTINGUISH absent from error. A transient auth/network

--- a/.github/workflows/release-intake.yml
+++ b/.github/workflows/release-intake.yml
@@ -40,7 +40,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          source .github/scripts/release-policy.sh
+
+          # SECURITY: source the release policy from the TRUSTED base (origin/main),
+          # NEVER from the checked-out tag tree. On a `push: tags` event the default
+          # checkout is the tag = dev HEAD (the to-be-released, not-yet-reviewed code),
+          # so sourcing its release-policy.sh would let a tampered policy govern this
+          # write-credentialed job. Mirrors release-guard (base.sha) and cPSM's intake.
+          # NB: the new pr-v* helpers must already be on main; bootstrap falls back to
+          # the tag's policy only when main has no policy file at all.
+          git fetch --force origin main
+          POLICY="$(mktemp)"
+          if git cat-file -e "origin/main:.github/scripts/release-policy.sh" 2>/dev/null; then
+            git show "origin/main:.github/scripts/release-policy.sh" > "${POLICY}"
+          else
+            echo "::notice::Release policy absent on origin/main; bootstrap release, using the tag's policy."
+            cp .github/scripts/release-policy.sh "${POLICY}"
+          fi
+          # shellcheck source=/dev/null
+          source "${POLICY}"
 
           TRIGGER="${GITHUB_REF_NAME}"
 

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -180,21 +180,28 @@ async def _async_close_client(client) -> None:
         _LOGGER.warning("Error closing HonClient: %s", err)
 
 
-# "Washer-only" consumption sensors that were mistakenly created on the tumble
-# dryers (TD) too: a tumble dryer does not use water and does not expose these
-# counters, so they stayed forever "unknown" entities. After the per-type refactor
-# they are no longer created: here we clean up the ones already registered, ONLY on
-# TD devices.
-_TD_REMOVED_SUFFIXES = ("_total_water", "_total_energy", "_current_energy", "_current_water")
+# "Washer-only" sensors that were mistakenly created on the tumble dryers (TD)
+# too: a tumble dryer does not use water and does not report loadingPercentage
+# (the app gates that statistic to WM/WD), so they stayed forever "unknown"
+# entities. After the per-type refactor they are no longer created: here we clean
+# up the ones already registered, ONLY on TD devices.
+_TD_REMOVED_SUFFIXES = (
+    "_total_water",
+    "_total_energy",
+    "_current_energy",
+    "_current_water",
+    "_loading_percentage",
+)
 
 
 def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove from the registry the legacy entities no longer provided by the integration.
 
     - "Power" switch (unique_id '<id>_power'), removed in the 2.3/2.4 refactor.
-    - Washer-only consumption sensors on the tumble dryers (TD): '<td_id>_total_water',
-      '_total_energy', '_current_energy', '_current_water'. Removed ONLY on devices
-      of type TD (cross-checked with the coordinator), never on WM/WD/AC.
+    - Washer-only sensors on the tumble dryers (TD): '<td_id>_total_water',
+      '_total_energy', '_current_energy', '_current_water', '_loading_percentage'.
+      Removed ONLY on devices of type TD (cross-checked with the coordinator),
+      never on WM/WD/AC.
 
     Without this cleanup there would be orphan 'unavailable' entities with the '?' badge.
     """

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -101,9 +101,23 @@ _CONNECTIVITY = HonBinarySensorEntityDescription(
     device_class=BinarySensorDeviceClass.CONNECTIVITY,
 )
 
+def _g_running(key: str, attr: str) -> "HonBinarySensorEntityDescription":
+    """Gated read-only RUNNING binary for an `option engaged` (0/1) flag."""
+    return HonBinarySensorEntityDescription(
+        key=key, attr_key=attr, device_class=BinarySensorDeviceClass.RUNNING,
+    )
+
+
 # Per-type sets (candidates; the capability-gate drops those not present on the device).
+# The option flags (night_wash/steam/energy_saving) are gvigroux-live-tested 0/1
+# params, gated by the universal binary gate so they appear only where reported.
 _WASH_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     _DOOR_OPEN, _DOOR_LOCK, _CHILD_LOCK, _DRUM_CLEAN, _FILTER_CLEAN, _DRY_CLEAN,
+    _g_running("night_wash", "nightWashStatus"),
+    _g_running("steam", "steamStatus"),
+    HonBinarySensorEntityDescription(
+        key="energy_saving", attr_key="energySavingStatus", icon="mdi:leaf",
+    ),
 )
 _DRY_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     _DOOR_OPEN, _DOOR_LOCK, _CHILD_LOCK,
@@ -187,9 +201,13 @@ _OVEN_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     ),
 )
 
-# Dishwasher (DW).
+# Dishwasher (DW): door + program-option flags (live-confirmed on real DW, gated).
 _DISHWASHER_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     _door("door_open", "doorStatus"),
+    _g_running("extra_dry", "extraDry"),
+    _g_running("half_load", "halfLoad"),
+    _g_running("auto_open_door", "openDoor"),
+    _g_running("eco_express", "ecoExpress"),
 )
 
 # Wine cellar (WC).

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -177,6 +177,12 @@ _OVEN_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
     _door("door_open", "doorStatus"),
     _door("door_zone1", "doorStatusZ1", translation_key="door_cavity1"),
     _door("door_zone2", "doorStatusZ2", translation_key="door_cavity2"),
+    HonBinarySensorEntityDescription(
+        key="preheat",
+        icon="mdi:thermometer-chevron-up",
+        attr_key="preheatStatus",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
 )
 
 # Dishwasher (DW).

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -181,7 +181,9 @@ _OVEN_BINARY: tuple[HonBinarySensorEntityDescription, ...] = (
         key="preheat",
         icon="mdi:thermometer-chevron-up",
         attr_key="preheatStatus",
-        device_class=BinarySensorDeviceClass.RUNNING,
+        # preheatStatus is 0=idle / 1=preheating / 2=ready; on == "1" (heating in
+        # progress), matching the app's `=='1'` test. HEAT fits the semantics.
+        device_class=BinarySensorDeviceClass.HEAT,
     ),
 )
 

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -279,7 +279,7 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
                 translation_key="appliance_or_client_unavailable",
             )
         try:
-            speed_key = AC_FAN_MAP_REVERSE.get(fan_mode, "0")
+            speed_key = AC_FAN_MAP_REVERSE.get(fan_mode, "5")
             _LOGGER.debug("Climate debug: set_fan_mode %s -> windSpeed=%s", fan_mode, speed_key)
             await self._send_command_in_executor(client, appliance, {"windSpeed": speed_key})
             await self._async_request_command_refresh()

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -116,8 +116,10 @@ AC_MODE_MAP = {
 AC_MODE_MAP_REVERSE = {v: k for k, v in AC_MODE_MAP.items()}
 
 # Fan speed map (confirmed: windSpeed in settings)
+# windSpeed enum (app mapFanSpeedTitle): 1=high, 2=medium(mid), 3=low, 5=auto.
+# There is NO value 0 (the device rejects writing 0); auto is 5.
 AC_FAN_MAP = {
-    "0": "auto",
+    "5": "auto",
     "3": "low",
     "2": "medium",
     "1": "high",
@@ -149,15 +151,22 @@ WM_ATTR_ERRORS        = "errors"
 TD_ATTR_CYCLES = "programsCounter"
 
 # --- Washing machine / tumble dryer states ------------------------------------
+# Authoritative MachineMode enum from the app (decomp `MachineMode`): the washing
+# group uses the same codes as MACHINE_MODE_MAP below. The previous table here was
+# miscoded (e.g. 2->"paused" while 2 is EXECUTION/running, and "half_load" is a
+# program option, not a machine state). Translation namespace stays "state".
 WM_STATE_MAP = {
-    "0": "waiting",
-    "1": "running",
-    "2": "paused",
-    "3": "completed",
-    "4": "error",
-    "5": "scheduled",
-    "6": "delayed_start",
-    "7": "half_load",
+    "0": "idle",
+    "1": "selection",
+    "2": "running",
+    "3": "paused",
+    "4": "delayed_start",
+    "5": "delayed_start_running",
+    "6": "error",
+    "7": "finished",
+    "8": "test",
+    "9": "stopped",
+    "10": "keep_fresh",
 }
 
 # --- Additional sensors/binary for the washing group --------------------------
@@ -218,10 +227,9 @@ TUMBLE_DRYER_PHASE_MAP = {
 # Values not in the map -> None (handled by the value_fn in sensor.py).
 
 # Authoritative app machMode (0-10), used by the types that share MachineMode
-# (oven, dishwasher, ...). NOTE: distinct from WM_STATE_MAP (the washing group's
-# own 0-7 codes); both now hold ENUM machine keys, exposed under distinct
-# translation_keys ("machine_mode" vs "state") so their state vocabularies stay
-# separate.
+# (oven, dishwasher, ...). Kept as a SEPARATE dict from WM_STATE_MAP (currently
+# identical content) so the two stay on distinct translation_keys ("machine_mode"
+# vs "state") and can diverge per appliance family without affecting each other.
 MACHINE_MODE_MAP = {
     "0": "idle",
     "1": "selection",
@@ -282,13 +290,13 @@ STAIN_TYPE_MAP = {
     "6": "cooking_oil",
     "7": "tea",
     "8": "coffee",
-    "9": "ice_cream",
+    "9": "chocolate",
     "10": "lip_gloss",
     "11": "curry",
     "12": "milk_tea",
-    "13": "rust",
+    "13": "chili_oil",
     "14": "blue_ink",
-    "15": "perfume",
+    "15": "color_pencil",
     "16": "shoe_cream",
     "17": "oil_pastel",
     "18": "blueberry",

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.0.4"
+  "version": "5.0.5"
 }

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -98,9 +98,22 @@ _WINE_NUMBERS: tuple[HonNumberEntityDescription, ...] = (
     _temp("target_temp_zone3", "tempSelZ3"),
 )
 
-# Oven (OV): cavity target (S7).
+# Oven (OV): cavity target (S7). Oven-appropriate fallback range (50-280 C step 5,
+# from the app device dictionary) used only when the device does not expose its own
+# range at runtime; a 0-100 default would be wrong for an oven.
 _OVEN_NUMBERS: tuple[HonNumberEntityDescription, ...] = (
-    _temp("target_temp", "tempSel", translation_key="target_temp_oven"),
+    HonNumberEntityDescription(
+        key="target_temp",
+        param="tempSel",
+        translation_key="target_temp_oven",
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        mode=NumberMode.BOX,
+        icon="mdi:thermometer",
+        fallback_min=50.0,
+        fallback_max=280.0,
+        fallback_step=5.0,
+    ),
 )
 
 NUMBERS: dict[str, tuple[HonNumberEntityDescription, ...]] = {

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfEnergy,
+    UnitOfMass,
     UnitOfTemperature,
     UnitOfTime,
     UnitOfVolume,
@@ -276,6 +277,23 @@ def _loading_pct(raw) -> float | None:
     return round(sum(ratios) / len(ratios), 1)
 
 
+def _g_grams(key: str, attr: str) -> "HonSensorEntityDescription":
+    """Gated mass sensor in grams (e.g. auto-dosed detergent/softener weight)."""
+    return HonSensorEntityDescription(
+        key=key,
+        attr_key=attr,
+        native_unit_of_measurement=UnitOfMass.GRAMS,
+        device_class=SensorDeviceClass.WEIGHT,
+        state_class=SensorStateClass.MEASUREMENT,
+        gated=True,
+    )
+
+
+def _g_int(key: str, attr: str, icon: str | None = None) -> "HonSensorEntityDescription":
+    """Gated plain-integer sensor: no device_class/unit, default float() render."""
+    return HonSensorEntityDescription(key=key, attr_key=attr, icon=icon, gated=True)
+
+
 _PROGRAM_NAME = HonSensorEntityDescription(
     key="program_name",
     icon="mdi:format-list-bulleted",
@@ -356,15 +374,35 @@ _WASH_EXTRA: tuple[HonSensorEntityDescription, ...] = (
     ),
 )
 
-# Washer (WM): state/time + program + wash extras + load/delay + consumption.
+# Auto-dose / cycle telemetry (premium features, not on every model). gated=True so
+# they self-suppress where absent. currentWashCycle/remainingRinseIterations are
+# gvigroux-live-tested bare params (the decomp has only the WM-prefixed statistics
+# form), so gating is essential.
+_WASH_DOSE: tuple[HonSensorEntityDescription, ...] = (
+    _g_int("current_wash_cycle", "currentWashCycle", icon="mdi:counter"),
+    _g_int("remaining_rinses", "remainingRinseIterations", icon="mdi:water-sync"),
+    HonSensorEntityDescription(
+        # Auto-dose strength relative to a standard dose (0=off/70=eco/100=std/
+        # 120=boost), not a continuous tank level: keep the "%" but no state_class
+        # (it is a stepped setpoint, not a quantity to graph).
+        key="detergent_level",
+        attr_key="detergentPercent",
+        native_unit_of_measurement="%",
+        icon="mdi:cup-water",
+        gated=True,
+    ),
+    _g_grams("detergent_weight", "haier_DetergentWeight"),
+    _g_grams("softener_weight", "haier_SoftenerWeight"),
+)
+# Washer (WM): state/time + program + wash extras + load/delay + consumption + dose.
 _WASHER: tuple[HonSensorEntityDescription, ...] = (
     _STATE, _REMAINING, _PROGRAM_NAME, _PHASE_WASH, *_WASH_EXTRA, _LOADING, _DELAY,
-    _ERRORS, *_WASH_CONSUMPTION,
+    _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE,
 )
 # Washer-dryer (WD = WM + drying): like the washer + dry level.
 _WASHER_DRYER: tuple[HonSensorEntityDescription, ...] = (
     _STATE, _REMAINING, _PROGRAM_NAME, _PHASE_WASH, *_WASH_EXTRA, _DRY_LEVEL, _LOADING,
-    _DELAY, _ERRORS, *_WASH_CONSUMPTION,
+    _DELAY, _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE,
 )
 
 # Tumble dryer: no water/energy (hOn does not expose them for the TD). The cycles
@@ -454,6 +492,23 @@ _AC: tuple[HonSensorEntityDescription, ...] = (
         native_unit_of_measurement="mg/m³",
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # Air-quality sensors on air-quality-capable AC / air-sensor units (gvigroux
+    # live). gated=True (unlike the always-present AC sensors) so a model without
+    # them shows nothing. pm10 is a real mass concentration (ug/m3, like pm25);
+    # voc/coLevel/airQuality are small LEVEL indexes in the app (L1..L4 / 0..3),
+    # NOT ppb/ppm/0-500 AQI, so they are bare integers (class-less AND unit-less)
+    # to avoid asserting a concentration the device does not report.
+    HonSensorEntityDescription(
+        key="pm10",
+        attr_key="pm10ValueIndoor",
+        native_unit_of_measurement="µg/m³",
+        device_class=SensorDeviceClass.PM10,
+        state_class=SensorStateClass.MEASUREMENT,
+        gated=True,
+    ),
+    _g_int("voc", "vocValueIndoor", icon="mdi:molecule"),
+    _g_int("co", "coLevel", icon="mdi:molecule"),
+    _g_int("air_quality", "airQuality", icon="mdi:air-filter"),
 )
 
 # --- Tier 2: read-only sensors (capability-gated) ----------------------------
@@ -563,6 +618,16 @@ _OVEN: tuple[HonSensorEntityDescription, ...] = (
     _g_temp("temp_cavity", "temp"),
     _g_minutes("remaining_time", "remainingTimeMM"),
     _g_minutes("delay_time", "delayTime"),
+    # prTime is the configured cook duration in SECONDS (range 1..86395), not
+    # minutes; map it as a seconds duration so the magnitude is correct.
+    HonSensorEntityDescription(
+        key="program_duration",
+        attr_key="prTime",
+        icon="mdi:timer-outline",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        gated=True,
+    ),
     _g_temp("probe_temp_1", "tempEmployedProbe1"),
     _g_temp("probe_temp_2", "tempEmployedProbe2"),
     _g_text("errors", "errors", icon="mdi:alert-circle-outline"),
@@ -575,9 +640,11 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
             translation_key="machine_mode", icon="mdi:dishwasher"),
     _g_text("program_name", "programName", icon="mdi:format-list-bulleted"),
     _g_minutes("remaining_time", "remainingTimeMM"),
+    _g_minutes("delay_time", "delayTime"),
     _g_enum("salt_level", "saltStatus", DW_LEVEL_MAP, icon="mdi:shaker-outline"),
     _g_enum("rinse_aid_level", "rinseAidStatus", DW_LEVEL_MAP,
             icon="mdi:water-opacity"),
+    _g_int("water_hardness", "waterHard", icon="mdi:water-opacity"),
     HonSensorEntityDescription(
         key="wash_temperature",
         # Dishwashers report the wash temperature under `temp` (live-confirmed on
@@ -596,12 +663,16 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
 # actual temperature is reported under `temp` (live-confirmed on HWS42/HWS77).
 # Light/presence are binary.
 _WINE: tuple[HonSensorEntityDescription, ...] = (
+    _g_enum("state", "machMode", MACHINE_MODE_MAP,
+            translation_key="machine_mode", icon="mdi:thermometer-wine"),
+    _g_text("program_name", "programName", icon="mdi:format-list-bulleted"),
     _g_temp("temp_ambient", "tempEnv"),
     _g_temp("temp_zone1", "temp"),
     _g_temp("temp_zone2", "tempZ2"),
     _g_humidity("humidity_zone1", "humidityZ1"),
     _g_humidity("humidity_zone2", "humidityZ2"),
     _g_minutes("remaining_time", "remainingTimeMM"),
+    _g_text("errors", "errors", icon="mdi:alert-circle-outline"),
 )
 
 # Induction hob (IH/HOB): temperature per cooking zone. Pan detection

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -366,14 +366,15 @@ _WASHER_DRYER: tuple[HonSensorEntityDescription, ...] = (
 # Tumble dryer: no water/energy (hOn does not expose them for the TD). The cycles
 # reuse the "total_washes" suffix but read programsCounter, so the already-
 # registered entity (previously always empty on totalWashCycle) is re-pointed to a
-# real value without changing entity_id.
+# real value without changing entity_id. No loading_percentage: the app gates the
+# Loading Percentage statistic to WM/WD only (TD uses loadEfficiency instead), so
+# the sensor would be perpetually unknown on a dryer.
 _DRYER: tuple[HonSensorEntityDescription, ...] = (
     _STATE,
     _REMAINING,
     _PROGRAM_NAME,
     _PHASE_DRY,
     _DRY_LEVEL,
-    _LOADING,
     _DELAY,
     _ERRORS,
     HonSensorEntityDescription(

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -496,6 +496,17 @@ def _g_minutes(key: str, attr: str) -> HonSensorEntityDescription:
     )
 
 
+def _g_humidity(key: str, attr: str) -> HonSensorEntityDescription:
+    return HonSensorEntityDescription(
+        key=key,
+        attr_key=attr,
+        native_unit_of_measurement="%",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        gated=True,
+    )
+
+
 def _g_text(key: str, attr: str, icon: str | None = None,
             value_fn: Callable[[object], object] | None = _as_text) -> HonSensorEntityDescription:
     return HonSensorEntityDescription(
@@ -544,10 +555,13 @@ _COOLING: tuple[HonSensorEntityDescription, ...] = (
 _OVEN: tuple[HonSensorEntityDescription, ...] = (
     _g_enum("state", "machMode", MACHINE_MODE_MAP,
             translation_key="machine_mode", icon="mdi:stove"),
+    _g_text("program_name", "programName", icon="mdi:format-list-bulleted"),
     _g_temp("temp_cavity", "temp"),
     _g_minutes("remaining_time", "remainingTimeMM"),
+    _g_minutes("delay_time", "delayTime"),
     _g_temp("probe_temp_1", "tempEmployedProbe1"),
     _g_temp("probe_temp_2", "tempEmployedProbe2"),
+    _g_text("errors", "errors", icon="mdi:alert-circle-outline"),
 )
 
 # Dishwasher (DW): state, program, time, salt/rinse-aid levels,
@@ -562,7 +576,9 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
             icon="mdi:water-opacity"),
     HonSensorEntityDescription(
         key="wash_temperature",
-        attr_key="temperature",
+        # The dishwasher reports the wash temperature under `temp` (live-confirmed
+        # on real DW; `temperature` is not a DW parameter in the app schema).
+        attr_key="temp",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -571,10 +587,15 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
     _g_text("errors", "errors", icon="mdi:alert-circle-outline"),
 )
 
-# Wine cellar (WC): ambient + zone temperature. Light/presence are binary.
+# Wine cellar (WC): ambient + per-zone temperature + per-zone humidity. Zone 1
+# actual temperature is reported under `temp` (live-confirmed on HWS42/HWS77).
+# Light/presence are binary.
 _WINE: tuple[HonSensorEntityDescription, ...] = (
     _g_temp("temp_ambient", "tempEnv"),
+    _g_temp("temp_zone1", "temp"),
     _g_temp("temp_zone2", "tempZ2"),
+    _g_humidity("humidity_zone1", "humidityZ1"),
+    _g_humidity("humidity_zone2", "humidityZ2"),
     _g_minutes("remaining_time", "remainingTimeMM"),
 )
 

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+import math
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -198,6 +199,79 @@ def _stain(raw) -> str | None:
     return STAIN_TYPE_MAP.get(str(raw))
 
 
+def _loading_pct(raw) -> float | None:
+    """Average drum-load percentage from the loadingPercentage attribute.
+
+    Laundry devices report loadingPercentage as a history LIST of
+    {"current", "max", "date"} records (load vs drum capacity over past cycles),
+    not a scalar, so the generic float() path would raise on the list and the
+    sensor would stay unknown. Following the official app's "Loading Percentage"
+    statistic, a record whose own max is 0/missing borrows the largest max in the
+    list, each record's current is clamped to its max, and the load percent
+    (current / max * 100) is averaged across the records. The clamp keeps the
+    result within 0..100. A plain scalar / numeric string is passed through
+    unchanged for forward/backward compatibility.
+
+    The app limits the average to the five most recent records by `date`. We
+    deliberately average ALL records instead and ignore `date`: its serialization
+    is not verified against a live washer (the only known sample is the app's mock
+    of JS Date objects), so any ordering would be unreliable, and the app's own
+    backfill reducer is buggy. Real statistics lists observed so far are short
+    (<= 5), where averaging all and "the most recent five" are identical. Revisit
+    the windowing once a washer is available to validate the `date` shape live.
+
+    Returns None (sensor "unknown", not a crash) when the value is missing, the
+    list is empty/malformed, or no usable max can be derived (e.g. a device with
+    no completed cycle yet, whose records all report max == 0 so drum capacity is
+    unknown).
+    """
+    if raw is None:
+        return None
+    # Scalar / numeric-string passthrough (a model that ever reports a plain value).
+    if not isinstance(raw, (list, tuple)):
+        try:
+            value = float(raw)
+        except (ValueError, TypeError):
+            return None
+        return value if math.isfinite(value) else None
+    records = [r for r in raw if isinstance(r, dict) and r.get("current") is not None]
+    if not records:
+        return None
+    # Fleet-wide fallback for records whose own max is 0/missing: borrow the
+    # largest known drum capacity (a clean global max, unlike the app's reducer).
+    valid_maxes = []
+    for record in records:
+        try:
+            candidate = float(record["max"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        if math.isfinite(candidate) and candidate > 0:
+            valid_maxes.append(candidate)
+    fallback_max = max(valid_maxes) if valid_maxes else None
+    ratios = []
+    for record in records:
+        try:
+            current = float(record["current"])
+        except (ValueError, TypeError):
+            continue
+        try:
+            maximum = float(record.get("max"))
+        except (ValueError, TypeError):
+            maximum = 0.0
+        # A non-finite/non-positive own max is unusable; borrow the fleet capacity.
+        usable_max = maximum if (math.isfinite(maximum) and maximum > 0) else None
+        denom = usable_max if usable_max else fallback_max
+        if not denom or denom <= 0:
+            continue
+        current = min(current, denom)  # clamp like the app's Math.min(current, max)
+        ratio = current / denom * 100.0
+        if math.isfinite(ratio) and ratio >= 0:
+            ratios.append(ratio)
+    if not ratios:
+        return None
+    return round(sum(ratios) / len(ratios), 1)
+
+
 _PROGRAM_NAME = HonSensorEntityDescription(
     key="program_name",
     icon="mdi:format-list-bulleted",
@@ -240,6 +314,7 @@ _LOADING = HonSensorEntityDescription(
     attr_key=WM_ATTR_LOADING,
     native_unit_of_measurement="%",
     state_class=SensorStateClass.MEASUREMENT,
+    value_fn=_loading_pct,
 )
 _DRY_LEVEL = HonSensorEntityDescription(
     key="dry_level",

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -116,6 +116,10 @@ class HonSensorEntityDescription(SensorEntityDescription):
     attr_key: str
     value_fn: Callable[[object], object] | None = None
     gated: bool = False
+    # Alternative attribute names to try (in order) when `attr_key` is absent.
+    # Used for params reported under different names across models (e.g. a
+    # dishwasher wash temperature under `temp` or `temperature`).
+    attr_fallbacks: tuple[str, ...] = ()
 
 
 # State + remaining time: identical for washer/washer-dryer/tumble dryer.
@@ -576,9 +580,10 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
             icon="mdi:water-opacity"),
     HonSensorEntityDescription(
         key="wash_temperature",
-        # The dishwasher reports the wash temperature under `temp` (live-confirmed
-        # on real DW; `temperature` is not a DW parameter in the app schema).
+        # Dishwashers report the wash temperature under `temp` (live-confirmed on
+        # real DW) on some models and `temperature` on others; gate/read both.
         attr_key="temp",
+        attr_fallbacks=("temperature",),
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -743,7 +748,11 @@ async def async_setup_entry(
             # Capability-gating (Tier 2 only): skip the sensors whose attribute
             # is not exposed by the device. The historic types (gated=False) stay
             # always created, as before.
-            if description.gated and description.attr_key not in attributes:
+            if (
+                description.gated
+                and description.attr_key not in attributes
+                and not any(k in attributes for k in description.attr_fallbacks)
+            ):
                 continue
             entities.append(HonSensor(coordinator, appliance_id, description))
             created.append(description.key)
@@ -778,6 +787,10 @@ class HonSensor(HonBaseEntity, SensorEntity):
     @property
     def native_value(self):
         raw = self._get_attr(self.entity_description.attr_key)
+        for fallback in self.entity_description.attr_fallbacks:
+            if raw is not None:
+                break
+            raw = self._get_attr(fallback)
         value_fn = self.entity_description.value_fn
         if value_fn is not None:
             return value_fn(raw)

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -129,7 +129,8 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         val = self._get_attr(WM_ATTR_STATUS, "0")
-        is_paused = str(val) == "2"
+        # machMode 3 = PAUSE_MODE (2 = EXECUTION/running) per the app's MachineMode enum.
+        is_paused = str(val) == "3"
         _LOGGER.debug(
             "Switch debug: is_on '%s' id=%s machMode=%s -> %s",
             self._attr_unique_id,

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -123,7 +123,7 @@
         "name": "Start delay"
       },
       "loading_percentage": {
-        "name": "Load"
+        "name": "Average load"
       },
       "dry_level": {
         "name": "Dry level"

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -199,6 +199,39 @@
       "ch2o": {
         "name": "Formaldehyde"
       },
+      "pm10": {
+        "name": "PM10"
+      },
+      "voc": {
+        "name": "VOC"
+      },
+      "co": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "water_hardness": {
+        "name": "Water hardness"
+      },
+      "current_wash_cycle": {
+        "name": "Current cycle"
+      },
+      "remaining_rinses": {
+        "name": "Remaining rinses"
+      },
+      "detergent_level": {
+        "name": "Detergent dose"
+      },
+      "detergent_weight": {
+        "name": "Detergent dispensed"
+      },
+      "softener_weight": {
+        "name": "Softener dispensed"
+      },
+      "program_duration": {
+        "name": "Program duration"
+      },
       "temp_zone1": {
         "name": "Zone 1 temperature"
       },
@@ -377,6 +410,24 @@
       },
       "preheat": {
         "name": "Preheating"
+      },
+      "extra_dry": {
+        "name": "Extra dry"
+      },
+      "half_load": {
+        "name": "Half load"
+      },
+      "auto_open_door": {
+        "name": "Auto door open"
+      },
+      "eco_express": {
+        "name": "Eco express"
+      },
+      "night_wash": {
+        "name": "Night wash"
+      },
+      "steam": {
+        "name": "Steam"
       },
       "door_zone1": {
         "name": "Zone 1 door"

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -70,14 +70,17 @@
       "state": {
         "name": "Status",
         "state": {
-          "waiting": "Waiting",
+          "idle": "Idle",
+          "selection": "Selection",
           "running": "Running",
           "paused": "Paused",
-          "completed": "Completed",
-          "error": "Error",
-          "scheduled": "Scheduled",
           "delayed_start": "Delayed start",
-          "half_load": "Half load"
+          "delayed_start_running": "Delayed start (running)",
+          "error": "Error",
+          "finished": "Finished",
+          "test": "Test",
+          "stopped": "Stopped",
+          "keep_fresh": "Keep fresh"
         }
       },
       "remaining_time": {
@@ -152,13 +155,13 @@
           "cooking_oil": "Cooking oil",
           "tea": "Tea",
           "coffee": "Coffee",
-          "ice_cream": "Ice cream",
+          "chocolate": "Chocolate",
           "lip_gloss": "Lip gloss",
           "curry": "Curry",
           "milk_tea": "Milk tea",
-          "rust": "Rust",
+          "chili_oil": "Chili oil",
           "blue_ink": "Blue ink",
-          "perfume": "Perfume",
+          "color_pencil": "Color pencil",
           "shoe_cream": "Shoe cream",
           "oil_pastel": "Oil pastel",
           "blueberry": "Blueberry",

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -226,6 +226,12 @@
       "humidity_ambient": {
         "name": "Ambient humidity"
       },
+      "humidity_zone1": {
+        "name": "Zone 1 humidity"
+      },
+      "humidity_zone2": {
+        "name": "Zone 2 humidity"
+      },
       "temp_cavity": {
         "name": "Oven temperature"
       },
@@ -368,6 +374,9 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "preheat": {
+        "name": "Preheating"
       },
       "door_zone1": {
         "name": "Zone 1 door"

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -70,14 +70,17 @@
       "state": {
         "name": "Stato",
         "state": {
-          "waiting": "In attesa",
+          "idle": "Inattivo",
+          "selection": "Selezione",
           "running": "In esecuzione",
           "paused": "In pausa",
-          "completed": "Completato",
+          "delayed_start": "Avvio ritardato",
+          "delayed_start_running": "Avvio ritardato (in corso)",
           "error": "Errore",
-          "scheduled": "Programmato",
-          "delayed_start": "Ritardo avvio",
-          "half_load": "Mezzo carico"
+          "finished": "Terminato",
+          "test": "Test",
+          "stopped": "Arresto",
+          "keep_fresh": "Mantieni fresco"
         }
       },
       "remaining_time": {
@@ -152,13 +155,13 @@
           "cooking_oil": "Olio da cucina",
           "tea": "Tè",
           "coffee": "Caffè",
-          "ice_cream": "Gelato",
+          "chocolate": "Cioccolato",
           "lip_gloss": "Lucidalabbra",
           "curry": "Curry",
           "milk_tea": "Tè al latte",
-          "rust": "Ruggine",
+          "chili_oil": "Olio di peperoncino",
           "blue_ink": "Inchiostro blu",
-          "perfume": "Profumo",
+          "color_pencil": "Matita colorata",
           "shoe_cream": "Lucido da scarpe",
           "oil_pastel": "Pastello a olio",
           "blueberry": "Mirtillo",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -123,7 +123,7 @@
         "name": "Ritardo Avvio"
       },
       "loading_percentage": {
-        "name": "Carico"
+        "name": "Carico medio"
       },
       "dry_level": {
         "name": "Livello Asciugatura"

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -226,6 +226,12 @@
       "humidity_ambient": {
         "name": "Umidità Ambiente"
       },
+      "humidity_zone1": {
+        "name": "Umidità Zona 1"
+      },
+      "humidity_zone2": {
+        "name": "Umidità Zona 2"
+      },
       "temp_cavity": {
         "name": "Temperatura Forno"
       },
@@ -368,6 +374,9 @@
       },
       "connectivity": {
         "name": "Connettività"
+      },
+      "preheat": {
+        "name": "Preriscaldamento"
       },
       "door_zone1": {
         "name": "Porta Zona 1"

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -199,6 +199,39 @@
       "ch2o": {
         "name": "Formaldeide"
       },
+      "pm10": {
+        "name": "PM10"
+      },
+      "voc": {
+        "name": "COV"
+      },
+      "co": {
+        "name": "Monossido di carbonio"
+      },
+      "air_quality": {
+        "name": "Qualità dell'aria"
+      },
+      "water_hardness": {
+        "name": "Durezza dell'acqua"
+      },
+      "current_wash_cycle": {
+        "name": "Ciclo corrente"
+      },
+      "remaining_rinses": {
+        "name": "Risciacqui rimanenti"
+      },
+      "detergent_level": {
+        "name": "Dose detersivo"
+      },
+      "detergent_weight": {
+        "name": "Detersivo erogato"
+      },
+      "softener_weight": {
+        "name": "Ammorbidente erogato"
+      },
+      "program_duration": {
+        "name": "Durata programma"
+      },
       "temp_zone1": {
         "name": "Temperatura Zona 1"
       },
@@ -377,6 +410,24 @@
       },
       "preheat": {
         "name": "Preriscaldamento"
+      },
+      "extra_dry": {
+        "name": "Asciugatura extra"
+      },
+      "half_load": {
+        "name": "Mezzo carico"
+      },
+      "auto_open_door": {
+        "name": "Apertura automatica porta"
+      },
+      "eco_express": {
+        "name": "Eco express"
+      },
+      "night_wash": {
+        "name": "Lavaggio notturno"
+      },
+      "steam": {
+        "name": "Vapore"
       },
       "door_zone1": {
         "name": "Porta Zona 1"

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -70,10 +70,11 @@ def _install_stubs() -> None:
     uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
 
     const = _mod("homeassistant.const")
-    for unit_cls in ("UnitOfTemperature", "UnitOfEnergy", "UnitOfTime", "UnitOfVolume"):
+    for unit_cls in ("UnitOfTemperature", "UnitOfEnergy", "UnitOfTime", "UnitOfVolume", "UnitOfMass"):
         if not hasattr(const, unit_cls):
             setattr(const, unit_cls, type(unit_cls, (), {
                 "CELSIUS": "C", "KILO_WATT_HOUR": "kWh", "MINUTES": "min", "LITERS": "L",
+                "GRAMS": "g", "SECONDS": "s",
             }))
 
     components = _mod("homeassistant.components")
@@ -97,6 +98,9 @@ def _install_stubs() -> None:
     sensor_mod.SensorDeviceClass = getattr(sensor_mod, "SensorDeviceClass", type("SensorDeviceClass", (), {
         "TEMPERATURE": "temperature", "HUMIDITY": "humidity", "ENERGY": "energy",
         "WATER": "water", "DURATION": "duration", "PM25": "pm25", "CO2": "co2",
+        "PM10": "pm10", "CO": "carbon_monoxide", "AQI": "aqi",
+        "VOLATILE_ORGANIC_COMPOUNDS_PARTS": "volatile_organic_compounds_parts",
+        "WEIGHT": "weight",
         "BATTERY": "battery", "POWER": "power", "ENUM": "enum",
     }))
     sensor_mod.SensorStateClass = getattr(sensor_mod, "SensorStateClass", type("SensorStateClass", (), {

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -119,6 +119,7 @@ def _install_stubs() -> None:
     binary_mod.BinarySensorDeviceClass = getattr(binary_mod, "BinarySensorDeviceClass", type("BinarySensorDeviceClass", (), {
         "DOOR": "door", "PROBLEM": "problem", "RUNNING": "running",
         "OCCUPANCY": "occupancy", "LIGHT": "light", "CONNECTIVITY": "connectivity",
+        "HEAT": "heat",
     }))
 
     # number platform

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -103,7 +103,12 @@ def _install_homeassistant_stubs() -> None:
         WATER = "water"
         DURATION = "duration"
         PM25 = "pm25"
+        PM10 = "pm10"
         CO2 = "carbon_dioxide"
+        CO = "carbon_monoxide"
+        AQI = "aqi"
+        VOLATILE_ORGANIC_COMPOUNDS_PARTS = "volatile_organic_compounds_parts"
+        WEIGHT = "weight"
         BATTERY = "battery"
         POWER = "power"
         ENUM = "enum"
@@ -128,14 +133,19 @@ def _install_homeassistant_stubs() -> None:
 
     class UnitOfTime:
         MINUTES = "min"
+        SECONDS = "s"
 
     class UnitOfTemperature:
         CELSIUS = "°C"
+
+    class UnitOfMass:
+        GRAMS = "g"
 
     const.UnitOfEnergy = getattr(const, "UnitOfEnergy", UnitOfEnergy)
     const.UnitOfVolume = getattr(const, "UnitOfVolume", UnitOfVolume)
     const.UnitOfTime = getattr(const, "UnitOfTime", UnitOfTime)
     const.UnitOfTemperature = getattr(const, "UnitOfTemperature", UnitOfTemperature)
+    const.UnitOfMass = getattr(const, "UnitOfMass", UnitOfMass)
 
     ha.config_entries = config_entries
     ha.core = core
@@ -179,7 +189,8 @@ class PerTypeTableTest(unittest.TestCase):
         self.assertEqual(
             self._keys("AC"),
             ["temp_indoor", "temp_outdoor", "humidity_indoor", "compressor_freq",
-             "total_energy", "pm25", "co2", "ch2o"],
+             "total_energy", "pm25", "co2", "ch2o", "pm10", "voc", "co",
+             "air_quality"],
         )
 
     def test_wm_keys(self) -> None:
@@ -188,7 +199,9 @@ class PerTypeTableTest(unittest.TestCase):
             ["state", "remaining_time", "program_name", "program_phase", "spin_speed",
              "wash_temperature", "dirty_level", "stain_type", "loading_percentage",
              "delay_time", "errors", "total_washes", "total_water", "total_energy",
-             "current_energy", "current_water"],
+             "current_energy", "current_water", "current_wash_cycle",
+             "remaining_rinses", "detergent_level", "detergent_weight",
+             "softener_weight"],
         )
 
     def test_wd_is_wm_plus_dry_level(self) -> None:
@@ -197,7 +210,9 @@ class PerTypeTableTest(unittest.TestCase):
             ["state", "remaining_time", "program_name", "program_phase", "spin_speed",
              "wash_temperature", "dirty_level", "stain_type", "dry_level",
              "loading_percentage", "delay_time", "errors", "total_washes", "total_water",
-             "total_energy", "current_energy", "current_water"],
+             "total_energy", "current_energy", "current_water", "current_wash_cycle",
+             "remaining_rinses", "detergent_level", "detergent_weight",
+             "softener_weight"],
         )
 
     def test_td_keys(self) -> None:

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -204,7 +204,7 @@ class PerTypeTableTest(unittest.TestCase):
         self.assertEqual(
             self._keys("TD"),
             ["state", "remaining_time", "program_name", "program_phase", "dry_level",
-             "loading_percentage", "delay_time", "errors", "temp_level", "total_washes"],
+             "delay_time", "errors", "temp_level", "total_washes"],
         )
 
     def test_td_has_no_water_or_energy(self) -> None:
@@ -249,13 +249,13 @@ class SensorBuildTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             {e._attr_unique_id for e in added},
             {"td-1_state", "td-1_remaining_time", "td-1_program_name",
-             "td-1_program_phase", "td-1_dry_level", "td-1_loading_percentage",
+             "td-1_program_phase", "td-1_dry_level",
              "td-1_delay_time", "td-1_errors", "td-1_temp_level", "td-1_total_washes"},
         )
         cycles = next(e for e in added if e._attr_unique_id == "td-1_total_washes")
         self.assertEqual(cycles.native_value, 42.0)  # reads programsCounter
         state = next(e for e in added if e._attr_unique_id == "td-1_state")
-        self.assertEqual(state.native_value, "running")  # WM_STATE_MAP["1"]
+        self.assertEqual(state.native_value, "selection")  # WM_STATE_MAP["1"]
 
     async def test_td_cycles_can_read_programscounter_from_statistics(self) -> None:
         from custom_components.addhon import sensor
@@ -328,9 +328,11 @@ class TdLegacyCleanupTest(unittest.TestCase):
             RegEntry("sensor.dryer_total_energy", "td-1_total_energy"),     # remove
             RegEntry("sensor.dryer_current_energy", "td-1_current_energy"), # remove
             RegEntry("sensor.dryer_current_water", "td-1_current_water"),   # remove
+            RegEntry("sensor.dryer_load", "td-1_loading_percentage"),       # remove (TD has no loading)
             RegEntry("sensor.dryer_cycles", "td-1_total_washes"),           # KEEP (dryer)
             RegEntry("sensor.dryer_state", "td-1_state"),                   # KEEP
             RegEntry("sensor.washer_total_water", "wm-1_total_water"),      # KEEP (WM, not TD)
+            RegEntry("sensor.washer_load", "wm-1_loading_percentage"),      # KEEP (WM keeps loading)
             RegEntry("switch.washer_power", "wm-1_power"),                  # remove (legacy power)
         ])
         self.addCleanup(setattr, er, "async_get", er.async_get)
@@ -353,13 +355,15 @@ class TdLegacyCleanupTest(unittest.TestCase):
                 "sensor.dryer_total_energy",
                 "sensor.dryer_current_energy",
                 "sensor.dryer_current_water",
+                "sensor.dryer_load",
                 "switch.washer_power",
             ]),
         )
-        # The dryer cycles/state and the washer's real water sensor survive.
+        # The dryer cycles/state and the washer's real water/loading sensors survive.
         self.assertNotIn("sensor.dryer_cycles", registry.removed)
         self.assertNotIn("sensor.dryer_state", registry.removed)
         self.assertNotIn("sensor.washer_total_water", registry.removed)
+        self.assertNotIn("sensor.washer_load", registry.removed)
 
 
 class LoadingPercentageValueFnTest(unittest.TestCase):
@@ -508,9 +512,26 @@ class LoadingPercentageBuildTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(value, 50.0)
 
-    async def test_td_uses_same_value_fn(self) -> None:
-        value = await self._native_value("TD", [{"current": 8, "max": 8}])
-        self.assertEqual(value, 100.0)
+    async def test_td_has_no_loading_sensor(self) -> None:
+        # The app gates loadingPercentage to WM/WD only; TD must not build it.
+        from custom_components.addhon import sensor
+        from custom_components.addhon.const import DOMAIN
+
+        data = {
+            "td-1": {
+                "type": "TD",
+                "name": "TD",
+                "attributes": {"loadingPercentage": [{"current": 8, "max": 8}]},
+                "settings": {},
+            }
+        }
+        coordinator = FakeCoordinator(data)
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator}}})
+        added: list = []
+        await sensor.async_setup_entry(hass, FakeEntry(), added.extend)
+        self.assertNotIn(
+            "td-1_loading_percentage", {e._attr_unique_id for e in added}
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -362,5 +362,156 @@ class TdLegacyCleanupTest(unittest.TestCase):
         self.assertNotIn("sensor.washer_total_water", registry.removed)
 
 
+class LoadingPercentageValueFnTest(unittest.TestCase):
+    """A-001: loadingPercentage is a history list, not a scalar."""
+
+    def _fn(self):
+        from custom_components.addhon.sensor import _loading_pct
+
+        return _loading_pct
+
+    def test_none_returns_none(self) -> None:
+        self.assertIsNone(self._fn()(None))
+
+    def test_empty_list_returns_none(self) -> None:
+        self.assertIsNone(self._fn()([]))
+
+    def test_app_mock_fixture_matches_app_average(self) -> None:
+        # The official app's own loadingPercentage mock (decomp.txt:3560687); the
+        # app KPI = mean of the clamped ratios = mean(90, 71.4, 60, 60) = 70.4.
+        raw = [
+            {"current": 0.9, "max": 1, "date": "2026-06-20"},
+            {"current": 5, "max": 7, "date": "2026-06-19"},
+            {"current": 0.6, "max": 1, "date": "2026-06-18"},
+            {"current": 0.6, "max": 1, "date": "2026-06-17"},
+        ]
+        self.assertEqual(self._fn()(raw), 70.4)
+
+    def test_average_of_records(self) -> None:
+        raw = [
+            {"current": 4, "max": 8, "date": "2026-06-10"},
+            {"current": 6, "max": 8, "date": "2026-06-20"},
+        ]
+        self.assertEqual(self._fn()(raw), 62.5)  # mean(50.0, 75.0)
+
+    def test_max_zero_backfilled_from_fleet(self) -> None:
+        # The max==0 record borrows the largest max (6); mean(50.0, 16.7) = 33.3.
+        raw = [
+            {"current": 3, "max": 6, "date": "2026-06-10"},
+            {"current": 1, "max": 0, "date": "2026-06-20"},
+        ]
+        self.assertEqual(self._fn()(raw), 33.3)
+
+    def test_all_max_zero_returns_none(self) -> None:
+        # The exact offline-shadow HW80 payload: no usable normalizer anywhere.
+        raw = [
+            {"current": 1, "max": 0, "date": "2026-06-20"},
+            {"current": 2, "max": 0, "date": "2026-06-19"},
+        ]
+        self.assertIsNone(self._fn()(raw))
+
+    def test_clamp_keeps_result_within_100(self) -> None:
+        # current > max must be clamped (Math.min in the app), never exceed 100%.
+        self.assertEqual(self._fn()([{"current": 9, "max": 5}]), 100.0)
+        # Cross-scale fleet fallback would overflow without the clamp.
+        raw = [
+            {"current": 0.6, "max": 1, "date": "2026-06-10"},
+            {"current": 9, "max": 0, "date": "2026-06-20"},
+        ]
+        # mean(60.0, clamp(9->1)/1*100=100.0) = 80.0; never 9/1*100 = 900.
+        self.assertEqual(self._fn()(raw), 80.0)
+
+    def test_averages_all_records(self) -> None:
+        # No date windowing: every valid record contributes to the mean.
+        raw = [{"current": 8, "max": 8}] * 3 + [{"current": 0, "max": 8}] * 3
+        self.assertEqual(self._fn()(raw), 50.0)  # mean(100, 100, 100, 0, 0, 0)
+
+    def test_order_independent(self) -> None:
+        raw = [
+            {"current": 2, "max": 8, "date": "a"},
+            {"current": 6, "max": 8, "date": "b"},
+            {"current": 8, "max": 8, "date": "c"},
+        ]
+        self.assertEqual(self._fn()(raw), self._fn()(list(reversed(raw))))
+
+    def test_full_drum(self) -> None:
+        self.assertEqual(self._fn()([{"current": 8, "max": 8}]), 100.0)
+
+    def test_current_zero_preserved(self) -> None:
+        self.assertEqual(self._fn()([{"current": 0, "max": 8}]), 0.0)
+
+    def test_non_dict_entries_ignored(self) -> None:
+        self.assertEqual(self._fn()(["garbage", 3, {"current": 4, "max": 8}]), 50.0)
+
+    def test_missing_or_non_numeric_keys_return_none(self) -> None:
+        self.assertIsNone(self._fn()([{"max": 8}]))
+        self.assertIsNone(self._fn()([{"current": "abc", "max": 8}]))
+
+    def test_scalar_passthrough(self) -> None:
+        self.assertEqual(self._fn()(55), 55.0)
+        self.assertEqual(self._fn()("55"), 55.0)
+
+    def test_non_numeric_scalar_returns_none(self) -> None:
+        self.assertIsNone(self._fn()("abc"))
+
+    def test_non_finite_scalar_returns_none(self) -> None:
+        self.assertIsNone(self._fn()(float("nan")))
+        self.assertIsNone(self._fn()(float("inf")))
+
+    def test_non_finite_max_is_unusable(self) -> None:
+        # inf/nan max must not act as a denominator (would inject a bogus 0.0).
+        self.assertIsNone(self._fn()([{"current": 4, "max": float("inf")}]))
+        self.assertIsNone(self._fn()([{"current": 4, "max": float("nan")}]))
+        # With a sibling that has a real max, the bad-max record borrows it (8).
+        raw = [{"current": 8, "max": 8}, {"current": 4, "max": float("inf")}]
+        self.assertEqual(self._fn()(raw), 75.0)  # mean(100.0, clamp(4/8)=50.0)
+
+
+class LoadingPercentageBuildTest(unittest.IsolatedAsyncioTestCase):
+    """End-to-end: the value_fn is wired through native_value for WM/WD/TD."""
+
+    async def _native_value(self, app_type: str, loading) -> object:
+        from custom_components.addhon import sensor
+        from custom_components.addhon.const import DOMAIN
+
+        uid = f"{app_type.lower()}-1"
+        data = {
+            uid: {
+                "type": app_type,
+                "name": app_type,
+                "attributes": {"loadingPercentage": loading},
+                "settings": {},
+            }
+        }
+        coordinator = FakeCoordinator(data)
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator}}})
+        added: list = []
+        await sensor.async_setup_entry(hass, FakeEntry(), added.extend)
+        entity = next(
+            e for e in added if e._attr_unique_id == f"{uid}_loading_percentage"
+        )
+        return entity.native_value
+
+    async def test_wm_list_does_not_crash_and_computes_pct(self) -> None:
+        value = await self._native_value(
+            "WM", [{"current": 6, "max": 8, "date": "2026-06-20"}]
+        )
+        self.assertEqual(value, 75.0)
+
+    async def test_wm_offline_shadow_payload_is_none(self) -> None:
+        value = await self._native_value("WM", [{"current": 1, "max": 0, "date": "x"}])
+        self.assertIsNone(value)
+
+    async def test_wd_uses_same_value_fn(self) -> None:
+        value = await self._native_value(
+            "WD", [{"current": 4, "max": 8, "date": "2026-06-20"}]
+        )
+        self.assertEqual(value, 50.0)
+
+    async def test_td_uses_same_value_fn(self) -> None:
+        value = await self._native_value("TD", [{"current": 8, "max": 8}])
+        self.assertEqual(value, 100.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -248,6 +248,20 @@ class Tier2TableTest(unittest.TestCase):
              "rinse_aid_level", "wash_temperature", "errors"],
         )
 
+    def test_oven_full_keys(self) -> None:
+        self.assertEqual(
+            _sensor_keys("OV"),
+            ["state", "program_name", "temp_cavity", "remaining_time",
+             "delay_time", "probe_temp_1", "probe_temp_2", "errors"],
+        )
+
+    def test_wine_full_keys(self) -> None:
+        self.assertEqual(
+            _sensor_keys("WC"),
+            ["temp_ambient", "temp_zone1", "temp_zone2", "humidity_zone1",
+             "humidity_zone2", "remaining_time"],
+        )
+
     def test_fr_and_fre_alias_cooling(self) -> None:
         self.assertEqual(_sensor_keys("REF"), _sensor_keys("FR"))
         self.assertEqual(_sensor_keys("REF"), _sensor_keys("FRE"))
@@ -471,6 +485,55 @@ class ConnectivityBinaryTest(unittest.IsolatedAsyncioTestCase):
         conn = await self._conn({"available": False})
         self.assertTrue(conn.available)
         self.assertFalse(conn.is_on)
+
+
+class GvigrouxImportTest(unittest.IsolatedAsyncioTestCase):
+    """Live-tested mapping items adopted from gvigroux/hon (real-device evidence)."""
+
+    async def test_oven_gains_program_delay_errors(self) -> None:
+        added = await _build_sensors("OV", {
+            "machMode": "2", "programName": "PIZZA", "delayTime": 30,
+            "errors": "00", "temp": 180, "remainingTimeMM": 20,
+        })
+        uids = {e._attr_unique_id for e in added}
+        self.assertIn("x-1_program_name", uids)
+        self.assertIn("x-1_delay_time", uids)
+        self.assertIn("x-1_errors", uids)
+
+    async def test_oven_preheat_binary(self) -> None:
+        added = await _build_binary("OV", {"preheatStatus": "1"})
+        preheat = next(e for e in added if e._attr_unique_id == "x-1_preheat")
+        self.assertTrue(preheat.is_on)
+
+    def test_oven_number_fallback_is_oven_range(self) -> None:
+        from custom_components.addhon.const import APPLIANCE_OV
+        from custom_components.addhon.number import NUMBERS
+
+        target = {d.key: d for d in NUMBERS[APPLIANCE_OV]}["target_temp"]
+        self.assertEqual(
+            (target.fallback_min, target.fallback_max, target.fallback_step),
+            (50.0, 280.0, 5.0),
+        )
+
+    async def test_dishwasher_reads_temp_not_temperature(self) -> None:
+        added = await _build_sensors("DW", {"temp": "45"})
+        wt = next(e for e in added if e._attr_unique_id == "x-1_wash_temperature")
+        self.assertEqual(wt.native_value, 45.0)
+        # The old `temperature` key no longer builds the sensor.
+        added2 = await _build_sensors("DW", {"temperature": "45"})
+        self.assertNotIn(
+            "x-1_wash_temperature", {e._attr_unique_id for e in added2}
+        )
+
+    async def test_wine_cooler_zone1_temp_and_humidity(self) -> None:
+        added = await _build_sensors("WC", {
+            "temp": 12, "tempZ2": 8, "humidityZ1": 60, "humidityZ2": 65,
+        })
+        uids = {e._attr_unique_id for e in added}
+        self.assertIn("x-1_temp_zone1", uids)
+        self.assertIn("x-1_temp_zone2", uids)
+        self.assertIn("x-1_humidity_zone1", uids)
+        self.assertIn("x-1_humidity_zone2", uids)
 
 
 if __name__ == "__main__":

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -327,10 +327,76 @@ class Tier2GatingTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_washer_stain_type_decodes(self) -> None:
         # WM stain_type ENUM: code -> machine key, 0 -> none, unknown -> None.
-        for raw, expected in (("1", "wine"), ("0", "none"), ("26", "fruit"), ("99", None)):
+        # 9/13/15 corrected to the app's stainOptions (were ice_cream/rust/perfume).
+        cases = (
+            ("1", "wine"), ("0", "none"), ("26", "fruit"), ("99", None),
+            ("9", "chocolate"), ("13", "chili_oil"), ("15", "color_pencil"),
+        )
+        for raw, expected in cases:
             added = await _build_sensors("WM", {"stainType": raw})
             st = next(e for e in added if e._attr_unique_id == "x-1_stain_type")
             self.assertEqual(st.native_value, expected)
+
+    async def test_washer_state_decodes(self) -> None:
+        # WM state ENUM uses the authoritative MachineMode: 2=running, 3=paused.
+        for raw, expected in (
+            ("0", "idle"), ("1", "selection"), ("2", "running"),
+            ("3", "paused"), ("7", "finished"), ("99", None),
+        ):
+            added = await _build_sensors("WM", {"machMode": raw})
+            st = next(e for e in added if e._attr_unique_id == "x-1_state")
+            self.assertEqual(st.native_value, expected)
+
+
+class ConstMapTest(unittest.TestCase):
+    def test_ac_fan_map_auto_is_5(self) -> None:
+        from custom_components.addhon.const import AC_FAN_MAP, AC_FAN_MAP_REVERSE
+
+        self.assertEqual(AC_FAN_MAP.get("5"), "auto")
+        self.assertNotIn("0", AC_FAN_MAP)  # the device rejects windSpeed 0
+        self.assertEqual(AC_FAN_MAP_REVERSE["auto"], "5")
+        self.assertEqual(AC_FAN_MAP_REVERSE["high"], "1")
+
+    def test_wm_state_map_authoritative_codes(self) -> None:
+        from custom_components.addhon.const import WM_STATE_MAP
+
+        # Authoritative MachineMode semantics (decomp): 1=selection, 2=running,
+        # 3=paused, 7=finished; "half_load" is a program option, never a state.
+        self.assertEqual(WM_STATE_MAP["1"], "selection")
+        self.assertEqual(WM_STATE_MAP["2"], "running")
+        self.assertEqual(WM_STATE_MAP["3"], "paused")
+        self.assertEqual(WM_STATE_MAP["7"], "finished")
+        self.assertNotIn("half_load", WM_STATE_MAP.values())
+
+    def test_stain_map_full_table(self) -> None:
+        from custom_components.addhon.const import STAIN_TYPE_MAP
+
+        # Locks the entire app stainOptions table (decomp.txt:977322-977422).
+        self.assertEqual(STAIN_TYPE_MAP, {
+            "0": "none", "1": "wine", "2": "grass", "3": "soil", "4": "blood",
+            "5": "milk", "6": "cooking_oil", "7": "tea", "8": "coffee",
+            "9": "chocolate", "10": "lip_gloss", "11": "curry", "12": "milk_tea",
+            "13": "chili_oil", "14": "blue_ink", "15": "color_pencil",
+            "16": "shoe_cream", "17": "oil_pastel", "18": "blueberry", "19": "sweat",
+            "20": "egg", "21": "ketchup", "22": "baby_food", "23": "soy_sauce",
+            "24": "bean_paste", "25": "chili_sauce", "26": "fruit",
+        })
+
+
+class PauseSwitchTest(unittest.IsolatedAsyncioTestCase):
+    def _switch(self, mach_mode: str):
+        sw = _mod("homeassistant.components.switch")
+        sw.SwitchEntity = getattr(sw, "SwitchEntity", type("SwitchEntity", (), {}))
+        from custom_components.addhon.switch import HonWashingMachinePauseSwitch
+
+        data = {"x-1": {"type": "WM", "name": "Dev",
+                        "attributes": {"machMode": mach_mode}, "settings": {}}}
+        return HonWashingMachinePauseSwitch(FakeCoordinator(data), "x-1", None)
+
+    def test_is_on_only_when_paused(self) -> None:
+        self.assertTrue(self._switch("3").is_on)   # 3 = PAUSE_MODE
+        self.assertFalse(self._switch("2").is_on)  # 2 = EXECUTION (running)
+        self.assertFalse(self._switch("0").is_on)
 
 
 class Tier2BinaryGatingTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -68,7 +68,13 @@ def _install_homeassistant_stubs() -> None:
         def async_write_ha_state(self) -> None:
             self.state_writes = getattr(self, "state_writes", 0) + 1
 
-    update_coordinator.CoordinatorEntity = getattr(update_coordinator, "CoordinatorEntity", CoordinatorEntity)
+    # Force-assign (not getattr-default): another test module may have already
+    # registered a CoordinatorEntity WITHOUT `available`, and ConnectivityBinaryTest
+    # relies on super().available resolving regardless of suite order. This stub is a
+    # superset of the minimal ones in test_program_select / test_number_setpoints /
+    # test_entity_translation_keys, so taking over the shared class is safe (mirrors
+    # test_entity_availability.py).
+    update_coordinator.CoordinatorEntity = CoordinatorEntity
     update_coordinator.DataUpdateCoordinator = getattr(update_coordinator, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
     update_coordinator.UpdateFailed = getattr(update_coordinator, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
 
@@ -98,7 +104,12 @@ def _install_homeassistant_stubs() -> None:
         WATER = "water"
         DURATION = "duration"
         PM25 = "pm25"
+        PM10 = "pm10"
         CO2 = "carbon_dioxide"
+        CO = "carbon_monoxide"
+        AQI = "aqi"
+        VOLATILE_ORGANIC_COMPOUNDS_PARTS = "volatile_organic_compounds_parts"
+        WEIGHT = "weight"
         BATTERY = "battery"
         POWER = "power"
         ENUM = "enum"
@@ -180,14 +191,19 @@ def _install_homeassistant_stubs() -> None:
 
     class UnitOfTime:
         MINUTES = "min"
+        SECONDS = "s"
 
     class UnitOfTemperature:
         CELSIUS = "°C"
+
+    class UnitOfMass:
+        GRAMS = "g"
 
     const.UnitOfEnergy = getattr(const, "UnitOfEnergy", UnitOfEnergy)
     const.UnitOfVolume = getattr(const, "UnitOfVolume", UnitOfVolume)
     const.UnitOfTime = getattr(const, "UnitOfTime", UnitOfTime)
     const.UnitOfTemperature = getattr(const, "UnitOfTemperature", UnitOfTemperature)
+    const.UnitOfMass = getattr(const, "UnitOfMass", UnitOfMass)
 
     ha.config_entries = config_entries
     ha.core = core
@@ -275,22 +291,23 @@ class Tier2TableTest(unittest.TestCase):
     def test_dishwasher_full_keys(self) -> None:
         self.assertEqual(
             _sensor_keys("DW"),
-            ["state", "program_name", "remaining_time", "salt_level",
-             "rinse_aid_level", "wash_temperature", "errors"],
+            ["state", "program_name", "remaining_time", "delay_time", "salt_level",
+             "rinse_aid_level", "water_hardness", "wash_temperature", "errors"],
         )
 
     def test_oven_full_keys(self) -> None:
         self.assertEqual(
             _sensor_keys("OV"),
             ["state", "program_name", "temp_cavity", "remaining_time",
-             "delay_time", "probe_temp_1", "probe_temp_2", "errors"],
+             "delay_time", "program_duration", "probe_temp_1", "probe_temp_2",
+             "errors"],
         )
 
     def test_wine_full_keys(self) -> None:
         self.assertEqual(
             _sensor_keys("WC"),
-            ["temp_ambient", "temp_zone1", "temp_zone2", "humidity_zone1",
-             "humidity_zone2", "remaining_time"],
+            ["state", "program_name", "temp_ambient", "temp_zone1", "temp_zone2",
+             "humidity_zone1", "humidity_zone2", "remaining_time", "errors"],
         )
 
     def test_fr_and_fre_alias_cooling(self) -> None:
@@ -308,12 +325,22 @@ class Tier2TableTest(unittest.TestCase):
             for d in SENSORS[app_type]:
                 self.assertTrue(d.gated, f"{app_type}/{d.key} must be gated")
 
-    def test_historic_types_not_gated(self) -> None:
+    def test_historic_core_not_gated_only_optionals_gated(self) -> None:
         from custom_components.addhon.sensor import SENSORS
 
-        for app_type in ("AC", "WM", "WD", "TD"):
-            for d in SENSORS[app_type]:
-                self.assertFalse(d.gated, f"{app_type}/{d.key} must NOT be gated")
+        # Historic types keep their CORE sensors always-created (gated=False); only
+        # the optional gvigroux-harvested add-ons (air-quality / auto-dose) are gated.
+        expected_gated = {
+            "AC": {"pm10", "voc", "co", "air_quality"},
+            "WM": {"current_wash_cycle", "remaining_rinses", "detergent_level",
+                   "detergent_weight", "softener_weight"},
+            "WD": {"current_wash_cycle", "remaining_rinses", "detergent_level",
+                   "detergent_weight", "softener_weight"},
+            "TD": set(),
+        }
+        for app_type, gated_keys in expected_gated.items():
+            actual = {d.key for d in SENSORS[app_type] if d.gated}
+            self.assertEqual(actual, gated_keys, f"{app_type} gated set mismatch")
 
     def test_hob_binary_has_six_pan_zones(self) -> None:
         self.assertEqual(
@@ -587,6 +614,119 @@ class GvigrouxImportTest(unittest.IsolatedAsyncioTestCase):
         # zone1 actual temp is `temp`, not `tempZ1` (which does not exist for WC).
         added = await _build_sensors("WC", {"tempZ1": 99})
         self.assertNotIn("x-1_temp_zone1", {e._attr_unique_id for e in added})
+
+    # --- gvigroux P1 harvest: air-quality / auto-dose / options (all gated) ---
+
+    async def test_ac_air_quality_appears_only_when_reported(self) -> None:
+        added = await _build_sensors("AC", {
+            "pm10ValueIndoor": "6", "vocValueIndoor": "1", "coLevel": "0",
+            "airQuality": "2",
+        })
+        by_uid = {e._attr_unique_id: e for e in added}
+        for k in ("pm10", "voc", "co", "air_quality"):
+            self.assertIn(f"x-1_{k}", by_uid)
+        self.assertEqual(by_uid["x-1_air_quality"].native_value, 2.0)
+        # absent when the device does not report them (gated)
+        uids2 = {e._attr_unique_id for e in await _build_sensors("AC", {})}
+        for k in ("pm10", "voc", "co", "air_quality"):
+            self.assertNotIn(f"x-1_{k}", uids2)
+
+    def test_ac_air_quality_device_classes(self) -> None:
+        # pm10 is a real mass concentration; voc/co/air_quality are level indexes
+        # surfaced as plain integers (no misleading device_class/unit).
+        from homeassistant.components.sensor import SensorDeviceClass
+
+        from custom_components.addhon.const import APPLIANCE_AC
+        from custom_components.addhon.sensor import SENSORS
+
+        ac = {d.key: d for d in SENSORS[APPLIANCE_AC]}
+        self.assertEqual(ac["pm10"].device_class, SensorDeviceClass.PM10)
+        self.assertEqual(ac["pm10"].native_unit_of_measurement, "µg/m³")
+        for k in ("voc", "co", "air_quality"):
+            self.assertIsNone(ac[k].device_class, f"{k} must be class-less")
+            self.assertIsNone(ac[k].native_unit_of_measurement, f"{k} must be unitless")
+
+    async def test_dishwasher_delay_hardness_and_option_binaries(self) -> None:
+        added = await _build_sensors("DW", {"delayTime": "30", "waterHard": "3"})
+        uids = {e._attr_unique_id for e in added}
+        self.assertIn("x-1_delay_time", uids)
+        hard = next(e for e in added if e._attr_unique_id == "x-1_water_hardness")
+        self.assertEqual(hard.native_value, 3.0)
+        bins = await _build_binary("DW", {
+            "extraDry": "1", "halfLoad": "0", "openDoor": "1", "ecoExpress": "0",
+        })
+        buids = {e._attr_unique_id for e in bins}
+        for k in ("extra_dry", "half_load", "auto_open_door", "eco_express"):
+            self.assertIn(f"x-1_{k}", buids)
+        extra = next(e for e in bins if e._attr_unique_id == "x-1_extra_dry")
+        self.assertTrue(extra.is_on)
+
+    async def test_washer_dose_sensors_and_option_binaries(self) -> None:
+        added = await _build_sensors("WM", {
+            "currentWashCycle": "2", "remainingRinseIterations": "1",
+            "detergentPercent": "80", "haier_DetergentWeight": "35",
+            "haier_SoftenerWeight": "20",
+        })
+        by_uid = {e._attr_unique_id: e for e in added}
+        for k in ("current_wash_cycle", "remaining_rinses", "detergent_level",
+                  "detergent_weight", "softener_weight"):
+            self.assertIn(f"x-1_{k}", by_uid)
+        self.assertEqual(by_uid["x-1_detergent_weight"].native_value, 35.0)
+        self.assertEqual(by_uid["x-1_softener_weight"].native_value, 20.0)
+        bins = {e._attr_unique_id: e for e in await _build_binary("WM", {
+            "nightWashStatus": "1", "steamStatus": "0", "energySavingStatus": "1",
+        })}
+        self.assertTrue(bins["x-1_night_wash"].is_on)
+        self.assertFalse(bins["x-1_steam"].is_on)
+        self.assertTrue(bins["x-1_energy_saving"].is_on)
+
+    async def test_wine_cooler_state_program_errors(self) -> None:
+        added = await _build_sensors("WC", {
+            "machMode": "2", "programName": "RED", "errors": "00",
+        })
+        by_uid = {e._attr_unique_id: e for e in added}
+        self.assertEqual(by_uid["x-1_state"].native_value, "running")  # MACHINE_MODE_MAP
+        self.assertEqual(by_uid["x-1_program_name"].native_value, "RED")
+        self.assertEqual(by_uid["x-1_errors"].native_value, "00")
+
+    async def test_wine_cooler_state_absent_when_unreported(self) -> None:
+        uids = {e._attr_unique_id for e in await _build_sensors("WC", {})}
+        for k in ("state", "program_name", "errors"):
+            self.assertNotIn(f"x-1_{k}", uids)
+
+    async def test_oven_program_duration(self) -> None:
+        added = await _build_sensors("OV", {"prTime": "2700"})
+        pd = next(e for e in added if e._attr_unique_id == "x-1_program_duration")
+        self.assertEqual(pd.native_value, 2700.0)
+
+    def test_oven_program_duration_is_seconds(self) -> None:
+        # prTime is seconds (range 1..86395), NOT minutes.
+        from homeassistant.components.sensor import SensorDeviceClass
+        from homeassistant.const import UnitOfTime
+
+        from custom_components.addhon.const import APPLIANCE_OV
+        from custom_components.addhon.sensor import SENSORS
+
+        pd = {d.key: d for d in SENSORS[APPLIANCE_OV]}["program_duration"]
+        self.assertEqual(pd.native_unit_of_measurement, UnitOfTime.SECONDS)
+        self.assertEqual(pd.device_class, SensorDeviceClass.DURATION)
+
+    async def test_dishwasher_options_absent_when_unreported(self) -> None:
+        uids = {e._attr_unique_id for e in await _build_sensors("DW", {})}
+        for k in ("delay_time", "water_hardness"):
+            self.assertNotIn(f"x-1_{k}", uids)
+        buids = {e._attr_unique_id for e in await _build_binary("DW", {})}
+        for k in ("extra_dry", "half_load", "auto_open_door", "eco_express"):
+            self.assertNotIn(f"x-1_{k}", buids)
+
+    async def test_washer_dose_absent_when_unreported(self) -> None:
+        uids = {e._attr_unique_id for e in await _build_sensors("WM", {})}
+        for k in ("current_wash_cycle", "remaining_rinses", "detergent_level",
+                  "detergent_weight", "softener_weight"):
+            self.assertNotIn(f"x-1_{k}", uids)
+        buids = {e._attr_unique_id for e in await _build_binary("WM", {})}
+        for k in ("night_wash", "steam", "energy_saving"):
+            self.assertNotIn(f"x-1_{k}", buids)
 
 
 if __name__ == "__main__":

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -134,10 +134,41 @@ def _install_homeassistant_stubs() -> None:
         OCCUPANCY = "occupancy"
         LIGHT = "light"
         CONNECTIVITY = "connectivity"
+        HEAT = "heat"
 
     binary_mod.BinarySensorEntityDescription = getattr(binary_mod, "BinarySensorEntityDescription", BinarySensorEntityDescription)
     binary_mod.BinarySensorEntity = getattr(binary_mod, "BinarySensorEntity", BinarySensorEntity)
     binary_mod.BinarySensorDeviceClass = getattr(binary_mod, "BinarySensorDeviceClass", BinarySensorDeviceClass)
+
+    # ── number platform stub (so importing custom_components.addhon.number works
+    #    standalone, not only when an earlier test module installed it) ─────────
+    number_mod = _mod("homeassistant.components.number")
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class NumberEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+        native_unit_of_measurement: str | None = None
+        mode: object | None = None
+
+    class NumberEntity:
+        pass
+
+    class NumberDeviceClass:
+        TEMPERATURE = "temperature"
+
+    class NumberMode:
+        BOX = "box"
+        AUTO = "auto"
+        SLIDER = "slider"
+
+    number_mod.NumberEntityDescription = getattr(number_mod, "NumberEntityDescription", NumberEntityDescription)
+    number_mod.NumberEntity = getattr(number_mod, "NumberEntity", NumberEntity)
+    number_mod.NumberDeviceClass = getattr(number_mod, "NumberDeviceClass", NumberDeviceClass)
+    number_mod.NumberMode = getattr(number_mod, "NumberMode", NumberMode)
 
     const = _mod("homeassistant.const")
 
@@ -515,25 +546,47 @@ class GvigrouxImportTest(unittest.IsolatedAsyncioTestCase):
             (50.0, 280.0, 5.0),
         )
 
-    async def test_dishwasher_reads_temp_not_temperature(self) -> None:
-        added = await _build_sensors("DW", {"temp": "45"})
-        wt = next(e for e in added if e._attr_unique_id == "x-1_wash_temperature")
-        self.assertEqual(wt.native_value, 45.0)
-        # The old `temperature` key no longer builds the sensor.
-        added2 = await _build_sensors("DW", {"temperature": "45"})
-        self.assertNotIn(
-            "x-1_wash_temperature", {e._attr_unique_id for e in added2}
-        )
+    async def test_dishwasher_wash_temp_reads_temp_or_temperature(self) -> None:
+        # Both key variants build the sensor and yield the value (gate/read both).
+        for attrs in ({"temp": "45"}, {"temperature": "45"}):
+            added = await _build_sensors("DW", attrs)
+            wt = next(e for e in added if e._attr_unique_id == "x-1_wash_temperature")
+            self.assertEqual(wt.native_value, 45.0)
+
+    def test_oven_delay_time_is_duration_minutes(self) -> None:
+        from homeassistant.components.sensor import SensorDeviceClass
+        from homeassistant.const import UnitOfTime
+
+        from custom_components.addhon.const import APPLIANCE_OV
+        from custom_components.addhon.sensor import SENSORS
+
+        d = {x.key: x for x in SENSORS[APPLIANCE_OV]}["delay_time"]
+        self.assertEqual(d.device_class, SensorDeviceClass.DURATION)
+        self.assertEqual(d.native_unit_of_measurement, UnitOfTime.MINUTES)
+
+    def test_oven_preheat_device_class_is_heat(self) -> None:
+        from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+        from custom_components.addhon.binary_sensor import BINARY_SENSORS
+        from custom_components.addhon.const import APPLIANCE_OV
+
+        d = {x.key: x for x in BINARY_SENSORS[APPLIANCE_OV]}["preheat"]
+        self.assertEqual(d.device_class, BinarySensorDeviceClass.HEAT)
 
     async def test_wine_cooler_zone1_temp_and_humidity(self) -> None:
         added = await _build_sensors("WC", {
             "temp": 12, "tempZ2": 8, "humidityZ1": 60, "humidityZ2": 65,
         })
-        uids = {e._attr_unique_id for e in added}
-        self.assertIn("x-1_temp_zone1", uids)
-        self.assertIn("x-1_temp_zone2", uids)
-        self.assertIn("x-1_humidity_zone1", uids)
-        self.assertIn("x-1_humidity_zone2", uids)
+        by_uid = {e._attr_unique_id: e for e in added}
+        self.assertEqual(by_uid["x-1_temp_zone1"].native_value, 12.0)  # reads `temp`
+        self.assertIn("x-1_temp_zone2", by_uid)
+        self.assertIn("x-1_humidity_zone1", by_uid)
+        self.assertIn("x-1_humidity_zone2", by_uid)
+
+    async def test_wine_cooler_zone1_ignores_tempz1(self) -> None:
+        # zone1 actual temp is `temp`, not `tempZ1` (which does not exist for WC).
+        added = await _build_sensors("WC", {"tempZ1": 99})
+        self.assertNotIn("x-1_temp_zone1", {e._attr_unique_id for e in added})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.0.5`.

<!-- release-tag: v5.0.5 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary sensors for washer night wash and steam modes.
  * Added binary sensors for oven preheat mode and dishwasher options (extra dry, half load, auto door open, eco express).
  * Added air-quality sensors for AC units.
  * Added dose and cycle telemetry sensors for washers.
  * Enhanced load percentage calculation with improved handling.

* **Bug Fixes**
  * Corrected AC fan "auto" mode mapping.
  * Updated washing machine state and stain type classifications.
  * Fixed washing machine pause mode detection.
  * Set proper oven temperature range (50–280°C).

* **Documentation**
  * Updated English and Italian translations for new sensors and modes.

* **Tests**
  * Expanded test coverage for new sensor types and entity mapping logic.

* **Chores**
  * Bumped version to 5.0.5.
  * Improved release policy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release corrects several data-mapping bugs (WM state codes, AC fan-speed auto value, stain type entries, pause switch detection) and expands sensor/binary-sensor coverage for washing machines, ovens, dishwashers, wine cellars, and AC units using live-device evidence from the gvigroux/hon dataset.

- **Bug fixes**: `WM_STATE_MAP` replaced with authoritative 0-10 MachineMode enum; AC fan auto mapped to `"5"` (not `"0"`, which devices reject); pause switch now checks `machMode == "3"` (PAUSE_MODE); `loading_percentage` removed from tumble dryers with a legacy-cleanup migration entry.
- **New sensors / binaries**: `_loading_pct` value_fn handles the list-format `loadingPercentage` payload; auto-dose sensors (WM/WD), air-quality sensors (AC), expanded oven/DW/WC sensor sets, and new option-flag binaries — all capability-gated so they self-suppress on unsupported models.
- **CI / security**: `release-intake.yml` now sources the release policy from `origin/main` rather than the checked-out tag to prevent a tampered policy from running in the write-credentialed job.

<h3>Confidence Score: 3/5</h3>

One defect will cause the translation-key test to fail: the new energy_saving binary sensor is absent from both en.json and it.json, so the entity displays without a name in the HA UI.

The energy_saving binary sensor key is collected by test_code_keys_match_translations_exactly (via _tk() which falls back to description.key) and compared against the JSON — the comparison fails because the key is not present in either translation file. Every other new binary sensor (night_wash, steam, preheat, extra_dry, half_load, auto_open_door, eco_express) is correctly translated; energy_saving was simply not added.

custom_components/addhon/binary_sensor.py (energy_saving sensor), custom_components/addhon/translations/en.json and it.json (missing energy_saving binary_sensor entry)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/binary_sensor.py | Adds new binary sensors (night_wash, steam, energy_saving for WM/WD; preheat for oven; 4 option flags for DW). All others are correctly registered with on_value="1" and translation keys present, but energy_saving is missing from both translation files. |
| custom_components/addhon/const.py | Corrects WM_STATE_MAP (0-10 authoritative MachineMode codes), AC_FAN_MAP (auto is "5" not "0"), and three STAIN_TYPE_MAP entries (9/13/15) to match app decompilation. |
| custom_components/addhon/sensor.py | Adds _loading_pct value_fn (handles list payload), attr_fallbacks support, new gated sensors (AC air quality, WM/WD auto-dose, oven/DW/WC expanded set), removes loading_percentage from TD; implementation is well-guarded and thoroughly tested. |
| custom_components/addhon/climate.py | Fixes set_fan_mode default fallback from "0" (rejected by device) to "5" (auto), aligning with the corrected AC_FAN_MAP. |
| custom_components/addhon/switch.py | Fixes pause detection to check machMode=="3" (PAUSE_MODE) instead of "2" (EXECUTION/running), consistent with the revised WM_STATE_MAP. |
| .github/workflows/release-intake.yml | Security hardening: release-policy.sh is now fetched from origin/main rather than the checked-out tag tree, preventing a tampered policy from governing the write-credentialed job. Bootstrap fallback to the tag's policy only when main lacks the file entirely. |
| custom_components/addhon/translations/en.json | Adds translations for all new sensor/binary sensor keys and updates WM state names — but energy_saving binary sensor key is absent. |
| custom_components/addhon/translations/it.json | Italian translations mirror en.json additions; energy_saving binary sensor key is also absent here. |
| tests/test_sensor_per_type.py | Extends per-type table tests for revised TD/WM/WD/AC/DW sensor sets, adds LoadingPercentageValueFn and LoadingPercentageBuild test classes with comprehensive edge-case coverage. |
| tests/test_tier2_sensors.py | Adds GvigrouxImportTest, ConstMapTest, and PauseSwitchTest covering all new gvigroux-sourced sensors/binaries, AC fan map correction, WM state map, stain table, and pause switch fix. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Device coordinator data] --> B{app_type}
    B -->|WM / WD| C[_WASH_BINARY\nnight_wash, steam, energy_saving\n+ _LOADING via value_fn _loading_pct]
    B -->|TD| D[_DRY_BINARY\nno loading_percentage]
    B -->|OV| E[_OVEN_BINARY\npreheat HEAT binary]
    B -->|DW| F[_DISHWASHER_BINARY\nextra_dry, half_load,\nauto_open_door, eco_express]
    B -->|AC| G[_AC sensors\npm10 + voc + co + air_quality gated]

    C --> H{attr present?}
    D --> H
    E --> H
    F --> H
    G --> H

    H -->|yes| I[Create entity]
    H -->|no| J[Skip — gated]

    I --> K{has translation_key?}
    K -->|yes| L[Look up translation_key in JSON]
    K -->|no| M[Fall back to description.key\ne.g. 'energy_saving' ⚠ missing]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Device coordinator data] --> B{app_type}
    B -->|WM / WD| C[_WASH_BINARY\nnight_wash, steam, energy_saving\n+ _LOADING via value_fn _loading_pct]
    B -->|TD| D[_DRY_BINARY\nno loading_percentage]
    B -->|OV| E[_OVEN_BINARY\npreheat HEAT binary]
    B -->|DW| F[_DISHWASHER_BINARY\nextra_dry, half_load,\nauto_open_door, eco_express]
    B -->|AC| G[_AC sensors\npm10 + voc + co + air_quality gated]

    C --> H{attr present?}
    D --> H
    E --> H
    F --> H
    G --> H

    H -->|yes| I[Create entity]
    H -->|no| J[Skip — gated]

    I --> K{has translation_key?}
    K -->|yes| L[Look up translation_key in JSON]
    K -->|no| M[Fall back to description.key\ne.g. 'energy_saving' ⚠ missing]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A113-115%0A**Missing%20translation%20key%20for%20%60energy_saving%60%20binary%20sensor**%0A%0A%60energy_saving%60%20is%20added%20to%20%60_WASH_BINARY%60%20without%20a%20corresponding%20entry%20in%20the%20%60entity.binary_sensor%60%20block%20of%20%60translations%2Fen.json%60%20or%20%60translations%2Fit.json%60.%20The%20%60test_entity_translation_keys.py%3A%3Atest_code_keys_match_translations_exactly%60%20test%20collects%20translation%20keys%20via%20%60_tk%28d%29%20%3D%20description.translation_key%20or%20description.key%60%2C%20so%20it%20resolves%20%60energy_saving%60%20from%20%60key%60%20and%20compares%20against%20the%20JSON%20%E2%80%94%20it%20will%20fail%20because%20the%20key%20is%20absent.%20Users%20would%20also%20see%20the%20entity%20with%20no%20translated%20name%20in%20the%20HA%20UI.%0A%0A&repo=tis24dev%2Faddhon&pr=26&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A113-115%0A**Missing%20translation%20key%20for%20%60energy_saving%60%20binary%20sensor**%0A%0A%60energy_saving%60%20is%20added%20to%20%60_WASH_BINARY%60%20without%20a%20corresponding%20entry%20in%20the%20%60entity.binary_sensor%60%20block%20of%20%60translations%2Fen.json%60%20or%20%60translations%2Fit.json%60.%20The%20%60test_entity_translation_keys.py%3A%3Atest_code_keys_match_translations_exactly%60%20test%20collects%20translation%20keys%20via%20%60_tk%28d%29%20%3D%20description.translation_key%20or%20description.key%60%2C%20so%20it%20resolves%20%60energy_saving%60%20from%20%60key%60%20and%20compares%20against%20the%20JSON%20%E2%80%94%20it%20will%20fail%20because%20the%20key%20is%20absent.%20Users%20would%20also%20see%20the%20entity%20with%20no%20translated%20name%20in%20the%20HA%20UI.%0A%0A&pr=26&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A113-115%0A**Missing%20translation%20key%20for%20%60energy_saving%60%20binary%20sensor**%0A%0A%60energy_saving%60%20is%20added%20to%20%60_WASH_BINARY%60%20without%20a%20corresponding%20entry%20in%20the%20%60entity.binary_sensor%60%20block%20of%20%60translations%2Fen.json%60%20or%20%60translations%2Fit.json%60.%20The%20%60test_entity_translation_keys.py%3A%3Atest_code_keys_match_translations_exactly%60%20test%20collects%20translation%20keys%20via%20%60_tk%28d%29%20%3D%20description.translation_key%20or%20description.key%60%2C%20so%20it%20resolves%20%60energy_saving%60%20from%20%60key%60%20and%20compares%20against%20the%20JSON%20%E2%80%94%20it%20will%20fail%20because%20the%20key%20is%20absent.%20Users%20would%20also%20see%20the%20entity%20with%20no%20translated%20name%20in%20the%20HA%20UI.%0A%0A&repo=tis24dev%2Faddhon&pr=26&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.0.5"](https://github.com/tis24dev/addhon/commit/b0f693d6cc230ee521efd78d637b5ac288ae7daf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38906087)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->