### PR TITLE
Release v5.0.6

### DIFF
--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -101,6 +101,19 @@ _CONNECTIVITY = HonBinarySensorEntityDescription(
     device_class=BinarySensorDeviceClass.CONNECTIVITY,
 )
 
+# Universal capability-gated binaries: candidates on ANY appliance type, created
+# only where the device reports the attribute (unlike _CONNECTIVITY, which is
+# always created so it can signal 'disconnected'). remoteCtrValid = whether remote
+# control is currently authorized; distinct from `available` (network reachability).
+_REMOTE_CONTROL = HonBinarySensorEntityDescription(
+    key="remote_control",
+    icon="mdi:remote",
+    attr_key="remoteCtrValid",            # "1" = remote control authorized
+    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+)
+_UNIVERSAL_GATED: tuple["HonBinarySensorEntityDescription", ...] = (_REMOTE_CONTROL,)
+
+
 def _g_running(key: str, attr: str) -> "HonBinarySensorEntityDescription":
     """Gated read-only RUNNING binary for an `option engaged` (0/1) flag."""
     return HonBinarySensorEntityDescription(
@@ -316,6 +329,12 @@ async def async_setup_entry(
                     "Binary debug: skip '%s' on '%s' id=%s (key '%s' absent)",
                     description.key, data.get("name"), appliance_id, description.attr_key,
                 )
+                continue
+            entities.append(HonBinarySensor(coordinator, appliance_id, description))
+            created.append(description.key)
+        # Universal capability-gated binaries (any type that reports the attr).
+        for description in _UNIVERSAL_GATED:
+            if description.attr_key not in attributes:
                 continue
             entities.append(HonBinarySensor(coordinator, appliance_id, description))
             created.append(description.key)

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1,4 +1,22 @@
-"""Diagnostics support for Haier hOn (Extended)."""
+"""Diagnostics support for Haier hOn (Extended).
+
+This dump is what a user attaches to a GitHub issue when an appliance is "not
+mapped" or "mapped badly". Home Assistant renders the built-in "Download
+diagnostics" button for the config entry AND for each device (the latter is wired
+by async_get_device_diagnostics below); no custom button is needed.
+
+Per appliance the dump carries, beyond the bare key list it used to emit:
+  * `attributes`  - the attribute VALUES (telemetry/state), recursively redacted;
+  * `commands`    - the writable schema per command param: value + enum + min/max/
+                    step + typology, so a maintainer sees the real ranges/options;
+  * `coverage`    - the signal: which bare attribute keys and which writable command
+                    params the device exposes with NO addhon entity. That is what
+                    tells the maintainer what to add.
+
+Identity (id/serial/mac and credential-ish keys) is redacted. The device nickname
+(`name`) is kept readable on purpose, to correlate the dump with the physical
+appliance.
+"""
 from __future__ import annotations
 
 import logging
@@ -7,9 +25,70 @@ from collections.abc import Mapping
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import (
+    APPLIANCE_AC,
+    APPLIANCE_WASH_GROUP,
+    DOMAIN,
+    PROGRAM_PARAM_NAMES,
+)
+from .hon_commands import SETTINGS_COMMANDS, param_range, param_values
 
 _LOGGER = logging.getLogger(__name__)
+
+_REDACTED = "***"
+
+# Keys whose VALUE is identity/credential material and must never leave the user's
+# machine in cleartext. Matched case-insensitively by EXACT key name (not substring,
+# which would risk nuking legitimately-named telemetry). `code` is the serial
+# fallback in client/engine/appliance.py, hence redacted despite the innocuous name.
+# `id`/`name`/`model`/`type` are deliberately absent: they are needed for mapping,
+# and the nickname is kept readable by product decision.
+_TO_REDACT = frozenset(
+    {
+        "serial",
+        "serialnumber",
+        "serial_number",
+        "mac",
+        "macaddress",
+        "mac_address",
+        "code",
+        "nickname",
+        "nick_name",
+        "email",
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "authorization",
+        "secret",
+        # commandHistory carries identity in VALUES: transactionId is "<MAC>_<ts>"
+        # (leaks the full MAC despite mac/macAddress being redacted), mobileId is the
+        # phone-install id of whoever issued the last command (often a third party).
+        "transactionid",
+        "mobileid",
+        "mobile_id",
+    }
+)
+
+# Bare attributes consumed by CUSTOM entity classes that have NO description table,
+# so a coverage calc based only on the description registries would wrongly report
+# them as unmapped. Kept small and documented; a unit test guards against drift.
+#   HonMeanWaterConsumption (sensor.py): totalWashCycle + totalWaterUsed
+#   HonWashingMachinePauseSwitch (switch.py): machMode
+#   HaierClimateEntity (climate.py): tempIndoor (current temp; its other reads are
+#       dotted settings.* keys, already excluded from the attribute axis)
+_CUSTOM_MAPPED_ATTRS: dict[str, frozenset[str]] = {
+    "WM": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+    "WD": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+    "TD": frozenset({"machMode"}),
+    "AC": frozenset({"tempIndoor"}),
+}
+
+# Settings-command params written by HaierClimateEntity (climate.py has no
+# description table). AC only.
+_AC_CLIMATE_PARAMS = frozenset(
+    {"onOffStatus", "machMode", "tempSel", "windSpeed", "windDirectionVertical"}
+)
 
 
 def _redact_title(title: str | None) -> str | None:
@@ -29,16 +108,223 @@ def _redact_email(email: str | None) -> str | None:
     if "@" in email:
         _, domain = email.split("@", 1)
         return f"***@{domain}"
-    return "***"
+    return _REDACTED
+
+
+def _jsonable(value):
+    """Coerce a leaf value to a JSON-native primitive.
+
+    The merged attributes dict carries wrapper objects (HonAttribute from the device
+    shadow, HonParameter from ``appliance.settings``), not primitives; HA's JSON
+    encoder raises ``TypeError`` on them. Unwrap a ``.value`` if present (one level),
+    else stringify, so the dump never carries an unserializable object.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "value"):
+        inner = value.value
+        if inner is None or isinstance(inner, (str, int, float, bool)):
+            return inner
+        return str(inner)
+    return str(value)
+
+
+def _redact(value):
+    """Recursively replace the value of any identity/credential key with ``***``.
+
+    Redaction is keyed on the dict KEY name (exact, case-insensitive); leaf telemetry
+    values, enum lists and numeric ranges pass through (coerced to JSON primitives).
+    """
+    if isinstance(value, Mapping):
+        return {
+            key: (
+                _REDACTED
+                if isinstance(key, str) and key.lower() in _TO_REDACT
+                else _redact(val)
+            )
+            for key, val in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact(item) for item in value]
+    return _jsonable(value)
+
+
+def _param_value(param):
+    """Scalar current value of a parameter, coerced to a JSON-safe primitive."""
+    return _jsonable(getattr(param, "value", None))
+
+
+def _param_schema(param) -> dict:
+    """Full schema of one command parameter: value + enum + range + metadata."""
+    schema: dict = {
+        "value": _param_value(param),
+        "typology": getattr(param, "typology", None),
+        "category": getattr(param, "category", None),
+        "mandatory": getattr(param, "mandatory", None),
+    }
+    enum = param_values(param)
+    if enum:
+        schema["enum"] = enum
+    rng = param_range(param)
+    if rng is not None:
+        schema["min"], schema["max"], schema["step"] = rng
+    return schema
+
+
+def _command_schema(appliance) -> dict:
+    """Per-command, per-parameter schema for every command the appliance exposes."""
+    commands = getattr(appliance, "commands", None)
+    if not isinstance(commands, Mapping):
+        return {}
+    out: dict = {}
+    for cmd_name, cmd in commands.items():
+        params = getattr(cmd, "parameters", None)
+        if isinstance(params, Mapping):
+            out[str(cmd_name)] = {
+                str(p_name): _param_schema(p) for p_name, p in params.items()
+            }
+        else:
+            out[str(cmd_name)] = {}
+    return out
+
+
+def _mapped_sets(app_type) -> tuple[set[str], set[str]]:
+    """(mapped attribute keys, mapped writable command params) for a type.
+
+    Registries are imported lazily so diagnostics.py keeps a tiny top-level import
+    surface and cannot be caught in an import cycle; on any import hiccup it degrades
+    to the documented custom set rather than crashing the dump.
+    """
+    mapped_attrs: set[str] = set(_CUSTOM_MAPPED_ATTRS.get(app_type, ()))
+    mapped_params: set[str] = set()
+    try:
+        from .binary_sensor import BINARY_SENSORS, _CONNECTIVITY, _UNIVERSAL_GATED
+        from .number import NUMBERS
+        from .sensor import SENSORS
+        from .switch import _AC_SWITCHES
+    except Exception:  # pragma: no cover - diagnostics must never crash
+        _LOGGER.debug(
+            "Diagnostics debug: coverage registries unavailable", exc_info=True
+        )
+        return mapped_attrs, mapped_params
+
+    for desc in SENSORS.get(app_type, ()):
+        mapped_attrs.add(desc.attr_key)
+        mapped_attrs.update(getattr(desc, "attr_fallbacks", ()) or ())
+    for desc in BINARY_SENSORS.get(app_type, ()):
+        mapped_attrs.add(desc.attr_key)
+    mapped_attrs.add(_CONNECTIVITY.attr_key)
+    for desc in _UNIVERSAL_GATED:
+        mapped_attrs.add(desc.attr_key)
+
+    for desc in NUMBERS.get(app_type, ()):
+        mapped_params.add(desc.param)
+    if app_type == APPLIANCE_AC:
+        for desc in _AC_SWITCHES:
+            mapped_params.add(desc.param)
+        mapped_params |= _AC_CLIMATE_PARAMS
+    if app_type in APPLIANCE_WASH_GROUP:
+        mapped_params.update(PROGRAM_PARAM_NAMES)
+    return mapped_attrs, mapped_params
+
+
+def _settings_param_names(appliance) -> set[str]:
+    """Names of every parameter under a settings/setParameters command (writables)."""
+    commands = getattr(appliance, "commands", None)
+    if not isinstance(commands, Mapping):
+        return set()
+    names: set[str] = set()
+    for cmd_name in SETTINGS_COMMANDS:
+        cmd = commands.get(cmd_name)
+        params = getattr(cmd, "parameters", None) if cmd is not None else None
+        if isinstance(params, Mapping):
+            names.update(str(k) for k in params)
+    return names
+
+
+def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> dict:
+    """What the device exposes with no addhon entity (the gold signal).
+
+    Attribute axis: only BARE keys (no dot) are considered; dotted ``settings.*``
+    keys mirror command parameters and belong to the command-param axis instead.
+    Unmapped attribute keys that come from the statistics container are split out so
+    real unmapped telemetry stays legible.
+    """
+    mapped_attrs, mapped_params = _mapped_sets(app_type)
+    settings_params = _settings_param_names(appliance)
+
+    # The device shadow exposes writable params ALSO as bare attribute keys (e.g. a
+    # fridge reports `tempSelZ1` both bare and as `settings.tempSelZ1`). Those belong
+    # to the command-param axis, not the attribute axis, so subtract every writable
+    # settings-param name as well - otherwise controlled setpoints (number/climate/AC
+    # switch) would be falsely listed as unmapped read-only attributes.
+    bare = {k for k in attributes if isinstance(k, str) and "." not in k}
+    # Read-only telemetry is the attribute axis: writable param mirrors live on the
+    # command-param axis, so exclude them from BOTH the unmapped list and the total
+    # (otherwise `total` overstates this axis' denominator).
+    read_only_bare = bare - settings_params
+    unmapped_attrs = sorted(read_only_bare - mapped_attrs)
+    stats_keys = set(statistics) if isinstance(statistics, Mapping) else set()
+
+    return {
+        "attributes_total": len(read_only_bare),
+        "attributes_unmapped": unmapped_attrs,
+        "attributes_unmapped_statistics": sorted(
+            k for k in unmapped_attrs if k in stats_keys
+        ),
+        "command_params_total": len(settings_params),
+        "command_params_unmapped": sorted(settings_params - mapped_params),
+    }
+
+
+def _appliance_block(appliance_id: str, data: Mapping) -> dict:
+    """Build the (redacted) diagnostics block for a single appliance."""
+    appliance = data.get("appliance")
+    app_type = data.get("type")
+    attributes = data.get("attributes")
+    attributes = attributes if isinstance(attributes, Mapping) else {}
+    statistics = data.get("statistics")
+    statistics = statistics if isinstance(statistics, Mapping) else {}
+
+    commands = _command_schema(appliance)
+    coverage = _coverage(app_type, attributes, statistics, appliance)
+
+    _LOGGER.debug(
+        "Diagnostics debug: appliance id=%s name=%s type=%s attrs=%d commands=%d "
+        "unmapped_attrs=%d unmapped_params=%d",
+        appliance_id,
+        data.get("name"),
+        app_type,
+        len(attributes),
+        len(commands),
+        len(coverage["attributes_unmapped"]),
+        len(coverage["command_params_unmapped"]),
+    )
+
+    block = {
+        "id": _REDACTED,
+        "name": data.get("name"),  # kept readable on purpose (correlation aid)
+        "type": app_type,
+        "model": data.get("model"),
+        "serial": _REDACTED,
+        "mac": _REDACTED,
+        "attributes": dict(attributes),
+        "commands": commands,
+        "coverage": coverage,
+    }
+    return _redact(block)
+
+
+def _coordinator(hass: HomeAssistant, entry: ConfigEntry):
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    return entry_data.get("coordinator")
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
-    """Return diagnostics for a config entry."""
-    domain_data = hass.data.get(DOMAIN, {})
-    entry_data = domain_data.get(entry.entry_id, {})
-    coordinator = entry_data.get("coordinator")
+    """Return diagnostics for a config entry (all appliances)."""
+    coordinator = _coordinator(hass, entry)
     _LOGGER.debug(
         "Diagnostics debug: diagnostics requested entry=%s title=%s coordinator_present=%s",
         entry.entry_id,
@@ -48,57 +334,47 @@ async def async_get_config_entry_diagnostics(
 
     appliances: list[dict] = []
     coord_data = getattr(coordinator, "data", None)
-    if isinstance(coord_data, dict):
+    if isinstance(coord_data, Mapping):
         for appliance_id, data in coord_data.items():
-            appliance = data.get("appliance")
-            commands_info: dict[str, list[str]] = {}
-
-            commands = getattr(appliance, "commands", None)
-            if isinstance(commands, Mapping):
-                for cmd_name, cmd in commands.items():
-                    params = getattr(cmd, "parameters", None)
-                    if isinstance(params, Mapping):
-                        commands_info[cmd_name] = sorted([str(k) for k in params.keys()])
-                    else:
-                        commands_info[cmd_name] = []
-
-            attributes = data.get("attributes") if isinstance(data, dict) else None
-            settings = data.get("settings") if isinstance(data, dict) else None
-            _LOGGER.debug(
-                "Diagnostics debug: appliance id=%s name=%s type=%s attributes=%d settings=%d commands=%s",
-                appliance_id,
-                data.get("name"),
-                data.get("type"),
-                len(attributes) if isinstance(attributes, dict) else 0,
-                len(settings) if isinstance(settings, dict) else 0,
-                commands_info,
-            )
-
-            appliances.append(
-                {
-                    "id": "***",
-                    "name": data.get("name"),
-                    "type": data.get("type"),
-                    "model": data.get("model"),
-                    "serial": "***",
-                    "attribute_keys": sorted(list(attributes.keys()))
-                    if isinstance(attributes, dict)
-                    else [],
-                    "settings_keys": sorted(list(settings.keys()))
-                    if isinstance(settings, dict)
-                    else [],
-                    "commands": commands_info,
-                }
-            )
+            if isinstance(data, Mapping):
+                appliances.append(_appliance_block(appliance_id, data))
 
     return {
         "entry": {
             "title": _redact_title(entry.title),
             "data": {
                 "email": _redact_email(entry.data.get("email")),
-                "password": "***",
+                "password": _REDACTED,
             },
             "options": dict(entry.options),
         },
         "appliances": appliances,
     }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device
+) -> dict:
+    """Return diagnostics for a single device (the appliance behind it).
+
+    ``device.identifiers`` is a set of ``(domain, id)`` tuples; base_entity.device_info
+    registers ``{(DOMAIN, appliance_id)}``, so the appliance_id is recovered directly.
+    The raw identifier (which may BE the serial) is never echoed into the output.
+    """
+    coordinator = _coordinator(hass, entry)
+    coord_data = getattr(coordinator, "data", None)
+
+    appliance_id = next(
+        (
+            ident[1]
+            for ident in getattr(device, "identifiers", ()) or ()
+            if isinstance(ident, tuple) and len(ident) == 2 and ident[0] == DOMAIN
+        ),
+        None,
+    )
+    if appliance_id is None or not isinstance(coord_data, Mapping):
+        return {}
+    data = coord_data.get(appliance_id)
+    if not isinstance(data, Mapping):
+        return {}
+    return {"appliance": _appliance_block(appliance_id, data)}

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.0.5"
+  "version": "5.0.6"
 }

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -394,15 +394,29 @@ _WASH_DOSE: tuple[HonSensorEntityDescription, ...] = (
     _g_grams("detergent_weight", "haier_DetergentWeight"),
     _g_grams("softener_weight", "haier_SoftenerWeight"),
 )
+# Drum-load estimate (kg) the machine derives before/after a cycle. gvigroux-live
+# on WM/WD; gated (not every model auto-weighs). `weight` is the cross-model
+# fallback attribute name (gvigroux sensor.py:181 reads `weight` when `actualWeight`
+# is absent).
+_ESTIMATED_WEIGHT = HonSensorEntityDescription(
+    key="estimated_weight",
+    icon="mdi:weight-kilogram",
+    attr_key="actualWeight",
+    attr_fallbacks=("weight",),
+    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+    device_class=SensorDeviceClass.WEIGHT,
+    state_class=SensorStateClass.MEASUREMENT,
+    gated=True,
+)
 # Washer (WM): state/time + program + wash extras + load/delay + consumption + dose.
 _WASHER: tuple[HonSensorEntityDescription, ...] = (
     _STATE, _REMAINING, _PROGRAM_NAME, _PHASE_WASH, *_WASH_EXTRA, _LOADING, _DELAY,
-    _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE,
+    _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE, _ESTIMATED_WEIGHT,
 )
 # Washer-dryer (WD = WM + drying): like the washer + dry level.
 _WASHER_DRYER: tuple[HonSensorEntityDescription, ...] = (
     _STATE, _REMAINING, _PROGRAM_NAME, _PHASE_WASH, *_WASH_EXTRA, _DRY_LEVEL, _LOADING,
-    _DELAY, _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE,
+    _DELAY, _ERRORS, *_WASH_CONSUMPTION, *_WASH_DOSE, _ESTIMATED_WEIGHT,
 )
 
 # Tumble dryer: no water/energy (hOn does not expose them for the TD). The cycles
@@ -827,6 +841,16 @@ async def async_setup_entry(
                 continue
             entities.append(HonSensor(coordinator, appliance_id, description))
             created.append(description.key)
+        # Derived sensors combine MULTIPLE attributes, so they cannot be a
+        # description-table row (those read a single attr_key). Mean water per
+        # cycle: WM/WD only (the dryer has no water), gated on both source attrs.
+        if (
+            app_type in (APPLIANCE_WM, APPLIANCE_WD)
+            and "totalWaterUsed" in attributes
+            and "totalWashCycle" in attributes
+        ):
+            entities.append(HonMeanWaterConsumption(coordinator, appliance_id))
+            created.append("mean_water_consumption")
         _LOGGER.debug(
             "Sensor debug: '%s' (type=%s, id=%s) -> %d/%d sensors %s",
             data.get("name", "Haier"),
@@ -871,3 +895,45 @@ class HonSensor(HonBaseEntity, SensorEntity):
             return float(raw)
         except (ValueError, TypeError):
             return None
+
+
+class HonMeanWaterConsumption(HonBaseEntity, SensorEntity):
+    """Average water used per wash cycle = totalWaterUsed / (totalWashCycle - 1).
+
+    DERIVED from two attributes, so it cannot be a description-table row (those
+    read a single attr_key). Washer / washer-dryer only (the tumble dryer has no
+    water). Created only when the device reports BOTH source attributes
+    (capability-gated, like every other harvested item). The `-1` matches the
+    app's cycle counter, which starts at 1; the `<= 0 -> None` guard yields
+    "unknown" on a device with no completed cycle yet instead of dividing by zero.
+    Mirrors gvigroux sensor.py:534-548.
+
+    NOTE: the divisor is `totalWashCycle - 1` (completed cycles), while our
+    `total_washes` sensor renders the RAW `totalWashCycle`, so this mean is NOT
+    exactly `total_water / total_washes`. The `-1` is intentional: gvigroux (the
+    only party with real washer hardware) uses it, and it makes the guard above
+    suppress the sensor on a factory-fresh machine (counter == 1) instead of
+    dividing lifetime water by a bogus 1.
+    """
+
+    _attr_translation_key = "mean_water_consumption"
+    _attr_icon = "mdi:water-sync"
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, appliance_id: str) -> None:
+        super().__init__(coordinator, appliance_id)
+        self._attr_unique_id = f"{appliance_id}_mean_water_consumption"
+
+    @property
+    def native_value(self):
+        try:
+            cycles = float(self._get_attr(WM_ATTR_TOTAL_WASH))
+            water = float(self._get_attr(WM_ATTR_TOTAL_WATER))
+        except (ValueError, TypeError):
+            return None
+        denom = cycles - 1
+        if denom <= 0:
+            return None
+        return round(water / denom, 2)

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -229,6 +229,12 @@
       "softener_weight": {
         "name": "Softener dispensed"
       },
+      "estimated_weight": {
+        "name": "Estimated weight"
+      },
+      "mean_water_consumption": {
+        "name": "Mean water consumption"
+      },
       "program_duration": {
         "name": "Program duration"
       },
@@ -407,6 +413,9 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "remote_control": {
+        "name": "Remote control"
       },
       "preheat": {
         "name": "Preheating"

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -229,6 +229,12 @@
       "softener_weight": {
         "name": "Ammorbidente erogato"
       },
+      "estimated_weight": {
+        "name": "Peso stimato"
+      },
+      "mean_water_consumption": {
+        "name": "Consumo idrico medio"
+      },
       "program_duration": {
         "name": "Durata programma"
       },
@@ -407,6 +413,9 @@
       },
       "connectivity": {
         "name": "Connettività"
+      },
+      "remote_control": {
+        "name": "Controllo remoto"
       },
       "preheat": {
         "name": "Preriscaldamento"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,501 @@
+"""Tests for the enriched diagnostics dump.
+
+The dump is what a user sends when an appliance is not mapped or mapped badly, so
+the contract under test is: VALUES/ranges/enums are present, identity is redacted
+(recursively) while telemetry and the readable nickname survive, and the `coverage`
+block surfaces exactly the bare attributes / writable params the device exposes with
+no addhon entity. Also covers the per-device hook resolving its appliance by
+identifier.
+
+Stdlib unittest with inline Home Assistant stubs (so the lazily-imported per-type
+registries can be imported for the coverage axis). No real Home Assistant install.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ha = _mod("homeassistant")
+
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+
+    exc = _mod("homeassistant.exceptions")
+    base_err = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base_err
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {}))
+
+    helpers = _mod("homeassistant.helpers")
+    entity = _mod("homeassistant.helpers.entity")
+    entity.DeviceInfo = getattr(entity, "DeviceInfo", dict)
+    ep = _mod("homeassistant.helpers.entity_platform")
+    ep.AddEntitiesCallback = getattr(ep, "AddEntitiesCallback", object)
+    er = _mod("homeassistant.helpers.entity_registry")
+    er.async_get = getattr(er, "async_get", lambda hass: None)
+    er.async_entries_for_config_entry = getattr(
+        er, "async_entries_for_config_entry", lambda registry, entry_id: []
+    )
+    uc = _mod("homeassistant.helpers.update_coordinator")
+
+    class CoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+
+    uc.CoordinatorEntity = getattr(uc, "CoordinatorEntity", CoordinatorEntity)
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+
+    const = _mod("homeassistant.const")
+    for unit_cls in ("UnitOfTemperature", "UnitOfEnergy", "UnitOfTime", "UnitOfVolume", "UnitOfMass"):
+        if not hasattr(const, unit_cls):
+            setattr(const, unit_cls, type(unit_cls, (), {
+                "CELSIUS": "C", "KILO_WATT_HOUR": "kWh", "MINUTES": "min", "LITERS": "L",
+                "GRAMS": "g", "KILOGRAMS": "kg", "SECONDS": "s",
+            }))
+
+    components = _mod("homeassistant.components")
+
+    sensor_mod = _mod("homeassistant.components.sensor")
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class SensorEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        native_unit_of_measurement: str | None = None
+        device_class: object | None = None
+        state_class: object | None = None
+        options: object | None = None
+
+    sensor_mod.SensorEntityDescription = getattr(sensor_mod, "SensorEntityDescription", SensorEntityDescription)
+    sensor_mod.SensorEntity = getattr(sensor_mod, "SensorEntity", type("SensorEntity", (), {}))
+    sensor_mod.SensorDeviceClass = getattr(sensor_mod, "SensorDeviceClass", type("SensorDeviceClass", (), {
+        "TEMPERATURE": "temperature", "HUMIDITY": "humidity", "ENERGY": "energy",
+        "WATER": "water", "DURATION": "duration", "PM25": "pm25", "CO2": "co2",
+        "PM10": "pm10", "CO": "carbon_monoxide", "AQI": "aqi",
+        "VOLATILE_ORGANIC_COMPOUNDS_PARTS": "volatile_organic_compounds_parts",
+        "WEIGHT": "weight", "BATTERY": "battery", "POWER": "power", "ENUM": "enum",
+    }))
+    sensor_mod.SensorStateClass = getattr(sensor_mod, "SensorStateClass", type("SensorStateClass", (), {
+        "MEASUREMENT": "measurement", "TOTAL": "total", "TOTAL_INCREASING": "total_increasing",
+    }))
+
+    binary_mod = _mod("homeassistant.components.binary_sensor")
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class BinarySensorEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+
+    binary_mod.BinarySensorEntityDescription = getattr(binary_mod, "BinarySensorEntityDescription", BinarySensorEntityDescription)
+    binary_mod.BinarySensorEntity = getattr(binary_mod, "BinarySensorEntity", type("BinarySensorEntity", (), {}))
+    binary_mod.BinarySensorDeviceClass = getattr(binary_mod, "BinarySensorDeviceClass", type("BinarySensorDeviceClass", (), {
+        "DOOR": "door", "PROBLEM": "problem", "RUNNING": "running",
+        "OCCUPANCY": "occupancy", "LIGHT": "light", "CONNECTIVITY": "connectivity",
+        "HEAT": "heat",
+    }))
+
+    number_mod = _mod("homeassistant.components.number")
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class NumberEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+        native_unit_of_measurement: str | None = None
+        mode: object | None = None
+
+    number_mod.NumberEntityDescription = getattr(number_mod, "NumberEntityDescription", NumberEntityDescription)
+    number_mod.NumberEntity = getattr(number_mod, "NumberEntity", type("NumberEntity", (), {}))
+    number_mod.NumberDeviceClass = getattr(number_mod, "NumberDeviceClass", type("NumberDeviceClass", (), {"TEMPERATURE": "temperature"}))
+    number_mod.NumberMode = getattr(number_mod, "NumberMode", type("NumberMode", (), {"AUTO": "auto", "BOX": "box", "SLIDER": "slider"}))
+
+    _mod("homeassistant.components.switch").SwitchEntity = type("SwitchEntity", (), {})
+    _mod("homeassistant.components.select").SelectEntity = type("SelectEntity", (), {})
+    _mod("homeassistant.components.button").ButtonEntity = type("ButtonEntity", (), {})
+
+    ha.config_entries = ce
+    ha.core = core
+    ha.exceptions = exc
+    ha.helpers = helpers
+    ha.const = const
+    ha.components = components
+    helpers.entity = entity
+    helpers.entity_platform = ep
+    helpers.entity_registry = er
+    helpers.update_coordinator = uc
+    components.sensor = sensor_mod
+    components.binary_sensor = binary_mod
+    components.number = number_mod
+
+
+_install_stubs()
+
+from custom_components.addhon import diagnostics  # noqa: E402
+from custom_components.addhon.const import DOMAIN  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class FakeWrapper:
+    """Mimics a HonAttribute/HonParameter: a non-primitive object with a `.value`."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class Opaque:
+    """A non-primitive value with NO `.value` (must be stringified, not crash JSON)."""
+
+    def __str__(self):
+        return "opaque-str"
+
+
+class FakeParam:
+    def __init__(self, value=None, values=None, typology=None, category=None, mandatory=None, rng=None):
+        self.value = value
+        if values is not None:
+            self.values = values
+        self.typology = typology
+        self.category = category
+        self.mandatory = mandatory
+        if rng is not None:
+            self.min, self.max, self.step = rng
+
+
+class FakeCommand:
+    def __init__(self, parameters):
+        self.parameters = parameters
+
+
+class FakeAppliance:
+    def __init__(self, commands):
+        self.commands = commands
+
+
+class FakeCoordinator:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeEntry:
+    def __init__(self, entry_id="e1"):
+        self.entry_id = entry_id
+        self.title = "(account) user@example.com"
+        self.data = {"email": "user@example.com", "password": "hunter2"}
+        self.options = {}
+
+
+class FakeDevice:
+    def __init__(self, identifiers):
+        self.identifiers = identifiers
+
+
+class FakeHass:
+    def __init__(self, coordinator, entry_id="e1"):
+        self.data = {DOMAIN: {entry_id: {"coordinator": coordinator}}}
+
+
+AC_ID = "ac-unique"
+WD_ID = "wd-unique"
+
+
+def _build_coordinator() -> FakeCoordinator:
+    ac = FakeAppliance(
+        commands={
+            "settings": FakeCommand({
+                # climate-written -> mapped
+                "tempSel": FakeParam(value="22", typology="range", rng=(16, 30, 1)),
+                "machMode": FakeParam(value="1", typology="enum", values=["0", "1", "2"]),
+                # AC switch param -> mapped
+                "lightStatus": FakeParam(value="0", typology="enum", values=["0", "1"]),
+                # no entity writes this -> unmapped writable
+                "mysteryParam": FakeParam(value="3", typology="enum", values=["3", "4"]),
+            }),
+        }
+    )
+    wd = FakeAppliance(
+        commands={
+            "settings": FakeCommand({
+                "program": FakeParam(value="9", typology="enum", values=["9", "10"]),  # mapped
+                "spinSpeed": FakeParam(value="1000", typology="range", rng=(0, 1400, 100)),  # unmapped
+            }),
+        }
+    )
+    return FakeCoordinator({
+        AC_ID: {
+            "appliance": ac,
+            "type": "AC",
+            "name": "Salotto AC",
+            "model": "AS35",
+            "serial": "PLAINTEXT-SERIAL",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "attributes": {
+                "tempIndoor": 22.5,           # mapped (sensor + custom)
+                "available": True,            # mapped (connectivity)
+                "settings.machMode": "1",     # dotted -> excluded from attr axis
+                "weirdAcSensor": 9,           # UNMAPPED bare telemetry
+                "macAddress": "AA:BB:CC:DD:EE:FF",  # identity nested in attributes
+                # writable params also surface BARE in the device shadow; they must
+                # NOT be reported as unmapped read-only attributes (fix: subtract
+                # settings params from the attribute axis).
+                "tempSel": "22",
+                "machMode": "1",
+                # wrapper objects (HonAttribute/HonParameter) must be JSON-coerced.
+                "liveParam": FakeWrapper(7),
+                "opaqueObj": Opaque(),
+                # commandHistory carries identity inside VALUES (transactionId = MAC_ts)
+                # and under nested keys (device.mobileId).
+                "commandHistory": {
+                    "command": {
+                        "transactionId": "AA:BB:CC:DD:EE:FF_2024-01-01T00:00:00Z",
+                        "macAddress": "AA:BB:CC:DD:EE:FF",
+                        "commandName": "startProgram",
+                        "device": {"mobileId": "phone-install-xyz", "os": "android"},
+                    },
+                },
+            },
+            "statistics": {},
+        },
+        WD_ID: {
+            "appliance": wd,
+            "type": "WD",
+            "name": "Lavatrice di Mario",
+            "model": "HW90",
+            "serial": "SN-PLAINTEXT",
+            "mac": "11:22:33:44:55:66",
+            "attributes": {
+                "machMode": "2",              # mapped (state sensor)
+                "weirdNewSensor": 5,          # UNMAPPED bare telemetry (gold)
+                "programsCounter": 12,        # UNMAPPED + from statistics
+                "settings.spinSpeed": "1000",  # dotted -> excluded
+                "serialNumber": "SN-PLAINTEXT",
+                "deviceInfo": {"code": "C999", "label": "ok"},  # nested identity
+            },
+            "statistics": {"programsCounter": 12},
+        },
+    })
+
+
+def _entry_diag():
+    coord = _build_coordinator()
+    hass = FakeHass(coord)
+    result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+    blocks = {b["type"]: b for b in result["appliances"]}
+    return result, blocks
+
+
+class DiagnosticsValuesTest(unittest.TestCase):
+    def test_attribute_values_present_and_not_redacted(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(blocks["AC"]["attributes"]["tempIndoor"], 22.5)
+        self.assertEqual(blocks["WD"]["attributes"]["machMode"], "2")
+
+    def test_command_ranges_present(self):
+        _, blocks = _entry_diag()
+        tempsel = blocks["AC"]["commands"]["settings"]["tempSel"]
+        self.assertEqual((tempsel["min"], tempsel["max"], tempsel["step"]), (16.0, 30.0, 1.0))
+
+    def test_command_enums_present(self):
+        _, blocks = _entry_diag()
+        machmode = blocks["AC"]["commands"]["settings"]["machMode"]
+        self.assertEqual(machmode["enum"], ["0", "1", "2"])
+        self.assertEqual(machmode["value"], "1")
+
+
+class DiagnosticsCoverageTest(unittest.TestCase):
+    def test_unmapped_bare_attribute_surfaces(self):
+        _, blocks = _entry_diag()
+        self.assertIn("weirdAcSensor", blocks["AC"]["coverage"]["attributes_unmapped"])
+        self.assertIn("weirdNewSensor", blocks["WD"]["coverage"]["attributes_unmapped"])
+
+    def test_mapped_attributes_not_reported_unmapped(self):
+        _, blocks = _entry_diag()
+        ac_unmapped = blocks["AC"]["coverage"]["attributes_unmapped"]
+        self.assertNotIn("tempIndoor", ac_unmapped)
+        self.assertNotIn("available", ac_unmapped)
+        self.assertNotIn("machMode", blocks["WD"]["coverage"]["attributes_unmapped"])
+
+    def test_dotted_keys_excluded_from_attribute_axis(self):
+        _, blocks = _entry_diag()
+        self.assertNotIn("settings.machMode", blocks["AC"]["coverage"]["attributes_unmapped"])
+        self.assertNotIn("settings.spinSpeed", blocks["WD"]["coverage"]["attributes_unmapped"])
+
+    def test_statistics_unmapped_split_out(self):
+        _, blocks = _entry_diag()
+        cov = blocks["WD"]["coverage"]
+        self.assertIn("programsCounter", cov["attributes_unmapped"])
+        self.assertIn("programsCounter", cov["attributes_unmapped_statistics"])
+        # real telemetry stays out of the statistics bucket
+        self.assertNotIn("weirdNewSensor", cov["attributes_unmapped_statistics"])
+
+    def test_unmapped_writable_params(self):
+        _, blocks = _entry_diag()
+        self.assertIn("mysteryParam", blocks["AC"]["coverage"]["command_params_unmapped"])
+        self.assertIn("spinSpeed", blocks["WD"]["coverage"]["command_params_unmapped"])
+
+    def test_mapped_writable_params_not_reported(self):
+        _, blocks = _entry_diag()
+        ac_unmapped = blocks["AC"]["coverage"]["command_params_unmapped"]
+        self.assertNotIn("tempSel", ac_unmapped)       # climate-written
+        self.assertNotIn("machMode", ac_unmapped)      # climate-written
+        self.assertNotIn("lightStatus", ac_unmapped)   # AC switch
+        self.assertNotIn("program", blocks["WD"]["coverage"]["command_params_unmapped"])
+
+
+    def test_bare_writable_params_not_reported_unmapped(self):
+        # A device shadow exposes writable params bare (tempSel/machMode); they belong
+        # to the command-param axis, not the read-only attribute axis.
+        _, blocks = _entry_diag()
+        ac_unmapped = blocks["AC"]["coverage"]["attributes_unmapped"]
+        self.assertNotIn("tempSel", ac_unmapped)
+        self.assertNotIn("machMode", ac_unmapped)
+
+    def test_attributes_total_excludes_writable_mirrors(self):
+        # `attributes_total` is the read-only-axis denominator: it must NOT count the
+        # bare writable mirrors (tempSel/machMode), and unmapped is a subset of it.
+        _, blocks = _entry_diag()
+        cov = blocks["AC"]["coverage"]
+        # AC bare keys: tempIndoor, available, weirdAcSensor, macAddress, tempSel,
+        # machMode, liveParam, opaqueObj, commandHistory (9); minus 2 writable
+        # mirrors (tempSel, machMode) -> 7.
+        self.assertEqual(cov["attributes_total"], 7)
+        self.assertLessEqual(len(cov["attributes_unmapped"]), cov["attributes_total"])
+
+
+class DiagnosticsSerializationTest(unittest.TestCase):
+    def test_whole_dump_is_json_serializable(self):
+        # HA serializes the dump; wrapper objects in attributes must be coerced.
+        result, _ = _entry_diag()
+        json.dumps(result)  # must not raise
+
+    def test_wrapper_value_unwrapped(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(blocks["AC"]["attributes"]["liveParam"], 7)
+
+    def test_opaque_value_stringified(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(blocks["AC"]["attributes"]["opaqueObj"], "opaque-str")
+
+
+class DiagnosticsRedactionTest(unittest.TestCase):
+    def test_top_level_identity_redacted(self):
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            self.assertEqual(block["id"], "***")
+            self.assertEqual(block["serial"], "***")
+            self.assertEqual(block["mac"], "***")
+
+    def test_identity_keys_redacted_recursively(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(blocks["AC"]["attributes"]["macAddress"], "***")
+        self.assertEqual(blocks["WD"]["attributes"]["serialNumber"], "***")
+        # nested dict: `code` (serial fallback) redacted, sibling preserved
+        self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["code"], "***")
+        self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["label"], "ok")
+
+    def test_command_history_value_borne_identity_redacted(self):
+        _, blocks = _entry_diag()
+        cmd = blocks["AC"]["attributes"]["commandHistory"]["command"]
+        self.assertEqual(cmd["transactionId"], "***")   # carried the full MAC
+        self.assertEqual(cmd["macAddress"], "***")
+        self.assertEqual(cmd["device"]["mobileId"], "***")
+        # non-sensitive siblings survive
+        self.assertEqual(cmd["commandName"], "startProgram")
+        self.assertEqual(cmd["device"]["os"], "android")
+
+    def test_nickname_kept_readable(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(blocks["WD"]["name"], "Lavatrice di Mario")
+        self.assertEqual(blocks["AC"]["name"], "Salotto AC")
+
+    def test_no_over_redaction_of_telemetry(self):
+        _, blocks = _entry_diag()
+        # model/type must survive (needed for mapping)
+        self.assertEqual(blocks["AC"]["model"], "AS35")
+        self.assertEqual(blocks["AC"]["type"], "AC")
+
+    def test_entry_envelope_redacted(self):
+        result, _ = _entry_diag()
+        self.assertEqual(result["entry"]["data"]["password"], "***")
+        self.assertEqual(result["entry"]["data"]["email"], "***@example.com")
+        self.assertNotIn("user@example.com", result["entry"]["title"] or "")
+
+
+class DiagnosticsDeviceTest(unittest.TestCase):
+    def test_device_diagnostics_returns_single_matching_appliance(self):
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, WD_ID)})
+        result = _run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device))
+        self.assertIn("appliance", result)
+        self.assertEqual(result["appliance"]["type"], "WD")
+        self.assertEqual(result["appliance"]["name"], "Lavatrice di Mario")
+
+    def test_device_diagnostics_unknown_device_returns_empty(self):
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, "does-not-exist")})
+        self.assertEqual(_run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)), {})
+
+    def test_device_diagnostics_foreign_identifier_ignored(self):
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={("some_other_domain", WD_ID)})
+        self.assertEqual(_run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)), {})
+
+
+class DiagnosticsDriftGuardTest(unittest.TestCase):
+    def test_custom_mapped_attrs_pinned(self):
+        # Adding a custom entity class that consumes a new bare attribute must come
+        # with an update here, otherwise the attribute would be reported as unmapped.
+        self.assertEqual(
+            diagnostics._CUSTOM_MAPPED_ATTRS,
+            {
+                "WM": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+                "WD": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+                "TD": frozenset({"machMode"}),
+                "AC": frozenset({"tempIndoor"}),
+            },
+        )
+
+    def test_ac_climate_params_pinned(self):
+        self.assertEqual(
+            diagnostics._AC_CLIMATE_PARAMS,
+            frozenset({"onOffStatus", "machMode", "tempSel", "windSpeed", "windDirectionVertical"}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -74,7 +74,7 @@ def _install_stubs() -> None:
         if not hasattr(const, unit_cls):
             setattr(const, unit_cls, type(unit_cls, (), {
                 "CELSIUS": "C", "KILO_WATT_HOUR": "kWh", "MINUTES": "min", "LITERS": "L",
-                "GRAMS": "g", "SECONDS": "s",
+                "GRAMS": "g", "KILOGRAMS": "kg", "SECONDS": "s",
             }))
 
     components = _mod("homeassistant.components")
@@ -179,10 +179,15 @@ def _collect_code_keys() -> dict[str, set[str]]:
     used["sensor"] = {
         _tk(d) for descs in sensor.SENSORS.values() for d in descs
     }
+    # Derived custom-class sensor (not a description-table row).
+    used["sensor"].add(sensor.HonMeanWaterConsumption._attr_translation_key)
     used["binary_sensor"] = {
         _tk(d) for descs in binary_sensor.BINARY_SENSORS.values() for d in descs
     }
     used["binary_sensor"].add(_tk(binary_sensor._CONNECTIVITY))
+    # Universal capability-gated binaries (not in the per-type table).
+    for d in binary_sensor._UNIVERSAL_GATED:
+        used["binary_sensor"].add(_tk(d))
     used["number"] = {
         _tk(d) for descs in number.NUMBERS.values() for d in descs
     }

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -140,6 +140,7 @@ def _install_homeassistant_stubs() -> None:
 
     class UnitOfMass:
         GRAMS = "g"
+        KILOGRAMS = "kg"
 
     const.UnitOfEnergy = getattr(const, "UnitOfEnergy", UnitOfEnergy)
     const.UnitOfVolume = getattr(const, "UnitOfVolume", UnitOfVolume)
@@ -201,7 +202,7 @@ class PerTypeTableTest(unittest.TestCase):
              "delay_time", "errors", "total_washes", "total_water", "total_energy",
              "current_energy", "current_water", "current_wash_cycle",
              "remaining_rinses", "detergent_level", "detergent_weight",
-             "softener_weight"],
+             "softener_weight", "estimated_weight"],
         )
 
     def test_wd_is_wm_plus_dry_level(self) -> None:
@@ -212,7 +213,7 @@ class PerTypeTableTest(unittest.TestCase):
              "loading_percentage", "delay_time", "errors", "total_washes", "total_water",
              "total_energy", "current_energy", "current_water", "current_wash_cycle",
              "remaining_rinses", "detergent_level", "detergent_weight",
-             "softener_weight"],
+             "softener_weight", "estimated_weight"],
         )
 
     def test_td_keys(self) -> None:

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -198,6 +198,7 @@ def _install_homeassistant_stubs() -> None:
 
     class UnitOfMass:
         GRAMS = "g"
+        KILOGRAMS = "kg"
 
     const.UnitOfEnergy = getattr(const, "UnitOfEnergy", UnitOfEnergy)
     const.UnitOfVolume = getattr(const, "UnitOfVolume", UnitOfVolume)
@@ -333,9 +334,9 @@ class Tier2TableTest(unittest.TestCase):
         expected_gated = {
             "AC": {"pm10", "voc", "co", "air_quality"},
             "WM": {"current_wash_cycle", "remaining_rinses", "detergent_level",
-                   "detergent_weight", "softener_weight"},
+                   "detergent_weight", "softener_weight", "estimated_weight"},
             "WD": {"current_wash_cycle", "remaining_rinses", "detergent_level",
-                   "detergent_weight", "softener_weight"},
+                   "detergent_weight", "softener_weight", "estimated_weight"},
             "TD": set(),
         }
         for app_type, gated_keys in expected_gated.items():
@@ -727,6 +728,65 @@ class GvigrouxImportTest(unittest.IsolatedAsyncioTestCase):
         buids = {e._attr_unique_id for e in await _build_binary("WM", {})}
         for k in ("night_wash", "steam", "energy_saving"):
             self.assertNotIn(f"x-1_{k}", buids)
+
+    # --- Wave 1/2 harvest: estimated weight / remote control / mean water
+    #     consumption (all gated) ---
+
+    async def test_estimated_weight_gated_with_fallback(self) -> None:
+        # actualWeight builds it; the `weight` fallback also builds it; absent when
+        # neither is reported. WM and WD both carry it.
+        for app_type in ("WM", "WD"):
+            added = await _build_sensors(app_type, {"actualWeight": "3.5"})
+            ew = next(e for e in added if e._attr_unique_id == "x-1_estimated_weight")
+            self.assertEqual(ew.native_value, 3.5)
+            added = await _build_sensors(app_type, {"weight": "4"})
+            ew = next(e for e in added if e._attr_unique_id == "x-1_estimated_weight")
+            self.assertEqual(ew.native_value, 4.0)  # reads the `weight` fallback
+            uids = {e._attr_unique_id for e in await _build_sensors(app_type, {})}
+            self.assertNotIn("x-1_estimated_weight", uids)
+
+    def test_estimated_weight_device_class_kg(self) -> None:
+        from homeassistant.components.sensor import SensorDeviceClass
+        from homeassistant.const import UnitOfMass
+
+        from custom_components.addhon.const import APPLIANCE_WM
+        from custom_components.addhon.sensor import SENSORS
+
+        d = {x.key: x for x in SENSORS[APPLIANCE_WM]}["estimated_weight"]
+        self.assertEqual(d.device_class, SensorDeviceClass.WEIGHT)
+        self.assertEqual(d.native_unit_of_measurement, UnitOfMass.KILOGRAMS)
+        self.assertEqual(d.attr_fallbacks, ("weight",))
+
+    async def test_remote_control_universal_gated(self) -> None:
+        # Present on ANY type that reports remoteCtrValid (AC has no per-type set;
+        # REF is a Tier-2 type) and absent otherwise. is_on follows "1".
+        for app_type in ("AC", "REF"):
+            added = await _build_binary(app_type, {"remoteCtrValid": "1"})
+            rc = next(e for e in added if e._attr_unique_id == "x-1_remote_control")
+            self.assertTrue(rc.is_on)
+            uids = {e._attr_unique_id for e in await _build_binary(app_type, {})}
+            self.assertNotIn("x-1_remote_control", uids)
+
+    async def test_mean_water_consumption(self) -> None:
+        # WM/WD only, gated on BOTH source attrs; value = water/(cycles-1).
+        for app_type in ("WM", "WD"):
+            added = await _build_sensors(
+                app_type, {"totalWaterUsed": "100", "totalWashCycle": "6"})
+            mw = next(e for e in added if e._attr_unique_id == "x-1_mean_water_consumption")
+            self.assertEqual(mw.native_value, 20.0)  # 100 / (6-1)
+        # <=0 denominator (first cycle) -> None, not a divide-by-zero
+        added = await _build_sensors("WM", {"totalWaterUsed": "100", "totalWashCycle": "1"})
+        mw = next(e for e in added if e._attr_unique_id == "x-1_mean_water_consumption")
+        self.assertIsNone(mw.native_value)
+
+    async def test_mean_water_absent_without_both_attrs_or_on_dryer(self) -> None:
+        # Needs BOTH attrs; the tumble dryer never builds it (no water).
+        for attrs in ({"totalWaterUsed": "100"}, {"totalWashCycle": "6"}):
+            uids = {e._attr_unique_id for e in await _build_sensors("WM", attrs)}
+            self.assertNotIn("x-1_mean_water_consumption", uids)
+        uids = {e._attr_unique_id for e in await _build_sensors(
+            "TD", {"totalWaterUsed": "100", "totalWashCycle": "6"})}
+        self.assertNotIn("x-1_mean_water_consumption", uids)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.0.6`.

<!-- release-tag: v5.0.6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote control binary sensor for compatible appliances
  * Added estimated drum weight sensor for washers
  * Added mean water consumption metric for better consumption tracking

* **Documentation**
  * Enhanced diagnostics with detailed device attribute and command information for improved troubleshooting

* **Chores**
  * Updated version to 5.0.6
  * Added Italian and English translations for new entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release adds three capability-gated entities (drum estimated-weight sensor, mean-water-consumption derived sensor, and a universal remote-control binary sensor), a substantially enriched diagnostics dump (attribute values, command schemas, and a coverage report surfacing unmapped attributes/params), and a full test suite for the new diagnostics path.

- **New sensors (WM/WD):** `_ESTIMATED_WEIGHT` reads `actualWeight` with a `weight` fallback; `HonMeanWaterConsumption` computes `totalWaterUsed / (totalWashCycle - 1)` with a correct zero-denominator guard; both are capability-gated.
- **New binary sensor (universal):** `_REMOTE_CONTROL` reads `remoteCtrValid` and is created for any appliance that reports the attribute via the new `_UNIVERSAL_GATED` registration loop.
- **Diagnostics overhaul:** `async_get_device_diagnostics` is added; the dump now carries attribute values (wrapper-objects coerced to JSON primitives), full command-param schemas (value/enum/range), recursive key-based PII redaction, and a `coverage` block that identifies unmapped bare attributes and writable params.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; all new entities are capability-gated and the diagnostics dump never crashes the integration.

The diagnostics overhaul and new sensors are well-tested and the gating logic is consistent throughout. The only concrete issue is `_REMOTE_CONTROL` carrying `BinarySensorDeviceClass.CONNECTIVITY`, which causes HA to label the sensor as 'Connected / Disconnected' even though `remoteCtrValid` represents remote-control authorization — a misleading UX signal. A test resource leak in `_run()` also emits warnings on newer Python. Neither blocks functionality, but the device-class mismatch will be immediately visible to end users on any appliance that reports `remoteCtrValid`.

custom_components/addhon/binary_sensor.py — the device class on `_REMOTE_CONTROL`; tests/test_diagnostics.py — unclosed event loop in `_run()`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/binary_sensor.py | Adds `_REMOTE_CONTROL` universal gated binary sensor and `_UNIVERSAL_GATED` registration loop; `_REMOTE_CONTROL` uses `BinarySensorDeviceClass.CONNECTIVITY` which is semantically incorrect for a remote-authorization state. |
| custom_components/addhon/diagnostics.py | Major overhaul: adds attribute values, command schemas, and coverage reporting to the diagnostics dump; recursive key-based PII redaction, per-device diagnostics hook, and graceful degradation on import failure all look correct. |
| custom_components/addhon/sensor.py | Adds `_ESTIMATED_WEIGHT` (gated, with `weight` fallback) for WM/WD, and `HonMeanWaterConsumption` derived sensor with correct divide-by-zero guard; both gated on attribute presence. |
| tests/test_diagnostics.py | New 501-line test covering redaction, coverage reporting, serialization, and per-device diagnostics; event loop created in `_run()` is never explicitly closed, which can produce ResourceWarning. |
| custom_components/addhon/manifest.json | Version bump from 5.0.5 to 5.0.6 only. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["async_get_device_diagnostics / async_get_config_entry_diagnostics"] --> B["_coordinator()"]
    B --> C{coordinator.data?}
    C -- "not Mapping" --> D["return {}"]
    C -- "Mapping" --> E["for each appliance_id, data"]
    E --> F["_appliance_block(appliance_id, data)"]
    F --> G["_command_schema(appliance)"]
    F --> H["_coverage(app_type, attributes, statistics, appliance)"]
    H --> I["_mapped_sets(app_type)"]
    I --> J["lazy import: SENSORS, BINARY_SENSORS, NUMBERS, _CONNECTIVITY, _UNIVERSAL_GATED, _AC_SWITCHES"]
    H --> K["_settings_param_names(appliance)"]
    F --> L["_redact(block)"]
    L --> M["recursive key-based PII redaction + _jsonable() coercion at leaves"]
    F --> N["block: id/serial/mac=*** | name/type/model | attributes | commands | coverage"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["async_get_device_diagnostics / async_get_config_entry_diagnostics"] --> B["_coordinator()"]
    B --> C{coordinator.data?}
    C -- "not Mapping" --> D["return {}"]
    C -- "Mapping" --> E["for each appliance_id, data"]
    E --> F["_appliance_block(appliance_id, data)"]
    F --> G["_command_schema(appliance)"]
    F --> H["_coverage(app_type, attributes, statistics, appliance)"]
    H --> I["_mapped_sets(app_type)"]
    I --> J["lazy import: SENSORS, BINARY_SENSORS, NUMBERS, _CONNECTIVITY, _UNIVERSAL_GATED, _AC_SWITCHES"]
    H --> K["_settings_param_names(appliance)"]
    F --> L["_redact(block)"]
    L --> M["recursive key-based PII redaction + _jsonable() coercion at leaves"]
    F --> N["block: id/serial/mac=*** | name/type/model | attributes | commands | coverage"]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A108-113%0AThe%20%60_REMOTE_CONTROL%60%20sensor%20uses%20%60BinarySensorDeviceClass.CONNECTIVITY%60%2C%20but%20the%20inline%20comment%20explicitly%20notes%20it%20is%20%22distinct%20from%20%60available%60%20%28network%20reachability%29%22.%20HA%20renders%20CONNECTIVITY%20sensors%20with%20a%20%22Connected%20%2F%20Disconnected%22%20label%20and%20network-plug%20icon%2C%20which%20misrepresents%20what%20%60remoteCtrValid%60%20actually%20signals%20%28authorization%2C%20not%20reachability%29.%20Omitting%20the%20device%20class%20%28or%20using%20%60None%60%29%20would%20let%20the%20translation-provided%20name%20speak%20for%20itself%20without%20an%20incorrect%20semantic%20override.%0A%0A%60%60%60suggestion%0A_REMOTE_CONTROL%20%3D%20HonBinarySensorEntityDescription%28%0A%20%20%20%20key%3D%22remote_control%22%2C%0A%20%20%20%20icon%3D%22mdi%3Aremote%22%2C%0A%20%20%20%20attr_key%3D%22remoteCtrValid%22%2C%20%20%20%20%20%20%20%20%20%20%20%20%23%20%221%22%20%3D%20remote%20control%20authorized%0A%20%20%20%20device_class%3DNone%2C%0A%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Ftest_diagnostics.py%3A167-168%0AThe%20%60_run%60%20helper%20creates%20a%20new%20event%20loop%20but%20never%20closes%20it.%20This%20produces%20%60ResourceWarning%3A%20unclosed%20event%20loop%60%20on%20CPython%203.12%2B%20and%20can%20cause%20flakiness%20when%20many%20test%20cases%20are%20run%20in%20the%20same%20process%2C%20because%20unclosed%20loops%20accumulate%20file%20descriptors.%0A%0A%60%60%60suggestion%0Adef%20_run%28coro%29%3A%0A%20%20%20%20loop%20%3D%20asyncio.new_event_loop%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20return%20loop.run_until_complete%28coro%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20loop.close%28%29%0A%60%60%60%0A%0A&repo=tis24dev%2Faddhon&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A108-113%0AThe%20%60_REMOTE_CONTROL%60%20sensor%20uses%20%60BinarySensorDeviceClass.CONNECTIVITY%60%2C%20but%20the%20inline%20comment%20explicitly%20notes%20it%20is%20%22distinct%20from%20%60available%60%20%28network%20reachability%29%22.%20HA%20renders%20CONNECTIVITY%20sensors%20with%20a%20%22Connected%20%2F%20Disconnected%22%20label%20and%20network-plug%20icon%2C%20which%20misrepresents%20what%20%60remoteCtrValid%60%20actually%20signals%20%28authorization%2C%20not%20reachability%29.%20Omitting%20the%20device%20class%20%28or%20using%20%60None%60%29%20would%20let%20the%20translation-provided%20name%20speak%20for%20itself%20without%20an%20incorrect%20semantic%20override.%0A%0A%60%60%60suggestion%0A_REMOTE_CONTROL%20%3D%20HonBinarySensorEntityDescription%28%0A%20%20%20%20key%3D%22remote_control%22%2C%0A%20%20%20%20icon%3D%22mdi%3Aremote%22%2C%0A%20%20%20%20attr_key%3D%22remoteCtrValid%22%2C%20%20%20%20%20%20%20%20%20%20%20%20%23%20%221%22%20%3D%20remote%20control%20authorized%0A%20%20%20%20device_class%3DNone%2C%0A%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Ftest_diagnostics.py%3A167-168%0AThe%20%60_run%60%20helper%20creates%20a%20new%20event%20loop%20but%20never%20closes%20it.%20This%20produces%20%60ResourceWarning%3A%20unclosed%20event%20loop%60%20on%20CPython%203.12%2B%20and%20can%20cause%20flakiness%20when%20many%20test%20cases%20are%20run%20in%20the%20same%20process%2C%20because%20unclosed%20loops%20accumulate%20file%20descriptors.%0A%0A%60%60%60suggestion%0Adef%20_run%28coro%29%3A%0A%20%20%20%20loop%20%3D%20asyncio.new_event_loop%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20return%20loop.run_until_complete%28coro%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20loop.close%28%29%0A%60%60%60%0A%0A&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acustom_components%2Faddhon%2Fbinary_sensor.py%3A108-113%0AThe%20%60_REMOTE_CONTROL%60%20sensor%20uses%20%60BinarySensorDeviceClass.CONNECTIVITY%60%2C%20but%20the%20inline%20comment%20explicitly%20notes%20it%20is%20%22distinct%20from%20%60available%60%20%28network%20reachability%29%22.%20HA%20renders%20CONNECTIVITY%20sensors%20with%20a%20%22Connected%20%2F%20Disconnected%22%20label%20and%20network-plug%20icon%2C%20which%20misrepresents%20what%20%60remoteCtrValid%60%20actually%20signals%20%28authorization%2C%20not%20reachability%29.%20Omitting%20the%20device%20class%20%28or%20using%20%60None%60%29%20would%20let%20the%20translation-provided%20name%20speak%20for%20itself%20without%20an%20incorrect%20semantic%20override.%0A%0A%60%60%60suggestion%0A_REMOTE_CONTROL%20%3D%20HonBinarySensorEntityDescription%28%0A%20%20%20%20key%3D%22remote_control%22%2C%0A%20%20%20%20icon%3D%22mdi%3Aremote%22%2C%0A%20%20%20%20attr_key%3D%22remoteCtrValid%22%2C%20%20%20%20%20%20%20%20%20%20%20%20%23%20%221%22%20%3D%20remote%20control%20authorized%0A%20%20%20%20device_class%3DNone%2C%0A%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Ftest_diagnostics.py%3A167-168%0AThe%20%60_run%60%20helper%20creates%20a%20new%20event%20loop%20but%20never%20closes%20it.%20This%20produces%20%60ResourceWarning%3A%20unclosed%20event%20loop%60%20on%20CPython%203.12%2B%20and%20can%20cause%20flakiness%20when%20many%20test%20cases%20are%20run%20in%20the%20same%20process%2C%20because%20unclosed%20loops%20accumulate%20file%20descriptors.%0A%0A%60%60%60suggestion%0Adef%20_run%28coro%29%3A%0A%20%20%20%20loop%20%3D%20asyncio.new_event_loop%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20return%20loop.run_until_complete%28coro%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20loop.close%28%29%0A%60%60%60%0A%0A&repo=tis24dev%2Faddhon&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.0.6"](https://github.com/tis24dev/addhon/commit/0e185e23bbba3dc979d9fe66f4d9ea712db0f94d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38931071)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->