### PR TITLE
Release v5.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Force LF line endings in the repository for all text files, regardless of the
+# editor's platform. Without this, opening/saving the repo from Windows (e.g. via
+# \\wsl$\Debian\opt\addhOn) re-saves files as CRLF and dirties the whole working
+# tree with pure end-of-line churn. `text=auto` lets git detect text vs binary;
+# `eol=lf` checks out and normalizes text files with LF.
+* text=auto eol=lf
+
+# Explicitly treat the project's text formats as LF.
+*.py    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.txt   text eol=lf
+*.cfg   text eol=lf
+*.toml  text eol=lf
+
+# Common binaries: never touch their bytes.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.zip   binary

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -37,6 +37,7 @@ from .logging_utils import (
     reset_integration_log_level,
     silence_mqtt_noise,
 )
+from .debug_utils import redact_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -313,10 +314,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             data = await hon_client.async_get_appliances_data()
             summary = [
                 {
-                    "id": appliance_id,
+                    "id": redact_mac(appliance_id),
                     "name": appliance_data.get("name"),
                     "type": appliance_data.get("type"),
-                    "mac": appliance_data.get("mac"),
+                    "mac": redact_mac(appliance_data.get("mac")),
                     "attributes": len(appliance_data.get("attributes", {}))
                     if isinstance(appliance_data.get("attributes"), dict)
                     else 0,

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import timedelta
+from typing import NoReturn
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -181,7 +182,7 @@ async def _async_close_client(client) -> None:
         _LOGGER.warning("Error closing HonClient: %s", err)
 
 
-def _raise_setup_error(err: Exception) -> None:
+def _raise_setup_error(err: Exception) -> NoReturn:
     """Classify a SETUP failure and raise the matching HA exception.
 
     An auth error triggers the reauth flow (ConfigEntryAuthFailed); anything else is
@@ -195,7 +196,7 @@ def _raise_setup_error(err: Exception) -> None:
     raise ConfigEntryNotReady(f"Unable to connect to hOn: {err}") from err
 
 
-def _raise_update_error(err: Exception) -> None:
+def _raise_update_error(err: Exception) -> NoReturn:
     """Classify a COORDINATOR update failure and raise the matching HA exception.
 
     An auth error triggers the reauth flow (ConfigEntryAuthFailed); anything else is a

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -197,7 +197,10 @@ _TD_REMOVED_SUFFIXES = (
 def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove from the registry the legacy entities no longer provided by the integration.
 
-    - "Power" switch (unique_id '<id>_power'), removed in the 2.3/2.4 refactor.
+    - "Power" SWITCH (unique_id '<id>_power'), removed in the 2.3/2.4 refactor.
+      Scoped to the switch domain on purpose: the legitimate WH `power` sensor
+      (unique_id '<id>_power') and KT `current_power` sensor (unique_id
+      '<id>_current_power') both end in '_power' and must NOT be purged.
     - Washer-only sensors on the tumble dryers (TD): '<td_id>_total_water',
       '_total_energy', '_current_energy', '_current_water', '_loading_percentage'.
       Removed ONLY on devices of type TD (cross-checked with the coordinator),
@@ -227,10 +230,11 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
     for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
         checked += 1
         unique_id = reg_entry.unique_id or ""
-        if unique_id.endswith("_power"):
+        domain = (reg_entry.entity_id or "").split(".", 1)[0]
+        if domain == "switch" and unique_id.endswith("_power"):
             registry.async_remove(reg_entry.entity_id)
             removed += 1
-            _LOGGER.info("Removed legacy power entity: %s", reg_entry.entity_id)
+            _LOGGER.info("Removed legacy power switch: %s", reg_entry.entity_id)
         elif unique_id in td_orphans:
             registry.async_remove(reg_entry.entity_id)
             removed += 1

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -181,6 +181,33 @@ async def _async_close_client(client) -> None:
         _LOGGER.warning("Error closing HonClient: %s", err)
 
 
+def _raise_setup_error(err: Exception) -> None:
+    """Classify a SETUP failure and raise the matching HA exception.
+
+    An auth error triggers the reauth flow (ConfigEntryAuthFailed); anything else is
+    ConfigEntryNotReady so HA retries setup later. Extracted from async_setup_entry so
+    the branch is unit-testable (a swapped branch would otherwise pass the suite). (#11)
+    """
+    from .hon_client import _requires_reauth
+
+    if _requires_reauth(err):
+        raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
+    raise ConfigEntryNotReady(f"Unable to connect to hOn: {err}") from err
+
+
+def _raise_update_error(err: Exception) -> None:
+    """Classify a COORDINATOR update failure and raise the matching HA exception.
+
+    An auth error triggers the reauth flow (ConfigEntryAuthFailed); anything else is a
+    transient UpdateFailed (the coordinator keeps its last good snapshot and retries).
+    Extracted for unit-testing (#11)."""
+    from .hon_client import _requires_reauth
+
+    if _requires_reauth(err):
+        raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
+    raise UpdateFailed(f"hOn update error: {err}") from err
+
+
 # "Washer-only" sensors that were mistakenly created on the tumble dryers (TD)
 # too: a tumble dryer does not use water and does not report loadingPercentage
 # (the app gates that statistic to WM/WD), so they stayed forever "unknown"
@@ -252,7 +279,7 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Haier hOn integration from a Config Entry."""
-    from .hon_client import HonClient, _requires_reauth
+    from .hon_client import HonClient
 
     # Silence by default the noise of the realtime MQTT attempts and register
     # the debug service. Done BEFORE the client setup so the logger is already at
@@ -303,9 +330,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception as err:
         _LOGGER.error("Unable to connect to hOn: %s", err)
         await _async_close_client(hon_client)
-        if _requires_reauth(err):
-            raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
-        raise ConfigEntryNotReady(f"Unable to connect to hOn: {err}") from err
+        _raise_setup_error(err)
 
     async def async_update_data() -> dict:
         """Fetch the updated data from all the hOn devices."""
@@ -335,9 +360,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return data
         except Exception as err:
             _LOGGER.debug("Coordinator debug: hOn data update failed: %s", err, exc_info=True)
-            if _requires_reauth(err):
-                raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
-            raise UpdateFailed(f"hOn update error: {err}") from err
+            _raise_update_error(err)
 
     stored = False
     try:

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -189,11 +189,13 @@ def _raise_setup_error(err: Exception) -> NoReturn:
     ConfigEntryNotReady so HA retries setup later. Extracted from async_setup_entry so
     the branch is unit-testable (a swapped branch would otherwise pass the suite). (#11)
     """
+    from .error_codes import classify
     from .hon_client import _requires_reauth
 
+    code = classify(err)
     if _requires_reauth(err):
-        raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
-    raise ConfigEntryNotReady(f"Unable to connect to hOn: {err}") from err
+        raise ConfigEntryAuthFailed(f"[{code.label}] Invalid hOn credentials: {err}") from err
+    raise ConfigEntryNotReady(f"[{code.label}] Unable to connect to hOn: {err}") from err
 
 
 def _raise_update_error(err: Exception) -> NoReturn:
@@ -202,11 +204,13 @@ def _raise_update_error(err: Exception) -> NoReturn:
     An auth error triggers the reauth flow (ConfigEntryAuthFailed); anything else is a
     transient UpdateFailed (the coordinator keeps its last good snapshot and retries).
     Extracted for unit-testing (#11)."""
+    from .error_codes import classify
     from .hon_client import _requires_reauth
 
+    code = classify(err)
     if _requires_reauth(err):
-        raise ConfigEntryAuthFailed(f"Invalid hOn credentials: {err}") from err
-    raise UpdateFailed(f"hOn update error: {err}") from err
+        raise ConfigEntryAuthFailed(f"[{code.label}] Invalid hOn credentials: {err}") from err
+    raise UpdateFailed(f"[{code.label}] hOn update error: {err}") from err
 
 
 # "Washer-only" sensors that were mistakenly created on the tumble dryers (TD)
@@ -360,7 +364,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             return data
         except Exception as err:
-            _LOGGER.debug("Coordinator debug: hOn data update failed: %s", err, exc_info=True)
+            from .error_codes import classify
+
+            hon_client.last_error_code = classify(err)
+            _LOGGER.debug(
+                "Coordinator debug: hOn data update failed [%s]: %s",
+                hon_client.last_error_code.label,
+                err,
+                exc_info=True,
+            )
             _raise_update_error(err)
 
     stored = False

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -355,6 +355,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         coordinator.hon_client = hon_client
 
+        # Realtime: wire MQTT pushes to the coordinator (#4). Without this the push
+        # channel was inert and entities only refreshed on the 60s poll. The push
+        # arrives on the awscrt thread, so the snapshot is built THERE (a coherent
+        # intra-thread read of the just-mutated appliances) and the publish is hopped
+        # onto the HA event loop via call_soon_threadsafe; async_set_updated_data
+        # publishes WITHOUT triggering a new poll (the 60s poll stays as a
+        # reconciliation safety-net). Detached on unload.
+        @callback
+        def _publish_realtime(snapshot: dict) -> None:
+            if snapshot:
+                coordinator.async_set_updated_data(snapshot)
+
+        def _on_realtime_push(_arg) -> None:
+            # Runs on the awscrt thread; must never let an exception reach it.
+            try:
+                snapshot = hon_client.build_realtime_snapshot()
+                hass.loop.call_soon_threadsafe(_publish_realtime, snapshot)
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("Setup debug: realtime push handling failed: %s", err)
+
+        try:
+            hon_client.subscribe_updates(_on_realtime_push)
+            entry.async_on_unload(lambda: hon_client.subscribe_updates(None))
+            _LOGGER.debug("Setup debug: realtime MQTT push wired to coordinator")
+        except Exception as err:  # pragma: no cover - realtime is best-effort
+            _LOGGER.warning("Setup debug: could not wire realtime MQTT push: %s", err)
+
         # Integration version, for the diagnostics device's sw_version ("Firmware:"
         # row on the device card). Lazy import so the test stubs that import this
         # package do not need to stub homeassistant.loader; tolerant if unavailable.

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .debug_utils import debug_key_sample
+from .debug_utils import debug_key_sample, redact_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ class HonBaseEntity(CoordinatorEntity):
             _LOGGER.debug(
                 "BaseEntity debug: created coordinator store '%s' for appliance=%s",
                 name,
-                self._appliance_id,
+                redact_id(self._appliance_id),
             )
         return store
 
@@ -218,8 +218,9 @@ class HonBaseEntity(CoordinatorEntity):
                 "BaseEntity debug: lookup '%s' for '%s' (id=%s) resolved from %s: "
                 "raw=%r (%s), value=%r; attribute_keys=%d %s; settings_keys=%d %s",
                 key,
-                getattr(self, "_attr_unique_id", None) or self.__class__.__name__,
-                self._appliance_id,
+                redact_id(getattr(self, "_attr_unique_id", None), self._appliance_id)
+                or self.__class__.__name__,
+                redact_id(self._appliance_id),
                 source,
                 raw_value,
                 type(raw_value).__name__,
@@ -318,8 +319,9 @@ class HonBaseEntity(CoordinatorEntity):
                 "BaseEntity debug: lookup '%s' for '%s' (id=%s) not found, "
                 "returning default=%r; attribute_keys=%d %s; settings_keys=%d %s",
                 key,
-                getattr(self, "_attr_unique_id", None) or self.__class__.__name__,
-                self._appliance_id,
+                redact_id(getattr(self, "_attr_unique_id", None), self._appliance_id)
+                or self.__class__.__name__,
+                redact_id(self._appliance_id),
                 default,
                 len(attributes) if isinstance(attributes, dict) else 0,
                 debug_key_sample(attributes) if isinstance(attributes, dict) else [],
@@ -335,15 +337,17 @@ class HonBaseEntity(CoordinatorEntity):
             refresh = self.coordinator.async_request_refresh
         _LOGGER.debug(
             "BaseEntity debug: refresh requested after command for appliance=%s entity=%s",
-            self._appliance_id,
-            getattr(self, "_attr_unique_id", None) or self.__class__.__name__,
+            redact_id(self._appliance_id),
+            redact_id(getattr(self, "_attr_unique_id", None), self._appliance_id)
+            or self.__class__.__name__,
         )
         await refresh()
         if getattr(self.coordinator, "last_update_success", True) is not False:
             _LOGGER.debug(
                 "BaseEntity debug: refresh after command succeeded for appliance=%s entity=%s",
-                self._appliance_id,
-                getattr(self, "_attr_unique_id", None) or self.__class__.__name__,
+                redact_id(self._appliance_id),
+                redact_id(getattr(self, "_attr_unique_id", None), self._appliance_id)
+                or self.__class__.__name__,
             )
             return
 

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -45,6 +45,7 @@ from .const import (
     WM_ATTR_DRY_CLEAN_NEEDED,
     WM_ATTR_FILTER_CLEAN,
 )
+from .debug_utils import redact_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -329,7 +330,7 @@ async def async_setup_entry(
             if description.attr_key not in attributes:
                 _LOGGER.debug(
                     "Binary debug: skip '%s' on '%s' id=%s (key '%s' absent)",
-                    description.key, data.get("name"), appliance_id, description.attr_key,
+                    description.key, data.get("name"), redact_id(appliance_id), description.attr_key,
                 )
                 continue
             entities.append(HonBinarySensor(coordinator, appliance_id, description))
@@ -346,7 +347,7 @@ async def async_setup_entry(
         created.append(_CONNECTIVITY.key)
         _LOGGER.debug(
             "Binary debug: '%s' (type=%s, id=%s) -> %d binary sensors %s",
-            data.get("name"), app_type, appliance_id, len(created), created,
+            data.get("name"), app_type, redact_id(appliance_id), len(created), created,
         )
     # Account-level diagnostic binary sensor (one per config entry).
     sw_version = entry_data.get("integration_version")

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -185,6 +185,20 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                                 f"'{self._command_name}': no parameter "
                                 f"{PROGRAM_PARAM_NAMES} among {available}"
                             )
+                    # Applying a program parameter can SWAP the active command in the
+                    # appliance dict: a HonParameterProgram setter does
+                    # command.category = value -> appliance.commands[name] =
+                    # categories[selected], replacing the object. Re-read the now active
+                    # command so the fixed parameters AND send() target the selected
+                    # program's command, not the stale pre-swap object. (#6)
+                    refreshed = commands.get(self._command_name)
+                    if refreshed is not None and refreshed is not command:
+                        _LOGGER.debug(
+                            "Button debug: active command '%s' swapped after program apply",
+                            self._command_name,
+                        )
+                        command = refreshed
+                        params = getattr(command, "parameters", {})
                     for name, value in self._command_parameters.items():
                         if name in params:
                             previous = getattr(params[name], "value", None)

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -19,7 +19,7 @@ from .const import (
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_STORE,
 )
-from .debug_utils import command_names, param_snapshot, redact_id
+from .debug_utils import command_names, param_snapshot, redact_id, redact_store
 from .logging_utils import reset_integration_log_level, silence_mqtt_noise
 
 _LOGGER = logging.getLogger(__name__)
@@ -136,7 +136,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             self._command_name,
             redact_id(self._appliance_id),
             pending_program,
-            dict(store),
+            redact_store(store),
             command_names(appliance),
         )
         try:
@@ -233,7 +233,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                 store.pop(self._appliance_id, None)
                 _LOGGER.debug(
                     "Button debug: pending program consumed and removed, store=%s",
-                    dict(store),
+                    redact_store(store),
                 )
             _LOGGER.info("Button: command '%s' sent", self._command_name)
             await self._async_request_command_refresh()

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -19,7 +19,7 @@ from .const import (
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_STORE,
 )
-from .debug_utils import command_names, param_snapshot
+from .debug_utils import command_names, param_snapshot, redact_id
 from .logging_utils import reset_integration_log_level, silence_mqtt_noise
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,18 +40,18 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Button debug: evaluating appliance '%s' id=%s type=%s commands=%s",
             data.get("name"),
-            appliance_id,
+            redact_id(appliance_id),
             app_type,
             command_names(data.get("appliance")),
         )
         if app_type not in APPLIANCE_WASH_GROUP:
-            _LOGGER.debug("Button debug: appliance id=%s ignored, type=%s", appliance_id, app_type)
+            _LOGGER.debug("Button debug: appliance id=%s ignored, type=%s", redact_id(appliance_id), app_type)
             continue
         appliance = data.get("appliance")
         commands = getattr(appliance, "commands", None)
         commands = commands if isinstance(commands, dict) else {}
         if "startProgram" in commands:
-            _LOGGER.debug("Button debug: creating startProgram button for id=%s", appliance_id)
+            _LOGGER.debug("Button debug: creating startProgram button for id=%s", redact_id(appliance_id))
             entities.append(
                 HonProgramCommandButton(
                     coordinator,
@@ -64,7 +64,7 @@ async def async_setup_entry(
                 )
             )
         if "stopProgram" in commands:
-            _LOGGER.debug("Button debug: creating stopProgram button for id=%s", appliance_id)
+            _LOGGER.debug("Button debug: creating stopProgram button for id=%s", redact_id(appliance_id))
             entities.append(
                 HonProgramCommandButton(
                     coordinator,
@@ -107,8 +107,8 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
         self._attr_icon = icon
         _LOGGER.debug(
             "Button debug: initialized '%s' id=%s command=%s fixed_params=%s",
-            self._attr_unique_id,
-            appliance_id,
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
             command_name,
             self._command_parameters,
         )
@@ -134,7 +134,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
         _LOGGER.debug(
             "Button debug: press '%s' id=%s pending_program=%s store=%s commands=%s",
             self._command_name,
-            self._appliance_id,
+            redact_id(self._appliance_id),
             pending_program,
             dict(store),
             command_names(appliance),

--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -21,7 +21,6 @@ from .command_loader import HonCommandLoader
 from .commands import HonCommand
 from .exceptions import NoAuthenticationException
 from .parameter.base import HonParameter
-from .parameter.range import HonParameterRange
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -247,12 +246,15 @@ class HonAppliance:
                 new := self.attributes.get("parameters", {}).get(key)
             ) is None or new.value == "":
                 continue
-            setting = command.settings[key]
             try:
-                if not isinstance(setting, HonParameterRange):
-                    command.settings[key].value = str(new.value)
-                else:
-                    command.settings[key].value = float(new.value)
+                # Always assign as a STRING (range params included): the range
+                # setter runs str_to_float, which tries int() first, so a float
+                # like 22.5 would be TRUNCATED to 22 without error (see
+                # helpers.str_to_float, and the same note in number.py /
+                # rules.py._apply_fixed). A string preserves the decimals, so a
+                # half-degree setpoint is not silently rounded when synced into
+                # the command and later re-sent to the cloud.
+                command.settings[key].value = str(new.value)
             except ValueError as error:
                 _LOGGER.info("Can't set %s - %s", key, error)
                 continue

--- a/custom_components/addhon/client/engine/parameter/range.py
+++ b/custom_components/addhon/client/engine/parameter/range.py
@@ -66,7 +66,16 @@ class HonParameterRange(HonParameter):
 
     @value.setter
     def value(self, value: str | float) -> None:
-        value = str_to_float(value)
+        # A fractional float passed directly (instead of the documented string) would be
+        # truncated by str_to_float's int()-first quirk (22.5 -> 22) and then silently
+        # accepted, so route only non-integer floats through str() to keep the decimals.
+        # Integer-valued inputs (str "4", int 4, float 4.0) stay int -> clean
+        # intern_value "4" (never "4.0"). str_to_float is golden-pinned, so the fix lives
+        # here in the write path, not in the helper.
+        if isinstance(value, float) and not value.is_integer():
+            value = str_to_float(str(value))
+        else:
+            value = str_to_float(value)
         if self.min <= value <= self.max and not ((value - self.min) * 100) % (
             self.step * 100
         ):

--- a/custom_components/addhon/client/factory.py
+++ b/custom_components/addhon/client/factory.py
@@ -19,18 +19,31 @@ _LOGGER = logging.getLogger(__name__)
 _NATIVE_APPLIANCE_CLS: Any = None
 
 
-def create_session(email: str, password: str) -> Any:
+def create_session(
+    email: str,
+    password: str,
+    *,
+    enable_mqtt: bool = True,
+    minimal: bool = False,
+) -> Any:
     """Create the NATIVE hOn session (`client.session.NativeHon`).
 
     Auth, connection, api, MQTT, orchestration and parser engine are all OURS.
     The caller uses it as an async context manager (`__aenter__()` -> `.appliances`).
+
+    `enable_mqtt=False` skips the AWS IoT realtime push and `minimal=True` skips the
+    per-appliance command/attribute/statistics loads: the config-flow validation uses
+    both so it only authenticates and counts the appliances, instead of doing the full
+    (and far slower / more fragile) runtime setup (issue #30).
 
     Lazy import of `NativeHon`: avoids the cycle (session.py imports this module) and
     keeps `factory` importable dry (`NativeHon` pulls in awscrt via MQTT).
     """
     from .session import NativeHon
 
-    return NativeHon(email=email, password=password)
+    return NativeHon(
+        email=email, password=password, enable_mqtt=enable_mqtt, minimal=minimal
+    )
 
 
 def _native_engine_appliance_cls() -> Any:

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -26,6 +26,7 @@ from . import factory
 from .transport.api import HonApi
 from .transport.auth import NativeAuthError
 from .transport.connection import HonConnection
+from ..debug_utils import redact_identity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,9 +109,14 @@ class NativeHon:
             await appliance.load_statistics()
         except (KeyError, ValueError, IndexError) as error:
             # An appliance with malformed data must not break the others; it is
-            # kept anyway (partial state) and logged.
+            # kept anyway (partial state) and logged. appliance_data is the RAW
+            # device dict (macAddress/serialNumber in cleartext) and this ERROR is
+            # never gated by the debug toggles -> it lands in home-assistant.log,
+            # the file users attach to issues. Redact identity before logging (the
+            # traceback carries no credentials, so _LOGGER.exception stays). The
+            # full (redacted) dict is available via Download Diagnostics.
             _LOGGER.exception(error)
-            _LOGGER.error("Device data - %s", appliance_data)
+            _LOGGER.error("Device data - %s", redact_identity(appliance_data))
         self._appliances.append(appliance)
 
     async def setup(self) -> None:

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -26,7 +26,6 @@ from . import factory
 from .transport.api import HonApi
 from .transport.auth import NativeAuthError
 from .transport.connection import HonConnection
-from ..debug_utils import redact_identity
 from ..error_codes import APPLIANCE_DATA_MALFORMED
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,9 +118,67 @@ class NativeHon:
             raise
         return self
 
+    # Exception families raised while building/loading ONE appliance from cloud
+    # data: the original (KeyError, ValueError, IndexError) plus TypeError and
+    # AttributeError -- a non-dict element's .get(), a malformed info["attributes"]
+    # comprehension in the constructor ({v["parName"]: v["parValue"] ...}), or
+    # load_attributes() popping a non-dict "shadow"/"parameters". Deliberately NOT
+    # Exception/BaseException: a genuine transport/auth error must still bubble to the
+    # setup classifier, and asyncio.CancelledError (a BaseException) must propagate so
+    # a cancelled setup is never mistaken for malformed data and swallowed.
+    _APPLIANCE_BUILD_ERRORS = (KeyError, ValueError, IndexError, TypeError, AttributeError)
+
+    def _log_malformed(self, error: BaseException, appliance_data: Any) -> None:
+        # A malformed appliance must not break the others (CR#2): it is logged and
+        # skipped (no usable object) or kept-partial (load failure). This ERROR is
+        # NEVER gated by the debug toggles -> it lands in home-assistant.log (the file
+        # users attach to issues), so it must be LEAK-PROOF BY CONSTRUCTION. Malformed
+        # cloud data hides identity where key-name redaction cannot reach it -- a
+        # serial as an attributes[].parValue (the real hOn shape), a MAC as a nested
+        # key, or an identity as the value of a benign key (e.g. zone) -- and the
+        # exception message itself echoes the offending raw value (int("AA:BB:..")
+        # -> "invalid literal for int(): 'AA:BB:..'"). So we log ONLY non-identity
+        # STRUCTURE: the exception TYPE name and the top-level field NAMES present
+        # (cloud schema names, not values) -- never a value, the raw dict, or the
+        # exception message/traceback. The full redacted dict (for the maintainer) is
+        # available via Download Diagnostics, which redacts at a different layer.
+        if isinstance(appliance_data, dict):
+            _LOGGER.error(
+                "[%s] Malformed appliance skipped (%s): fields=%s",
+                APPLIANCE_DATA_MALFORMED.label,
+                type(error).__name__,
+                # str() the keys BEFORE sorting: this logger runs inside the except
+                # handlers, so it must NEVER raise (a raise would escape and abort the
+                # whole setup loop -- the exact failure CR#2 fixes). sorted() on
+                # mixed-type keys raises TypeError; cloud JSON keys are always str so
+                # this is belt-and-suspenders, but the boundary must hold by construction.
+                sorted(map(str, appliance_data.keys())),
+            )
+        else:
+            _LOGGER.error(
+                "[%s] Malformed appliance skipped (%s): non-dict element type=%s",
+                APPLIANCE_DATA_MALFORMED.label,
+                type(error).__name__,
+                type(appliance_data).__name__,
+            )
+
     async def _create_appliance(self, appliance_data: dict, zone: int = 0) -> None:
-        appliance = factory.create_appliance(self._api, appliance_data, zone=zone)
-        if appliance.mac_address == "":
+        # Per-appliance fault boundary (CR#2 -- distinct from the steady-state
+        # coordinator/polling resilience): a single malformed device must be
+        # logged-and-skipped so the OTHER appliances still load and setup completes.
+        #
+        # CONSTRUCTION failures leave no usable object -> SKIP (do not append).
+        # factory.create_appliance runs HonAppliance.__init__, which flattens
+        # info["attributes"] and raises TypeError/KeyError on a bad shape; this ran
+        # BEFORE the per-device try in the old code, so it aborted setup of ALL
+        # appliances. mac_address is read here too (a property over the parsed info).
+        try:
+            appliance = factory.create_appliance(self._api, appliance_data, zone=zone)
+            mac_empty = appliance.mac_address == ""
+        except self._APPLIANCE_BUILD_ERRORS as error:
+            self._log_malformed(error, appliance_data)
+            return
+        if mac_empty:
             return
         if self._minimal:
             # Validation only: the appliance is built (so .appliances is populated and
@@ -133,20 +190,13 @@ class NativeHon:
             await appliance.load_commands()
             await appliance.load_attributes()
             await appliance.load_statistics()
-        except (KeyError, ValueError, IndexError) as error:
-            # An appliance with malformed data must not break the others; it is
-            # kept anyway (partial state) and logged. appliance_data is the RAW
-            # device dict (macAddress/serialNumber in cleartext) and this ERROR is
-            # never gated by the debug toggles -> it lands in home-assistant.log,
-            # the file users attach to issues. Redact identity before logging (the
-            # traceback carries no credentials, so _LOGGER.exception stays). The
-            # full (redacted) dict is available via Download Diagnostics.
-            _LOGGER.exception(error)
-            _LOGGER.error(
-                "[%s] Device data - %s",
-                APPLIANCE_DATA_MALFORMED.label,
-                redact_identity(appliance_data),
-            )
+        except self._APPLIANCE_BUILD_ERRORS as error:
+            # LOAD failure: the appliance object EXISTS but its data is partial. Keep
+            # it appended (partial state -- the shipped behavior) and log. Broadened
+            # from (KeyError, ValueError, IndexError) to also catch AttributeError
+            # (load_attributes pops a non-dict "shadow" then .get on it) and TypeError,
+            # which previously escaped this catch and aborted the whole loop.
+            self._log_malformed(error, appliance_data)
         self._appliances.append(appliance)
 
     async def setup(self) -> None:
@@ -154,7 +204,27 @@ class NativeHon:
         appliances = await self.api.load_appliances()
         self._setup_phase = "load_appliance"
         for appliance in appliances:
-            if (zones := int(appliance.get("zone", "0"))) > 1:
+            # Guard a non-dict element BEFORE appliance.get(...)/appliance.copy() can
+            # raise AttributeError: parse_appliance_list returns the cloud list
+            # verbatim with no per-element dict guarantee, so a schema-drift entry must
+            # be logged-and-skipped, not abort the whole loop (CR#2).
+            if not isinstance(appliance, dict):
+                self._log_malformed(
+                    TypeError(
+                        f"appliance entry is {type(appliance).__name__}, expected dict"
+                    ),
+                    appliance,
+                )
+                continue
+            # Zone parse is INSIDE the per-appliance boundary: a non-numeric "zone"
+            # raises ValueError (or TypeError on a non-str/int), which must skip only
+            # this device, not the rest.
+            try:
+                zones = int(appliance.get("zone", "0"))
+            except (TypeError, ValueError) as error:
+                self._log_malformed(error, appliance)
+                continue
+            if zones > 1:
                 for zone in range(zones):
                     await self._create_appliance(appliance.copy(), zone=zone + 1)
             await self._create_appliance(appliance)

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -27,6 +27,7 @@ from .transport.api import HonApi
 from .transport.auth import NativeAuthError
 from .transport.connection import HonConnection
 from ..debug_utils import redact_identity
+from ..error_codes import APPLIANCE_DATA_MALFORMED
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class NativeHon:
         mobile_id: str = "",
         refresh_token: str = "",
         enable_mqtt: bool = True,
+        minimal: bool = False,
     ) -> None:
         self._email = email
         self._password = password
@@ -54,11 +56,18 @@ class NativeHon:
         self._mobile_id = mobile_id
         self._refresh_token = refresh_token
         self._enable_mqtt = enable_mqtt
+        # minimal=True (config-flow validation): authenticate + load_appliances only,
+        # skip the per-appliance command/attribute/statistics loads (issue #30). The
+        # full setup runs at runtime (minimal=False).
+        self._minimal = minimal
         self._connection: HonConnection | None = None
         self._api: HonApi | None = None
         self._appliances: list[Any] = []
         self._mqtt_client: Any = None
         self._notify_function: Any = None
+        # Coarse setup phase, read by HonClient when the dedicated-loop 60s cap fires
+        # to attribute the (otherwise message-less) timeout to a stable error code.
+        self._setup_phase: str = ""
 
     async def __aenter__(self) -> "NativeHon":
         return await self.create()
@@ -114,6 +123,12 @@ class NativeHon:
         appliance = factory.create_appliance(self._api, appliance_data, zone=zone)
         if appliance.mac_address == "":
             return
+        if self._minimal:
+            # Validation only: the appliance is built (so .appliances is populated and
+            # the config flow can count + type it) but its per-appliance loads are
+            # skipped (issue #30); the full hydrate happens at runtime.
+            self._appliances.append(appliance)
+            return
         try:
             await appliance.load_commands()
             await appliance.load_attributes()
@@ -127,11 +142,17 @@ class NativeHon:
             # traceback carries no credentials, so _LOGGER.exception stays). The
             # full (redacted) dict is available via Download Diagnostics.
             _LOGGER.exception(error)
-            _LOGGER.error("Device data - %s", redact_identity(appliance_data))
+            _LOGGER.error(
+                "[%s] Device data - %s",
+                APPLIANCE_DATA_MALFORMED.label,
+                redact_identity(appliance_data),
+            )
         self._appliances.append(appliance)
 
     async def setup(self) -> None:
+        self._setup_phase = "load_appliances"
         appliances = await self.api.load_appliances()
+        self._setup_phase = "load_appliance"
         for appliance in appliances:
             if (zones := int(appliance.get("zone", "0"))) > 1:
                 for zone in range(zones):
@@ -139,6 +160,9 @@ class NativeHon:
             await self._create_appliance(appliance)
         if self._enable_mqtt and not self._mqtt_client:
             self._mqtt_client = await self._make_mqtt()
+        # Setup done: clear the phase so a later (non-setup) loop timeout is not
+        # mis-attributed to a setup step.
+        self._setup_phase = ""
 
     async def _make_mqtt(self) -> Any:
         # Lazy import: transport.mqtt imports awscrt/awsiot (absent dry/CI).

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -88,15 +88,26 @@ class NativeHon:
         self._appliances = appliances
 
     async def create(self) -> "NativeHon":
-        self._connection = await HonConnection(
-            self._email,
-            self._password,
-            session=self._session,
-            mobile_id=self._mobile_id,
-            refresh_token=self._refresh_token,
-        ).create()
-        self._api = HonApi(self._connection)
-        await self.setup()
+        try:
+            self._connection = await HonConnection(
+                self._email,
+                self._password,
+                session=self._session,
+                mobile_id=self._mobile_id,
+                refresh_token=self._refresh_token,
+            ).create()
+            self._api = HonApi(self._connection)
+            await self.setup()
+        except BaseException:
+            # setup() makes the first HTTP calls (and may start MQTT) and can raise
+            # (network/auth). When a caller uses `async with NativeHon(...)`, a failure
+            # in __aenter__/create() means __aexit__ is NEVER run, so close() would not
+            # fire and the owned aiohttp.ClientSession (+ any started MQTT client) would
+            # leak. Tear down here (close() is idempotent); BaseException so a cancelled
+            # setup also cleans up, and re-raise to preserve the original error. (#31,
+            # symmetric to the #21 guard on NativeMqttClient.create().)
+            await self.close()
+            raise
         return self
 
     async def _create_appliance(self, appliance_data: dict, zone: int = 0) -> None:
@@ -145,8 +156,22 @@ class NativeHon:
     async def close(self) -> None:
         # Stop the MQTT BEFORE the connection (the watchdog must not retry on
         # a session being closed); we close it to avoid leaking it.
+        #
+        # Best-effort + idempotent: close() runs on normal teardown AND from the
+        # create() failure path, so (a) a cleanup error must NEVER mask the original
+        # setup exception being re-raised (it would flip the config-entry
+        # classification, e.g. hide a reauth-needed error), and (b) a second close()
+        # (setup_sync also calls it after a failed create()) must be a no-op. Each step
+        # is guarded and the reference is cleared before awaiting.
         if self._mqtt_client is not None:
-            await self._mqtt_client.stop()
-            self._mqtt_client = None
+            mqtt, self._mqtt_client = self._mqtt_client, None
+            try:
+                await mqtt.stop()
+            except Exception:  # noqa: BLE001 - cleanup must not mask the real error
+                _LOGGER.debug("addhOn: MQTT stop during close failed", exc_info=True)
         if self._api is not None:
-            await self._api.close()
+            api, self._api = self._api, None
+            try:
+                await api.close()
+            except Exception:  # noqa: BLE001 - cleanup must not mask the real error
+                _LOGGER.debug("addhOn: api close during close failed", exc_info=True)

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from pprint import pformat
 from typing import Any
 
 from . import device as _device
 from .connection import HonConnection
 from .parse import parse_appliance_list
+from ...debug_utils import redact_identity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class HonApi:
                 sorted(result.keys()) if isinstance(result, dict) else "n/a",
                 sorted(modules.keys()) if isinstance(modules, dict) else "n/a",
             )
-            _LOGGER.debug("hOn raw appliance response: %s", result)
+            _LOGGER.debug("hOn raw appliance response: %s", redact_identity(result))
         return appliances
 
     async def load_commands(self, appliance: Any) -> dict:
@@ -234,8 +234,19 @@ class HonApi:
             payload = json_data.get("payload") if isinstance(json_data, dict) else None
             if isinstance(payload, dict) and payload.get("resultCode") == "0":
                 return True
-            _LOGGER.error("hOn send_command failed: %s", await response.text())
-            _LOGGER.error("%s - Payload:\n%s", url, pformat(data))
+            # The request payload (data) carries macAddress, transactionId (= MAC)
+            # and device.mobileId; the response may echo them too. Log only the
+            # command + resultCode at ERROR (no identity, always emitted), and the
+            # full REDACTED payload/response at DEBUG (gated) for troubleshooting.
+            result_code = payload.get("resultCode") if isinstance(payload, dict) else None
+            _LOGGER.error(
+                "hOn send_command failed: command=%s resultCode=%s", command, result_code
+            )
+            _LOGGER.debug(
+                "hOn send_command failed payload (redacted)=%s response=%s",
+                redact_identity(data),
+                redact_identity(json_data),
+            )
         return False
 
     async def close(self) -> None:

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -112,10 +112,12 @@ class HonApi:
         # below REMOVES resultCode from the returned dict (the parser does not want it
         # in the command entries) while validating it.
         if not isinstance(payload, dict) or not payload:
-            _LOGGER.error("hOn load_commands: invalid payload: %s", data)
+            # data is the raw cloud response (mirrors the device context: macAddress,
+            # etc.) and this ERROR is never gated -> redact identity before logging.
+            _LOGGER.error("hOn load_commands: invalid payload: %s", redact_identity(data))
             return {}
         if payload.pop("resultCode", None) != "0":
-            _LOGGER.error("hOn load_commands: resultCode != 0: %s", data)
+            _LOGGER.error("hOn load_commands: resultCode != 0: %s", redact_identity(data))
             return {}
         return payload
 

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -72,7 +72,7 @@ class HonApi:
             f"{API_URL}/unified-api/v1/view/appliance-list",
             json={"deviceId": device_id},
         ) as resp:
-            result = await resp.json()
+            result = await resp.json(content_type=None)
         appliances = parse_appliance_list(result)
         if not appliances:
             # Request/auth OK but 0 appliances: log the response structure to
@@ -106,7 +106,7 @@ class HonApi:
             params["series"] = series
         url = f"{API_URL}/commands/v1/retrieve"
         async with self._connection.get(url, params=params) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
         payload = data.get("payload") if isinstance(data, dict) else None
         # Error-branch on any invalid shape (non-dict or empty payload) -> {}. The pop
         # below REMOVES resultCode from the returned dict (the parser does not want it
@@ -122,7 +122,7 @@ class HonApi:
     async def load_command_history(self, appliance: Any) -> list:
         url = f"{API_URL}/commands/v1/appliance/{appliance.mac_address}/history"
         async with self._connection.get(url) as response:
-            result = await response.json()
+            result = await response.json(content_type=None)
         if not isinstance(result, dict) or not result.get("payload"):
             return []
         payload = result["payload"]
@@ -132,7 +132,7 @@ class HonApi:
     async def load_favourites(self, appliance: Any) -> list:
         url = f"{API_URL}/commands/v1/appliance/{appliance.mac_address}/favourite"
         async with self._connection.get(url) as response:
-            result = await response.json()
+            result = await response.json(content_type=None)
         if not isinstance(result, dict) or not result.get("payload"):
             return []
         payload = result["payload"]
@@ -143,7 +143,7 @@ class HonApi:
         url = f"{API_URL}/commands/v1/retrieve-last-activity"
         params = {"macAddress": appliance.mac_address}
         async with self._connection.get(url, params=params) as response:
-            result = await response.json()
+            result = await response.json(content_type=None)
         if isinstance(result, dict):
             activity = result.get("attributes")
             if isinstance(activity, dict) and activity:
@@ -154,7 +154,7 @@ class HonApi:
         url = f"{API_URL}/commands/v1/appliance-model"
         params = {"code": appliance.code, "macAddress": appliance.mac_address}
         async with self._connection.get(url, params=params) as response:
-            result = await response.json()
+            result = await response.json(content_type=None)
         if isinstance(result, dict):
             payload = result.get("payload")
             if isinstance(payload, dict):
@@ -170,7 +170,7 @@ class HonApi:
         }
         url = f"{API_URL}/commands/v1/context"
         async with self._connection.get(url, params=params) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
         payload = data.get("payload", {}) if isinstance(data, dict) else {}
         return payload if isinstance(payload, dict) else {}
 
@@ -181,7 +181,7 @@ class HonApi:
         }
         url = f"{API_URL}/commands/v1/statistics"
         async with self._connection.get(url, params=params) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
         payload = data.get("payload", {}) if isinstance(data, dict) else {}
         return payload if isinstance(payload, dict) else {}
 
@@ -189,14 +189,14 @@ class HonApi:
         url = f"{API_URL}/commands/v1/maintenance-cycle"
         params = {"macAddress": appliance.mac_address}
         async with self._connection.get(url, params=params) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
         payload = data.get("payload", {}) if isinstance(data, dict) else {}
         return payload if isinstance(payload, dict) else {}
 
     async def load_aws_token(self) -> str:
         url = f"{API_URL}/auth/v1/introspection"
         async with self._connection.get(url) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
         payload = data.get("payload", {}) if isinstance(data, dict) else {}
         token = payload.get("tokenSigned", "") if isinstance(payload, dict) else ""
         return token if isinstance(token, str) else ""
@@ -230,7 +230,7 @@ class HonApi:
             data["programName"] = program_name.upper()
         url = f"{API_URL}/commands/v1/send"
         async with self._connection.post(url, json=data) as response:
-            json_data = await response.json()
+            json_data = await response.json(content_type=None)
             payload = json_data.get("payload") if isinstance(json_data, dict) else None
             if isinstance(payload, dict) and payload.get("resultCode") == "0":
                 return True

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -29,6 +29,7 @@ from . import device as _device
 from .connection import HonConnection
 from .parse import parse_appliance_list
 from ...debug_utils import redact_identity
+from ...error_codes import APPLIANCE_LIST_EMPTY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,9 +81,10 @@ class HonApi:
             # unified-api list includes offline ones too).
             modules = result.get("modules") if isinstance(result, dict) else None
             _LOGGER.warning(
-                "hOn API: 0 appliances (request OK). result keys=%s; modules keys=%s. "
+                "[%s] hOn API: 0 appliances (request OK). result keys=%s; modules keys=%s. "
                 "If the appliances appear in the hOn app, it is more likely an API change "
                 "than an empty/unshared account.",
+                APPLIANCE_LIST_EMPTY.label,
                 sorted(result.keys()) if isinstance(result, dict) else "n/a",
                 sorted(modules.keys()) if isinstance(modules, dict) else "n/a",
             )

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -216,9 +216,21 @@ class HonAuth:
             if resp.status >= 400:
                 return False
             data = await resp.json(content_type=None)
+        # A malformed 2xx (no id_token/access_token) must NOT raise KeyError: treat
+        # it as a failed refresh so the caller falls back to authenticate(). Do not
+        # touch _expires before validating, or a fake refresh would mask expiry.
+        id_token = data.get("id_token") if isinstance(data, dict) else None
+        access_token = data.get("access_token") if isinstance(data, dict) else None
+        if not id_token or not access_token:
+            _LOGGER.warning("addhOn: refresh response missing tokens; treating as failure")
+            return False
         self._expires = datetime.now(timezone.utc)
-        self.id_token = data["id_token"]
-        self.access_token = data["access_token"]
+        self.id_token = id_token
+        self.access_token = access_token
+        # Honour refresh_token rotation: if the IdP returned a new one, persist it
+        # (otherwise the old token is reused and a future refresh would fail).
+        if new_refresh := (data.get("refresh_token") if isinstance(data, dict) else None):
+            self.refresh_token = new_refresh
         await self._api_auth()
         return True
 

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -58,6 +58,13 @@ class HonConnection:
         # replaces. Instantiated here (not in create()) so concurrent coroutines
         # share the same lock.
         self._refresh_lock = asyncio.Lock()
+        # Monotonic counter, bumped (under _refresh_lock) on every successful
+        # refresh/authenticate by BOTH the pre-request path (_check_headers) and the
+        # 401/403 retry path (_refresh_after_rejection). Each request snapshots it
+        # when it sends; the retry recovery refreshes only if the gen is unchanged ->
+        # a concurrent burst collapses to a single refresh without gating on
+        # token_expires_soon (a non-expiry 401 must still refresh once). See CR#3.
+        self._refresh_gen = 0
 
     @property
     def device(self) -> HonDevice:
@@ -115,20 +122,50 @@ class HonConnection:
                 if _need_refresh():
                     await self.auth.refresh(self._refresh_token)
                     self._refresh_token = self.auth.refresh_token
+                    self._refresh_gen += 1
                 if _need_auth():
                     await self.auth.authenticate()
                     self._refresh_token = self.auth.refresh_token
+                    self._refresh_gen += 1
         return build_auth_headers(self.auth.cognito_token, self.auth.id_token, headers)
+
+    async def _refresh_after_rejection(self, gen_at_send: int) -> None:
+        # 401/403 recovery refresh, single-flighted under the SAME lock as the
+        # pre-request path (CR#3). Without the lock a concurrent-request burst (e.g.
+        # command_loader's asyncio.gather) that all 401 would each fire a refresh on
+        # the same rotating, possibly single-use refresh_token. `gen_at_send` is the
+        # refresh generation captured when THIS request was sent: under the lock we
+        # refresh only if no sibling (pre-request OR retry) has refreshed since, so the
+        # burst collapses to exactly one refresh -- yet a genuine non-expiry 401 still
+        # refreshes once (we do NOT gate on token_expires_soon). Copy the (possibly
+        # rotated) refresh_token back so a later refresh/persist uses the current one
+        # (the missing copy-back let a stale token re-stale auth and force a re-login).
+        #
+        # The lock is RELEASED on return, BEFORE the caller's recursive _intercept,
+        # which re-acquires it via _check_headers -- asyncio.Lock is not reentrant, so
+        # holding it across the recursion would deadlock.
+        async with self._refresh_lock:
+            if self._refresh_gen != gen_at_send:
+                return  # a sibling already refreshed; reuse its fresh tokens
+            await self.auth.refresh(self._refresh_token)
+            self._refresh_token = self.auth.refresh_token
+            self._refresh_gen += 1
 
     @asynccontextmanager
     async def _intercept(
         self, method, url: Any, *args: Any, loop: int = 0, **kwargs: Any
     ) -> AsyncIterator[aiohttp.ClientResponse]:
         kwargs["headers"] = await self._check_headers(kwargs.get("headers", {}))
+        # Generation of the token these headers carry: if a concurrent request (the
+        # pre-request path or another 401 retry) refreshes before our recovery runs,
+        # the gen advances and _refresh_after_rejection skips a redundant, token-
+        # consuming refresh (CR#3). Snapshot BEFORE sending so it reflects the token
+        # that may get rejected, not one a sibling rotated to meanwhile.
+        refresh_gen = self._refresh_gen
         async with method(url, *args, **kwargs) as response:
             if (self.auth.token_expires_soon or response.status in (401, 403)) and loop == 0:
                 _LOGGER.info("addhOn: token expiring/%s, refresh", response.status)
-                await self.auth.refresh(self._refresh_token)
+                await self._refresh_after_rejection(refresh_gen)
                 async with self._intercept(method, url, *args, loop=1, **kwargs) as result:
                     yield result
             elif (self.auth.token_is_expired or response.status in (401, 403)) and loop == 1:

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -69,7 +69,14 @@ class HonConnection:
     async def create(self) -> "HonConnection":
         if self._session is None:
             self._session = aiohttp.ClientSession()
-        self._auth = HonAuth(self._session, self._email, self._password, self._device)
+        try:
+            self._auth = HonAuth(self._session, self._email, self._password, self._device)
+        except BaseException:
+            # We just created (and own) the ClientSession; if anything after that fails
+            # a failed create() must not leak it. close() only closes a session WE own
+            # (a caller-supplied session is left alone). (#31 root, defense in depth.)
+            await self.close()
+            raise
         return self
 
     async def _check_headers(self, headers: dict) -> dict:

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -23,6 +23,15 @@ from .headers import build_auth_headers
 
 _LOGGER = logging.getLogger(__name__)
 
+# Per-request HTTP timeouts on the session WE own. Without them aiohttp defaults to
+# a 300s total, so a dead/blocked endpoint (e.g. api-iot.he.services or AWS IoT
+# unreachable on the user's network) only failed when the 60s dedicated-loop cap
+# fired, as an opaque message-less timeout (issue #30). These bound each request
+# well under that cap, so a stuck endpoint fails fast and attributable.
+_CONNECT_TIMEOUT = 10  # TCP connect + TLS handshake to one endpoint
+_TOTAL_TIMEOUT = 30  # whole request incl. response read
+_SOCK_READ_TIMEOUT = 20  # gap between received chunks
+
 
 class HonConnection:
     """Authenticated HTTP session: creates/owns aiohttp.ClientSession + HonAuth."""
@@ -68,7 +77,14 @@ class HonConnection:
 
     async def create(self) -> "HonConnection":
         if self._session is None:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(
+                    total=_TOTAL_TIMEOUT,
+                    connect=_CONNECT_TIMEOUT,
+                    sock_connect=_CONNECT_TIMEOUT,
+                    sock_read=_SOCK_READ_TIMEOUT,
+                )
+            )
         try:
             self._auth = HonAuth(self._session, self._email, self._password, self._device)
         except BaseException:

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -8,6 +8,7 @@ Happy path validated live; the retry branches have offline tests with a mocked s
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -41,6 +42,13 @@ class HonConnection:
         self._owns_session = session is None
         self._session = session
         self._auth: HonAuth | None = None
+        # Serializes token refresh/authenticate across concurrent requests (e.g.
+        # the asyncio.gather burst in load_commands): without it, N parallel
+        # _check_headers would each fire a refresh on the SAME refresh_token.
+        # Lives on the connection (stable owner), NOT on HonAuth which create()
+        # replaces. Instantiated here (not in create()) so concurrent coroutines
+        # share the same lock.
+        self._refresh_lock = asyncio.Lock()
 
     @property
     def device(self) -> HonDevice:
@@ -65,13 +73,28 @@ class HonConnection:
         return self
 
     async def _check_headers(self, headers: dict) -> dict:
-        # If I have a refresh_token I try to refresh, otherwise (or if the tokens
-        # are missing) I log in; then I inject the tokens.
-        if self._refresh_token:
-            await self.auth.refresh(self._refresh_token)
-        if not (self.auth.cognito_token and self.auth.id_token):
-            await self.auth.authenticate()
-        self._refresh_token = self.auth.refresh_token
+        # Refresh ONLY when needed: no usable token in RAM (first request, or a
+        # restart with a persisted refresh_token) OR the token is near expiry.
+        # Previously this refreshed on EVERY request (#1) and recursed into a
+        # second refresh on 401 (#14). The 401 recovery lives in _intercept and is
+        # untouched. The lock + re-check (double-checked locking) collapses a burst
+        # of concurrent requests into a single refresh/authenticate (#race), so a
+        # rotating IdP cannot invalidate the shared refresh_token mid-flight.
+        def _need_refresh() -> bool:
+            have_tokens = bool(self.auth.cognito_token and self.auth.id_token)
+            return bool(self._refresh_token) and (not have_tokens or self.auth.token_expires_soon)
+
+        def _need_auth() -> bool:
+            return not (self.auth.cognito_token and self.auth.id_token)
+
+        if _need_refresh() or _need_auth():
+            async with self._refresh_lock:
+                if _need_refresh():
+                    await self.auth.refresh(self._refresh_token)
+                    self._refresh_token = self.auth.refresh_token
+                if _need_auth():
+                    await self.auth.authenticate()
+                    self._refresh_token = self.auth.refresh_token
         return build_auth_headers(self.auth.cognito_token, self.auth.id_token, headers)
 
     @asynccontextmanager

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -53,6 +53,16 @@ _RECONNECT_AFTER_FAILED_TICKS = 3
 # rebuild failures, so a persistent 5xx from the AWS authorizer is not hammered
 # every tick. Reset to 0 on recovery; never masks (each failure still logs WARNING).
 _RECONNECT_BACKOFF_CAP = 60
+# Consecutive in-place re-subscribe FAILURES (transport reports connected, but the
+# SUBACK keeps stalling) before the watchdog stops retrying the subscribe and escalates
+# to a full _start() rebuild. A half-open socket awscrt still believes is connected, or
+# a stale/revoked AWS custom-authorizer session that never fires a disconnection
+# callback: WITHOUT this cap the connected-but-unsubscribed branch never yields to the
+# rebuild path, so the in-place re-subscribe loops forever and NEVER refreshes the AWS
+# token / tears down the dead client (only _start() does that). Hitting the cap routes
+# to a full rebuild PROMPTLY -- skipping the _RECONNECT_AFTER_FAILED_TICKS grace wait,
+# since this connection is already known dead. Reset to 0 on ANY successful subscribe.
+_MAX_RESUBSCRIBE_FAILURES = 3
 
 
 def _subscribed_topics(appliance) -> list:
@@ -78,6 +88,20 @@ class NativeMqttClient:
         self._appliances = hon.appliances
         self._client: mqtt5.Client | None = None
         self._connection = False
+        # Distinct from _connection: tracks whether _subscribe_appliances() last
+        # completed without raising. _connection ("transport connected", set by the
+        # awscrt connection-success callback) and "appliance topics actually
+        # subscribed" are TWO states; conflating them made the watchdog treat a
+        # connected-but-unsubscribed client as healthy and stop rebuilding, so realtime
+        # pushes were silently dead until the next full AWS IoT disconnect (the 60s HTTP
+        # poll masks it). Two failure modes leave us connected-but-unsubscribed:
+        #   1. a rebuild whose _subscribe_appliances() hits _SUBSCRIBE_TIMEOUT (success
+        #      callback already flipped _connection=True before the SUBACK stalled);
+        #   2. awscrt's own auto-reconnect after a transient blip -- AWS IoT custom-
+        #      authorizer websocket sessions are clean (no session_behavior is set in
+        #      _start(), so subscriptions are NOT restored across a reconnect).
+        # Both are recovered by the watchdog: see _watchdog().
+        self._subscribed = False
         # Bumped on every _start(): the state-mutating lifecycle callbacks are bound
         # to the generation of the client that registered them, so a late event from a
         # client we already stopped cannot flip self._connection on the new one (awscrt
@@ -106,8 +130,18 @@ class NativeMqttClient:
         try:
             self._set_setup_phase("mqtt_connect")
             await self._start()
+            gen = self._generation
             self._set_setup_phase("mqtt_subscribe")
             await self._subscribe_appliances()
+            # Subscriptions are now in place: mark healthy so the watchdog does not
+            # treat the initial connect as connected-but-unsubscribed (see _watchdog).
+            # Re-check connection AND generation AFTER the await, not unconditionally:
+            # a disconnection callback (on the awscrt thread) can fire mid-subscribe and
+            # set _connection=_subscribed=False; an unconditional `= True` here would
+            # clobber that back, leaving a stuck "healthy on a dropped session" state
+            # (the exact bug class this flag exists to kill). gen == _generation also
+            # guards against a rebuild landing during the await.
+            self._subscribed = self._connection and (gen == self._generation)
             await self._start_watchdog()
         except BaseException:
             # _start() has already started the awscrt client; if a later step fails
@@ -178,6 +212,10 @@ class NativeMqttClient:
         if self._is_stale_generation(generation):
             return
         self._connection = False
+        # A failed/dropped connection loses all subscriptions (clean session): clear
+        # the flag so the watchdog re-subscribes once awscrt reconnects. The generation
+        # guard above already prevents a late event from an old client clearing it.
+        self._subscribed = False
         _LOGGER.info("Lifecycle Connection Failure: %s", data)
 
     def _on_lifecycle_disconnection(
@@ -186,6 +224,9 @@ class NativeMqttClient:
         if self._is_stale_generation(generation):
             return
         self._connection = False
+        # See _on_lifecycle_connection_failure: a disconnect drops subscriptions, so
+        # the watchdog must re-establish them after the auto-reconnect.
+        self._subscribed = False
         _LOGGER.info("Lifecycle Disconnection: %s", data)
 
     def _on_publish_received(self, data: "mqtt5.PublishReceivedData") -> None:
@@ -290,6 +331,10 @@ class NativeMqttClient:
             except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
             self._client = None
+        # A fresh client carries over no subscriptions: clear the flag here (the caller
+        # -- create() or the watchdog rebuild path -- sets it True only after
+        # _subscribe_appliances() succeeds).
+        self._subscribed = False
         # Tag this client's state-mutating callbacks with a fresh generation so a late
         # event from the client just stopped cannot flip self._connection (see
         # _is_stale_generation).
@@ -345,31 +390,112 @@ class NativeMqttClient:
     async def _watchdog(self) -> None:
         failed_ticks = 0
         backoff = 0
+        # Consecutive in-place re-subscribe FAILURES (Issue 1): a transport that awscrt
+        # keeps reporting connected but whose SUBACK never lands (half-open socket /
+        # stale custom-authorizer session that never fires a disconnection callback)
+        # would otherwise loop the in-place re-subscribe forever and never refresh the
+        # AWS token via _start(). After _MAX_RESUBSCRIBE_FAILURES we escalate to a full
+        # rebuild. Reset to 0 on ANY successful subscribe (re-subscribe or rebuild).
+        resubscribe_failures = 0
         while True:
             # The rebuild (load_aws_token / subscribe) can raise transiently; without
             # this guard one exception would end the task and kill realtime until a
             # reload. Re-raise CancelledError FIRST (stop() cancels+awaits us, so
             # swallowing it would deadlock shutdown); on any other error log and keep
-            # looping with an additive backoff (capped, reset on recovery).
+            # looping with an additive backoff (capped, reset on recovery). A re-subscribe
+            # failure (Issue 1) increments resubscribe_failures via attempted_resubscribe.
+            attempted_resubscribe = False
             try:
                 await asyncio.sleep(_WATCHDOG_INTERVAL + backoff)
-                if self._connection:
+                # Healthy ONLY when the transport is connected AND the appliance topics
+                # are subscribed. Checking _connection alone treated a connected-but-
+                # unsubscribed client as healthy and stopped rebuilding (the original
+                # bug), so realtime pushes died silently until the next full disconnect.
+                if self._connection and self._subscribed:
                     failed_ticks = 0
                     backoff = 0
+                    resubscribe_failures = 0
                     continue
-                # Sustained downtime only: give awscrt's own auto-reconnect a chance
-                # before forcing a rebuild (see _RECONNECT_AFTER_FAILED_TICKS).
-                failed_ticks += 1
-                if failed_ticks < _RECONNECT_AFTER_FAILED_TICKS:
+                # Connected but the subscription is missing (a rebuild whose subscribe
+                # timed out, OR awscrt's own auto-reconnect on a clean session): the
+                # transport is up, so a full rebuild would needlessly tear down a working
+                # connection and re-hit the AWS authorizer endpoint. Re-subscribe in
+                # place instead -- UNLESS the in-place re-subscribe has already failed
+                # _MAX_RESUBSCRIBE_FAILURES times in a row (Issue 1): a connection awscrt
+                # still believes is up but that never SUBACKs is dead at the application
+                # layer, and only _start() can refresh the token + rebuild the client, so
+                # we fall through to the rebuild path below instead of looping forever.
+                if (
+                    self._connection
+                    and not self._subscribed
+                    and resubscribe_failures < _MAX_RESUBSCRIBE_FAILURES
+                ):
+                    _LOGGER.info("Re-subscribe mqtt topics")
+                    gen = self._generation
+                    # Mark BEFORE the await so a raise (e.g. MQTT_SUBSCRIBE_TIMEOUT)
+                    # landing in the shared `except` is counted as a re-subscribe failure
+                    # (Issue 1 escalation). It is cleared again right after a successful
+                    # subscribe so a successful tick never counts.
+                    attempted_resubscribe = True
+                    await self._subscribe_appliances()
+                    attempted_resubscribe = False
+                    # Re-check connection AND generation AFTER the await, not an
+                    # unconditional True (Issue 3): a disconnection callback can land on
+                    # the awscrt thread during the subscribe and set
+                    # _connection=_subscribed=False; clobbering it back to True here would
+                    # leave a stuck "healthy on a dropped session". gen == _generation
+                    # also rejects a rebuild that landed mid-await.
+                    self._subscribed = self._connection and (gen == self._generation)
+                    if not self._subscribed:
+                        # The connection dropped (or a new client generation landed)
+                        # during the subscribe: do NOT treat this tick as a recovery.
+                        # Leave the counters untouched and let the next tick's
+                        # not-connected path count the outage normally.
+                        continue
+                    resubscribe_failures = 0  # subscribe succeeded
+                    # Issue 2: a genuine recovery resets the outage counters, same as the
+                    # healthy branch. Leaving failed_ticks set across a successful
+                    # re-subscribe would force a full rebuild one tick early on a flapping
+                    # connection, breaking the _RECONNECT_AFTER_FAILED_TICKS contract.
+                    failed_ticks = 0
+                    backoff = 0  # re-subscribe succeeded
                     continue
+                # Not connected (or re-subscribe escalated to a rebuild): sustained
+                # downtime only forces a rebuild. Give awscrt's own auto-reconnect a
+                # chance first (see _RECONNECT_AFTER_FAILED_TICKS) -- but an escalation
+                # (resubscribe_failures exceeded) skips the wait, the connection is
+                # already known dead.
+                escalated = (
+                    self._connection
+                    and not self._subscribed
+                    and resubscribe_failures >= _MAX_RESUBSCRIBE_FAILURES
+                )
+                if not escalated:
+                    failed_ticks += 1
+                    if failed_ticks < _RECONNECT_AFTER_FAILED_TICKS:
+                        continue
                 failed_ticks = 0
                 _LOGGER.info("Restart mqtt connection")
                 await self._start()
+                gen = self._generation
                 await self._subscribe_appliances()
+                # Rebuild + subscribe both succeeded: mark healthy. _start() reset
+                # _subscribed to False, so leaving it unset on a subscribe failure (which
+                # raises before this line) keeps the recovery loop honest. Re-check
+                # connection AND generation AFTER the await (Issue 3), not an
+                # unconditional True, so a disconnect or newer generation landing during
+                # the subscribe is not clobbered.
+                self._subscribed = self._connection and (gen == self._generation)
+                resubscribe_failures = 0  # the rebuild re-subscribed
                 backoff = 0  # rebuild succeeded
             except asyncio.CancelledError:
                 raise
             except Exception:
+                if attempted_resubscribe:
+                    # Issue 1: an in-place re-subscribe attempt raised. Count it so a
+                    # connection awscrt keeps reporting up but that never SUBACKs is
+                    # escalated to a full rebuild after _MAX_RESUBSCRIBE_FAILURES.
+                    resubscribe_failures += 1
                 backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
                 _LOGGER.warning(
                     "MQTT watchdog: reconnect failed, retrying in %ss",

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -164,42 +164,55 @@ class NativeMqttClient:
         if not isinstance(payload, dict):
             _LOGGER.debug("MQTT: non-object payload on %s: %r", topic, payload)
             return
-        # Defensive: appliance not found for this topic -> exit.
-        appliance = next(
-            (
-                a
-                for a in self._appliances
-                if topic in a.info.get("topics", {}).get("subscribe", [])
-            ),
-            None,
-        )
-        if appliance is None:
-            _LOGGER.debug("MQTT: topic with no matching appliance: %s", topic)
-            return
-        if topic and "appliancestatus" in topic:
-            params = appliance.attributes.get("parameters", {})
-            for parameter in payload.get("parameters", []):
-                name = parameter.get("parName")
-                # Only already-known parameters (seeded by load_attributes). A new
-                # parName is recovered at the next HTTP poll; creating it here would
-                # couple this transport module to the engine's HonAttribute.
-                if name in params:
-                    params[name].update(parameter)
-            appliance.sync_params_to_command("settings")
-        elif topic and "disconnected" in topic:
-            _LOGGER.info(
-                "Disconnected %s: %s",
-                appliance.nick_name,
-                payload.get("disconnectReason"),
+        # The rest also runs on the awscrt callback thread: a VALID dict payload can
+        # still make the engine raise (params[name].update, sync_params_to_command, or
+        # self._hon.notify -> an arbitrary HA callback). An unhandled exception here
+        # would crash the callback and silence every later push, so the whole body is
+        # wrapped: log at WARNING (the MQTT logger defaults to WARNING, so debug/info
+        # would be muted and would mask real engine bugs) and drop just this message.
+        # State is reconciled at the next HTTP poll, so skipping is safe and idempotent.
+        try:
+            # Defensive: appliance not found for this topic -> exit.
+            appliance = next(
+                (
+                    a
+                    for a in self._appliances
+                    if topic in a.info.get("topics", {}).get("subscribe", [])
+                ),
+                None,
             )
-            appliance.connection = False
-        elif topic and "connected" in topic:
-            appliance.connection = True
-            _LOGGER.info("Connected %s", appliance.nick_name)
-        elif topic and "discovery" in topic:
-            _LOGGER.info("Discovered %s", appliance.nick_name)
-        self._hon.notify()
-        _LOGGER.info("%s - %s", topic, payload)
+            if appliance is None:
+                _LOGGER.debug("MQTT: topic with no matching appliance: %s", topic)
+                return
+            if topic and "appliancestatus" in topic:
+                params = appliance.attributes.get("parameters", {})
+                for parameter in payload.get("parameters", []):
+                    name = parameter.get("parName")
+                    # Only already-known parameters (seeded by load_attributes). A new
+                    # parName is recovered at the next HTTP poll; creating it here would
+                    # couple this transport module to the engine's HonAttribute.
+                    if name in params:
+                        params[name].update(parameter)
+                appliance.sync_params_to_command("settings")
+            elif topic and "disconnected" in topic:
+                _LOGGER.info(
+                    "Disconnected %s: %s",
+                    appliance.nick_name,
+                    payload.get("disconnectReason"),
+                )
+                appliance.connection = False
+            elif topic and "connected" in topic:
+                appliance.connection = True
+                _LOGGER.info("Connected %s", appliance.nick_name)
+            elif topic and "discovery" in topic:
+                _LOGGER.info("Discovered %s", appliance.nick_name)
+            self._hon.notify()
+            _LOGGER.info("%s - %s", topic, payload)
+        except Exception:
+            # Broad on purpose: the body spans transport -> engine -> HA coordinator and
+            # may raise arbitrary types; we must never let one reach the awscrt thread.
+            _LOGGER.warning("MQTT: handler failed on %s", topic, exc_info=True)
+            return
 
     # -- connection / subscribe / watchdog -------------------------------------
     async def _start(self) -> None:

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -343,6 +343,18 @@ class NativeMqttClient:
         # -- create() or the watchdog rebuild path -- sets it True only after
         # _subscribe_appliances() succeeds).
         self._subscribed = False
+        # Reset _connection too so it tracks the CURRENT client: the new one is not up
+        # until ITS generation-tagged success callback fires below. A rebuild reached via
+        # the escalation branch (connected-but-unsubscribed) would otherwise carry over
+        # _connection=True from the just-stopped client. That is NOT a false-healthy
+        # (_subscribed above is already False, so the watchdog never treats it as
+        # healthy), but a rebuild whose _subscribe_appliances() then fails would leave a
+        # stale connected-but-unsubscribed state on a client that is not actually up yet,
+        # sending the next tick down the in-place re-subscribe path against a dead client
+        # instead of rebuilding. The only late callback the stopped client can still emit
+        # is a disconnection (-> False), never a spurious success, and the generation bump
+        # below rejects every other stale event; so this reset cannot be clobbered True.
+        self._connection = False
         # Tag this client's state-mutating callbacks with a fresh generation so a late
         # event from the client just stopped cannot flip self._connection (see
         # _is_stale_generation).

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -33,6 +33,7 @@ from awscrt import mqtt5
 from awsiot import mqtt5_client_builder  # type: ignore[import-untyped]
 
 from .device import MOBILE_ID
+from ...debug_utils import redact_id, redact_identity, redact_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -186,10 +187,17 @@ class NativeMqttClient:
         try:
             payload = json.loads(data.publish_packet.payload.decode())
         except (ValueError, UnicodeDecodeError) as err:
-            _LOGGER.debug("MQTT: undecodable payload on %s: %s", topic, err)
+            _LOGGER.debug("MQTT: undecodable payload on %s: %s", redact_topic(topic), err)
             return
         if not isinstance(payload, dict):
-            _LOGGER.debug("MQTT: non-object payload on %s: %r", topic, payload)
+            # Log only the TYPE, not the value: redact_identity masks dict keys but a
+            # bare scalar (e.g. a JSON string that happens to be a MAC) would pass
+            # through, so never echo a non-object payload's content.
+            _LOGGER.debug(
+                "MQTT: non-object payload on %s: type=%s",
+                redact_topic(topic),
+                type(payload).__name__,
+            )
             return
         # The rest also runs on the awscrt callback thread: a VALID dict payload can
         # still make the engine raise (params[name].update, sync_params_to_command, or
@@ -205,7 +213,9 @@ class NativeMqttClient:
                 None,
             )
             if appliance is None:
-                _LOGGER.debug("MQTT: topic with no matching appliance: %s", topic)
+                _LOGGER.debug(
+                    "MQTT: topic with no matching appliance: %s", redact_topic(topic)
+                )
                 return
             if topic and "appliancestatus" in topic:
                 params = appliance.attributes.get("parameters", {})
@@ -237,21 +247,21 @@ class NativeMqttClient:
             elif topic and "disconnected" in topic:
                 _LOGGER.info(
                     "Disconnected %s: %s",
-                    appliance.nick_name,
+                    redact_id(appliance.nick_name),
                     payload.get("disconnectReason"),
                 )
                 appliance.connection = False
             elif topic and "connected" in topic:
                 appliance.connection = True
-                _LOGGER.info("Connected %s", appliance.nick_name)
+                _LOGGER.info("Connected %s", redact_id(appliance.nick_name))
             elif topic and "discovery" in topic:
-                _LOGGER.info("Discovered %s", appliance.nick_name)
+                _LOGGER.info("Discovered %s", redact_id(appliance.nick_name))
             self._hon.notify()
-            _LOGGER.info("%s - %s", topic, payload)
+            _LOGGER.info("%s - %s", redact_topic(topic), redact_identity(payload))
         except Exception:
             # Broad on purpose: the body spans transport -> engine -> HA coordinator and
             # may raise arbitrary types; we must never let one reach the awscrt thread.
-            _LOGGER.warning("MQTT: handler failed on %s", topic, exc_info=True)
+            _LOGGER.warning("MQTT: handler failed on %s", redact_topic(topic), exc_info=True)
             return
 
     # -- connection / subscribe / watchdog -------------------------------------
@@ -307,7 +317,7 @@ class NativeMqttClient:
                 mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
             )
             await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
-            _LOGGER.info("Subscribed to topic %s", topic)
+            _LOGGER.info("Subscribed to topic %s", redact_topic(topic))
 
     async def _start_watchdog(self) -> None:
         if not self._watchdog_task or self._watchdog_task.done():

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -290,7 +290,15 @@ class NativeMqttClient:
                     # valid parameters in the same batch are still applied (and notify
                     # still fires), instead of dropping the entire message.
                     if not isinstance(parameter, dict):
-                        _LOGGER.debug("MQTT: skipping non-dict parameter element: %r", parameter)
+                        # Log only the TYPE, never the value (CR#4): a malformed element
+                        # is a raw cloud-controlled scalar; a bare MAC/serial would
+                        # bypass redaction (redact_identity is key-based, a pass-through
+                        # for a scalar). Mirrors the non-object-payload / not-a-list
+                        # branches above. The value is not diagnostically useful anyway.
+                        _LOGGER.debug(
+                            "MQTT: skipping non-dict parameter element: type=%s",
+                            type(parameter).__name__,
+                        )
                         continue
                     name = parameter.get("parName")
                     # Only already-known parameters (seeded by load_attributes). A new

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -41,6 +41,11 @@ AWS_AUTHORIZER = "candy-iot-authorizer"
 
 _WATCHDOG_INTERVAL = 5  # seconds
 _SUBSCRIBE_TIMEOUT = 10  # seconds
+# Consecutive down ticks before the watchdog forces a full client rebuild. awscrt's
+# mqtt5 client auto-reconnects on its own (with backoff); rebuilding every tick would
+# tear that down and re-hit the AWS authorizer-token endpoint each cycle. Waiting for
+# sustained downtime lets the native reconnect recover first.
+_RECONNECT_AFTER_FAILED_TICKS = 3
 
 
 class NativeMqttClient:
@@ -115,8 +120,21 @@ class NativeMqttClient:
     def _on_publish_received(self, data: "mqtt5.PublishReceivedData") -> None:
         if not (data and data.publish_packet and data.publish_packet.payload):
             return
-        payload = json.loads(data.publish_packet.payload.decode())
         topic = data.publish_packet.topic
+        # Defensive (this runs on an awscrt callback thread): a malformed payload
+        # must be skipped, not raised, or it would crash the callback and silence
+        # every later push instead of just dropping this one. Two cases:
+        #   1. not decodable / not JSON -> json.loads raises;
+        #   2. valid JSON but not an object (e.g. a bare list/scalar) -> the later
+        #      payload.get(...) calls would raise AttributeError.
+        try:
+            payload = json.loads(data.publish_packet.payload.decode())
+        except (ValueError, UnicodeDecodeError) as err:
+            _LOGGER.debug("MQTT: undecodable payload on %s: %s", topic, err)
+            return
+        if not isinstance(payload, dict):
+            _LOGGER.debug("MQTT: non-object payload on %s: %r", topic, payload)
+            return
         # Defensive: appliance not found for this topic -> exit.
         appliance = next(
             (
@@ -156,6 +174,16 @@ class NativeMqttClient:
 
     # -- connection / subscribe / watchdog -------------------------------------
     async def _start(self) -> None:
+        # The watchdog calls _start() to reconnect: overwriting self._client
+        # without stopping the previous one leaks its native AWS IoT connection
+        # (socket + worker threads are NOT released by GC, only by .stop()), so a
+        # sustained disconnection would spawn a new orphan client every cycle.
+        if self._client is not None:
+            try:
+                self._client.stop()
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
+            self._client = None
         self._client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=AWS_ENDPOINT,
             auth_authorizer_name=AWS_AUTHORIZER,
@@ -188,9 +216,18 @@ class NativeMqttClient:
             self._watchdog_task = asyncio.create_task(self._watchdog())
 
     async def _watchdog(self) -> None:
+        failed_ticks = 0
         while True:
             await asyncio.sleep(_WATCHDOG_INTERVAL)
-            if not self._connection:
-                _LOGGER.info("Restart mqtt connection")
-                await self._start()
-                self._subscribe_appliances()
+            if self._connection:
+                failed_ticks = 0
+                continue
+            # Sustained downtime only: give awscrt's own auto-reconnect a chance
+            # before forcing a rebuild (see _RECONNECT_AFTER_FAILED_TICKS).
+            failed_ticks += 1
+            if failed_ticks < _RECONNECT_AFTER_FAILED_TICKS:
+                continue
+            failed_ticks = 0
+            _LOGGER.info("Restart mqtt connection")
+            await self._start()
+            self._subscribe_appliances()

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -47,6 +47,10 @@ _SUBSCRIBE_TIMEOUT = 10  # seconds
 # tear that down and re-hit the AWS authorizer-token endpoint each cycle. Waiting for
 # sustained downtime lets the native reconnect recover first.
 _RECONNECT_AFTER_FAILED_TICKS = 3
+# Additive backoff cap (seconds) applied to the watchdog cadence after consecutive
+# rebuild failures, so a persistent 5xx from the AWS authorizer is not hammered
+# every tick. Reset to 0 on recovery; never masks (each failure still logs WARNING).
+_RECONNECT_BACKOFF_CAP = 60
 
 
 def _subscribed_topics(appliance) -> list:
@@ -87,7 +91,7 @@ class NativeMqttClient:
 
     async def create(self) -> "NativeMqttClient":
         await self._start()
-        self._subscribe_appliances()
+        await self._subscribe_appliances()
         await self._start_watchdog()
         return self
 
@@ -279,15 +283,20 @@ class NativeMqttClient:
         )
         self.client.start()
 
-    def _subscribe_appliances(self) -> None:
+    async def _subscribe_appliances(self) -> None:
         for appliance in self._appliances:
-            self._subscribe(appliance)
+            await self._subscribe(appliance)
 
-    def _subscribe(self, appliance: Any) -> None:
-        for topic in appliance.info.get("topics", {}).get("subscribe", []):
-            self.client.subscribe(
+    async def _subscribe(self, appliance: Any) -> None:
+        for topic in _subscribed_topics(appliance):
+            # awscrt subscribe() returns a concurrent.futures.Future; await it via
+            # wrap_future instead of a blocking .result(), so the hon_loop is not
+            # frozen up to _SUBSCRIBE_TIMEOUT per topic. Order is preserved (await
+            # each before the next); the timeout bound is unchanged.
+            future = self.client.subscribe(
                 mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
-            ).result(_SUBSCRIBE_TIMEOUT)
+            )
+            await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
             _LOGGER.info("Subscribed to topic %s", topic)
 
     async def _start_watchdog(self) -> None:
@@ -296,17 +305,35 @@ class NativeMqttClient:
 
     async def _watchdog(self) -> None:
         failed_ticks = 0
+        backoff = 0
         while True:
-            await asyncio.sleep(_WATCHDOG_INTERVAL)
-            if self._connection:
+            # The rebuild (load_aws_token / subscribe) can raise transiently; without
+            # this guard one exception would end the task and kill realtime until a
+            # reload. Re-raise CancelledError FIRST (stop() cancels+awaits us, so
+            # swallowing it would deadlock shutdown); on any other error log and keep
+            # looping with an additive backoff (capped, reset on recovery).
+            try:
+                await asyncio.sleep(_WATCHDOG_INTERVAL + backoff)
+                if self._connection:
+                    failed_ticks = 0
+                    backoff = 0
+                    continue
+                # Sustained downtime only: give awscrt's own auto-reconnect a chance
+                # before forcing a rebuild (see _RECONNECT_AFTER_FAILED_TICKS).
+                failed_ticks += 1
+                if failed_ticks < _RECONNECT_AFTER_FAILED_TICKS:
+                    continue
                 failed_ticks = 0
-                continue
-            # Sustained downtime only: give awscrt's own auto-reconnect a chance
-            # before forcing a rebuild (see _RECONNECT_AFTER_FAILED_TICKS).
-            failed_ticks += 1
-            if failed_ticks < _RECONNECT_AFTER_FAILED_TICKS:
-                continue
-            failed_ticks = 0
-            _LOGGER.info("Restart mqtt connection")
-            await self._start()
-            self._subscribe_appliances()
+                _LOGGER.info("Restart mqtt connection")
+                await self._start()
+                await self._subscribe_appliances()
+                backoff = 0  # rebuild succeeded
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
+                _LOGGER.warning(
+                    "MQTT watchdog: reconnect failed, retrying in %ss",
+                    _WATCHDOG_INTERVAL + backoff,
+                    exc_info=True,
+                )

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -49,6 +49,19 @@ _SUBSCRIBE_TIMEOUT = 10  # seconds
 _RECONNECT_AFTER_FAILED_TICKS = 3
 
 
+def _subscribed_topics(appliance) -> list:
+    """Subscribe topics of an appliance, tolerating null/non-dict info shapes.
+
+    `info.get("topics", {})` returns {} only on a MISSING key, NOT on an explicit
+    null value (the cloud routinely sends nested nulls): `None.get(...)` would then
+    raise and, in the topic-match generator, drop the message for EVERY appliance.
+    """
+    info = getattr(appliance, "info", None)
+    topics = info.get("topics") if isinstance(info, dict) else None
+    sub = topics.get("subscribe") if isinstance(topics, dict) else None
+    return sub if isinstance(sub, list) else []
+
+
 class NativeMqttClient:
     """Realtime push via AWS IoT MQTT5 on top of the native session."""
 
@@ -174,11 +187,7 @@ class NativeMqttClient:
         try:
             # Defensive: appliance not found for this topic -> exit.
             appliance = next(
-                (
-                    a
-                    for a in self._appliances
-                    if topic in a.info.get("topics", {}).get("subscribe", [])
-                ),
+                (a for a in self._appliances if topic in _subscribed_topics(a)),
                 None,
             )
             if appliance is None:
@@ -186,7 +195,24 @@ class NativeMqttClient:
                 return
             if topic and "appliancestatus" in topic:
                 params = appliance.attributes.get("parameters", {})
-                for parameter in payload.get("parameters", []):
+                raw_params = payload.get("parameters")
+                if not isinstance(raw_params, list):
+                    # The cloud may send parameters as null or a non-list; treat as
+                    # empty (dirty data, DEBUG not WARNING) instead of letting it drop
+                    # the whole message at the broad except below.
+                    if raw_params is not None:
+                        _LOGGER.debug(
+                            "MQTT: appliancestatus parameters not a list (%s), skipping",
+                            type(raw_params).__name__,
+                        )
+                    raw_params = []
+                for parameter in raw_params:
+                    # Skip a single malformed element (e.g. a null in the list) so the
+                    # valid parameters in the same batch are still applied (and notify
+                    # still fires), instead of dropping the entire message.
+                    if not isinstance(parameter, dict):
+                        _LOGGER.debug("MQTT: skipping non-dict parameter element: %r", parameter)
+                        continue
                     name = parameter.get("parName")
                     # Only already-known parameters (seeded by load_attributes). A new
                     # parName is recovered at the next HTTP poll; creating it here would

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -23,6 +23,7 @@ it (`NativeHon`) imports it lazily. The lifecycle INFO noise is governed by
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import secrets
@@ -58,6 +59,11 @@ class NativeMqttClient:
         self._appliances = hon.appliances
         self._client: mqtt5.Client | None = None
         self._connection = False
+        # Bumped on every _start(): the state-mutating lifecycle callbacks are bound
+        # to the generation of the client that registered them, so a late event from a
+        # client we already stopped cannot flip self._connection on the new one (awscrt
+        # stop() is asynchronous). See _is_stale_generation.
+        self._generation = 0
         self._watchdog_task: asyncio.Task[None] | None = None
 
     @property
@@ -91,12 +97,31 @@ class NativeMqttClient:
             self._client = None
 
     # -- lifecycle callbacks ---------------------------------------------------
+    # The callbacks that write self._connection are registered (in _start) bound to the
+    # generation of their client. awscrt stop() is asynchronous, so the client we tear
+    # down during a rebuild can still emit a late disconnection/failure AFTER the new
+    # client reported success; without this guard that stale event would flip
+    # self._connection back to False on a healthy connection and make the watchdog count
+    # a false outage (and possibly force a superfluous rebuild). An event from a
+    # non-current generation is ignored.
+    def _is_stale_generation(self, generation: int) -> bool:
+        if generation != self._generation:
+            _LOGGER.debug(
+                "MQTT: ignoring stale lifecycle event (gen %s != current %s)",
+                generation,
+                self._generation,
+            )
+            return True
+        return False
+
     def _on_lifecycle_stopped(self, data: "mqtt5.LifecycleStoppedData") -> None:
         _LOGGER.info("Lifecycle Stopped: %s", data)
 
     def _on_lifecycle_connection_success(
-        self, data: "mqtt5.LifecycleConnectSuccessData"
+        self, data: "mqtt5.LifecycleConnectSuccessData", generation: int
     ) -> None:
+        if self._is_stale_generation(generation):
+            return
         self._connection = True
         _LOGGER.info("Lifecycle Connection Success: %s", data)
 
@@ -106,14 +131,18 @@ class NativeMqttClient:
         _LOGGER.info("Lifecycle Attempting Connect: %s", data)
 
     def _on_lifecycle_connection_failure(
-        self, data: "mqtt5.LifecycleConnectFailureData"
+        self, data: "mqtt5.LifecycleConnectFailureData", generation: int
     ) -> None:
+        if self._is_stale_generation(generation):
+            return
         self._connection = False
         _LOGGER.info("Lifecycle Connection Failure: %s", data)
 
     def _on_lifecycle_disconnection(
-        self, data: "mqtt5.LifecycleDisconnectData"
+        self, data: "mqtt5.LifecycleDisconnectData", generation: int
     ) -> None:
+        if self._is_stale_generation(generation):
+            return
         self._connection = False
         _LOGGER.info("Lifecycle Disconnection: %s", data)
 
@@ -184,6 +213,11 @@ class NativeMqttClient:
             except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
             self._client = None
+        # Tag this client's state-mutating callbacks with a fresh generation so a late
+        # event from the client just stopped cannot flip self._connection (see
+        # _is_stale_generation).
+        self._generation += 1
+        generation = self._generation
         self._client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=AWS_ENDPOINT,
             auth_authorizer_name=AWS_AUTHORIZER,
@@ -192,10 +226,16 @@ class NativeMqttClient:
             auth_token_value=self._api.auth.id_token,
             client_id=f"{self._mobile_id}_{secrets.token_hex(8)}",
             on_lifecycle_stopped=self._on_lifecycle_stopped,
-            on_lifecycle_connection_success=self._on_lifecycle_connection_success,
+            on_lifecycle_connection_success=functools.partial(
+                self._on_lifecycle_connection_success, generation=generation
+            ),
             on_lifecycle_attempting_connect=self._on_lifecycle_attempting_connect,
-            on_lifecycle_connection_failure=self._on_lifecycle_connection_failure,
-            on_lifecycle_disconnection=self._on_lifecycle_disconnection,
+            on_lifecycle_connection_failure=functools.partial(
+                self._on_lifecycle_connection_failure, generation=generation
+            ),
+            on_lifecycle_disconnection=functools.partial(
+                self._on_lifecycle_disconnection, generation=generation
+            ),
             on_publish_received=self._on_publish_received,
         )
         self.client.start()

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -90,9 +90,19 @@ class NativeMqttClient:
         return self._client
 
     async def create(self) -> "NativeMqttClient":
-        await self._start()
-        await self._subscribe_appliances()
-        await self._start_watchdog()
+        try:
+            await self._start()
+            await self._subscribe_appliances()
+            await self._start_watchdog()
+        except BaseException:
+            # _start() has already started the awscrt client; if a later step fails
+            # create() raises BEFORE NativeHon stores us (session._make_mqtt), so
+            # NativeHon.close() can never reach the client -> the socket + native
+            # worker threads leak. Tear it down here (stop() is idempotent and
+            # exception-guarded). BaseException so a cancelled setup also cleans up;
+            # we re-raise to preserve the original error/cancellation.
+            await self.stop()
+            raise
         return self
 
     async def stop(self) -> None:

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -34,6 +34,7 @@ from awsiot import mqtt5_client_builder  # type: ignore[import-untyped]
 
 from .device import MOBILE_ID
 from ...debug_utils import redact_id, redact_identity, redact_topic
+from ...error_codes import HonCodedError, MQTT_SUBSCRIBE_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,9 +91,22 @@ class NativeMqttClient:
             raise AttributeError("MQTT client not started")
         return self._client
 
+    def _set_setup_phase(self, phase: str) -> None:
+        """Record the setup phase on the parent session so a dedicated-loop 60s
+        timeout during the FIRST connect is attributed to the right MQTT step. Only
+        set from create() (not the watchdog reconnect, which runs after setup)."""
+        hon = self._hon
+        if hon is not None:
+            try:
+                hon._setup_phase = phase
+            except Exception:  # pragma: no cover - defensive
+                pass
+
     async def create(self) -> "NativeMqttClient":
         try:
+            self._set_setup_phase("mqtt_connect")
             await self._start()
+            self._set_setup_phase("mqtt_subscribe")
             await self._subscribe_appliances()
             await self._start_watchdog()
         except BaseException:
@@ -316,7 +330,12 @@ class NativeMqttClient:
             future = self.client.subscribe(
                 mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
             )
-            await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
+            try:
+                await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
+            except asyncio.TimeoutError as err:
+                # Attribute the stall to a stable code. No identity in the message
+                # (the topic embeds the MAC) -> the bare timeout str only.
+                raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, str(err)) from err
             _LOGGER.info("Subscribed to topic %s", redact_topic(topic))
 
     async def _start_watchdog(self) -> None:

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -33,7 +33,7 @@ from .const import (
     AC_SWING_MODE_ON,
     AC_SWING_MODE_OFF,
 )
-from .debug_utils import command_names
+from .debug_utils import command_names, redact_id
 from .ac_command import (
     async_send_settings,
     fixed_vertical_value,
@@ -69,14 +69,14 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Climate debug: evaluating appliance '%s' id=%s type=%s commands=%s attributes=%d",
             data.get("name"),
-            aid,
+            redact_id(aid),
             data.get("type"),
             command_names(appliance),
             len(data.get("attributes", {})) if isinstance(data.get("attributes"), dict) else 0,
         )
         if data.get("type") == APPLIANCE_AC:
             entities.append(HaierClimateEntity(coordinator, aid, client))
-            _LOGGER.debug("Climate debug: created climate entity for id=%s", aid)
+            _LOGGER.debug("Climate debug: created climate entity for id=%s", redact_id(aid))
     async_add_entities(entities)
 
 
@@ -120,8 +120,8 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         self._attr_fan_modes = self._derive_fan_modes()
         _LOGGER.debug(
             "Climate debug: initialized '%s' id=%s hvac_modes=%s fan_modes=%s temp_range=%s-%s",
-            self._attr_unique_id,
-            appliance_id,
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
             self._attr_hvac_modes,
             self._attr_fan_modes,
             self.min_temp,
@@ -189,8 +189,8 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         if str(on_off) == "0":
             _LOGGER.debug(
                 "Climate debug: hvac_mode '%s' id=%s onOffStatus=%s -> OFF",
-                self._attr_unique_id,
-                self._appliance_id,
+                redact_id(self._attr_unique_id, self._appliance_id),
+                redact_id(self._appliance_id),
                 on_off,
             )
             return HVACMode.OFF
@@ -206,8 +206,8 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             mode = HVACMode(str(mode_str).lower())
             _LOGGER.debug(
                 "Climate debug: hvac_mode '%s' id=%s onOffStatus=%s machMode=%s -> %s",
-                self._attr_unique_id,
-                self._appliance_id,
+                redact_id(self._attr_unique_id, self._appliance_id),
+                redact_id(self._appliance_id),
                 on_off,
                 mode_val,
                 mode,

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -44,6 +44,17 @@ from .hon_commands import param_range
 
 _LOGGER = logging.getLogger(__name__)
 
+# Full HA mode list, used as the fallback when the device's machMode enum is not
+# readable (so a device we cannot introspect keeps offering every mode, as before).
+_DEFAULT_HVAC_MODES = [
+    HVACMode.OFF,
+    HVACMode.AUTO,
+    HVACMode.COOL,
+    HVACMode.DRY,
+    HVACMode.HEAT,
+    HVACMode.FAN_ONLY,
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -99,16 +110,14 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         if self._swing_supported:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
             self._attr_swing_modes = [AC_SWING_MODE_OFF, AC_SWING_MODE_ON]
-        # Force the native HA enums for the command panel
-        self._attr_hvac_modes = [
-            HVACMode.OFF,
-            HVACMode.AUTO,
-            HVACMode.COOL,
-            HVACMode.DRY,
-            HVACMode.HEAT,
-            HVACMode.FAN_ONLY,
-        ]
-        self._attr_fan_modes = list(AC_FAN_MAP_REVERSE.keys())
+        # hvac_modes / fan_modes derived from the device's real machMode/windSpeed
+        # enum (capability-gate, like swing above): the UI must not offer a mode
+        # the device would reject at runtime. When the enum is NOT readable (param
+        # absent or no values, e.g. a model ported without a runtime schema) we
+        # fall back to the full HA list to avoid hiding modes a device supports but
+        # does not expose -- the engine enum setter still rejects an invalid value.
+        self._attr_hvac_modes = self._derive_hvac_modes()
+        self._attr_fan_modes = self._derive_fan_modes()
         _LOGGER.debug(
             "Climate debug: initialized '%s' id=%s hvac_modes=%s fan_modes=%s temp_range=%s-%s",
             self._attr_unique_id,
@@ -118,6 +127,43 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             self.min_temp,
             self.max_temp,
         )
+
+    def _derive_hvac_modes(self) -> list[HVACMode]:
+        """Supported HVAC modes from the device's machMode enum (OFF always present).
+
+        Falls back to the full HA list when the enum is unreadable (param absent or
+        empty values), to avoid regressing devices we cannot introspect.
+        """
+        param = settings_param(self._appliance, AC_MODE_PARAM)
+        values = param_allowed_values(param) if param is not None else []
+        if not values:
+            return list(_DEFAULT_HVAC_MODES)
+        modes = [HVACMode.OFF]  # OFF is onOffStatus, never a machMode value
+        for code in values:  # keep the device's enum order (stable)
+            name = AC_MODE_MAP.get(str(code))
+            if name is None:
+                continue
+            try:
+                mode = HVACMode(name)
+            except ValueError:
+                continue
+            if mode not in modes:
+                modes.append(mode)
+        # Only OFF resolved (enum present but none mapped): keep the full list.
+        return modes if len(modes) > 1 else list(_DEFAULT_HVAC_MODES)
+
+    def _derive_fan_modes(self) -> list[str]:
+        """Supported fan modes from the device's windSpeed enum, full list as fallback."""
+        param = settings_param(self._appliance, AC_FAN_PARAM)
+        values = param_allowed_values(param) if param is not None else []
+        if not values:
+            return list(AC_FAN_MAP_REVERSE.keys())
+        modes: list[str] = []
+        for code in values:
+            name = AC_FAN_MAP.get(str(code))
+            if name and name not in modes:
+                modes.append(name)
+        return modes or list(AC_FAN_MAP_REVERSE.keys())
 
     @property
     def _live_temp_range(self) -> tuple[float, float, float]:

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -309,8 +309,30 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             ) from err
 
     async def async_turn_on(self) -> None:
-        """Turn on the air conditioner, putting it in COOL mode."""
-        await self.async_set_hvac_mode(HVACMode.COOL)
+        """Turn the AC back on, restoring its last mode.
+
+        HA convention for TURN_ON is to resume the previous operating state, not
+        force a fixed mode. We send only onOffStatus=1: the device keeps its stored
+        machMode, so it resumes the last mode (the old code forced COOL).
+        """
+        appliance = self._appliance
+        client = self._hon_client
+        if not appliance or not client:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="appliance_or_client_unavailable",
+            )
+        try:
+            _LOGGER.debug("Climate debug: turn_on -> onOffStatus=1 (mode preserved)")
+            await self._send_command_in_executor(client, appliance, {"onOffStatus": "1"})
+            await self._async_request_command_refresh()
+        except Exception as err:
+            _LOGGER.error("Climate: turn_on error: %s", err, exc_info=True)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_turn_off(self) -> None:
         """Turn off the air conditioner."""

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -21,6 +21,9 @@ from .const import (
     AC_FAN_MAP_REVERSE,
     AC_ATTR_MODE,
     AC_ATTR_TEMP,
+    AC_TEMP_PARAM,
+    AC_MODE_PARAM,
+    AC_FAN_PARAM,
     AC_ATTR_ON_OFF,
     AC_ATTR_CURRENT_TEMP,
     AC_ATTR_FAN_SPEED,
@@ -37,6 +40,7 @@ from .ac_command import (
     param_allowed_values,
     settings_param,
 )
+from .hon_commands import param_range
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,9 +77,14 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         self._attr_name = None
         self._attr_unique_id = f"{appliance_id}_climate"
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        self._attr_target_temperature_step = 1.0
-        self._attr_min_temp = 16.0
-        self._attr_max_temp = 30.0
+        # Setpoint range/step read from the device's real tempSel parameter (see
+        # min_temp/max_temp/target_temperature_step below), not hardcoded: a model
+        # with a different range or half-degree step must be honoured so the UI
+        # only offers values the device accepts. Fallback to 16-30/1.0 if absent.
+        self._temp_param = settings_param(self._appliance, AC_TEMP_PARAM)
+        self._temp_fallback_range = (
+            param_range(self._temp_param) if self._temp_param is not None else None
+        ) or (16.0, 30.0, 1.0)
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
@@ -106,9 +115,26 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             appliance_id,
             self._attr_hvac_modes,
             self._attr_fan_modes,
-            self._attr_min_temp,
-            self._attr_max_temp,
+            self.min_temp,
+            self.max_temp,
         )
+
+    @property
+    def _live_temp_range(self) -> tuple[float, float, float]:
+        """(min, max, step) read from the runtime tempSel parameter, fallback to snapshot."""
+        return param_range(self._temp_param) or self._temp_fallback_range
+
+    @property
+    def min_temp(self) -> float:
+        return self._live_temp_range[0]
+
+    @property
+    def max_temp(self) -> float:
+        return self._live_temp_range[1]
+
+    @property
+    def target_temperature_step(self) -> float:
+        return self._live_temp_range[2]
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -258,8 +284,13 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
                 translation_key="appliance_or_client_unavailable",
             )
         try:
-            _LOGGER.debug("Climate debug: set_temperature %s -> tempSel=%s", temp, int(temp))
-            await self._send_command_in_executor(client, appliance, {"tempSel": str(int(temp))})
+            # Do NOT int()-truncate: an integer value stays a clean int string
+            # ("23"), a fractional one keeps its decimals ("23.5") and the engine
+            # Range setter validates it against the device's real step/grid
+            # (mirrors number.py; the old int() silently dropped the half degree).
+            send_value = str(int(temp)) if float(temp).is_integer() else str(temp)
+            _LOGGER.debug("Climate debug: set_temperature %s -> tempSel=%s", temp, send_value)
+            await self._send_command_in_executor(client, appliance, {"tempSel": send_value})
             await self._async_request_command_refresh()
         except Exception as err:
             _LOGGER.error("Climate: set_temperature error: %s", err, exc_info=True)

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -268,19 +268,16 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Send the mode change, converting the HVACMode into the exact hOn numeric code."""
         appliance = self._appliance
-        if not appliance:
+        client = self._hon_client
+        # Both checks BEFORE the try: a missing appliance/client must surface the
+        # specific key, not be rewrapped into command_error by the except below
+        # (consistent with set_temperature/fan/swing).
+        if not appliance or not client:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="appliance_or_client_unavailable",
             )
         try:
-            client = self._hon_client
-            if client is None:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="appliance_or_client_unavailable",
-                )
-
             if hvac_mode == HVACMode.OFF:
                 _LOGGER.debug("Climate debug: set_hvac_mode OFF -> onOffStatus=0")
                 await self._send_command_in_executor(client, appliance, {"onOffStatus": "0"})

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -12,9 +12,26 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import CONF_ENABLE_DEBUG, CONF_ENABLE_MQTT_DEBUG, DOMAIN
+from .error_codes import UNKNOWN, HonErrorCode, classify
 from .hon_client import HonClient, _requires_reauth
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _error_base_and_code(exc: BaseException, fallback_base: str) -> tuple[str, str]:
+    """Map a validation exception to the (form error key, ADDHON-NNN label).
+
+    A code with a localized ``config.error.<slug>`` string (``ui=True``) drives both
+    the precise key AND the shown code; otherwise the generic bucket
+    (cannot_connect / invalid_auth) is used with the bare code label. A code-less
+    exception (legacy string-constructed CannotConnect/InvalidAuth in the tests)
+    falls back to the bucket with no code."""
+    code = getattr(exc, "error_code", None)
+    if isinstance(code, HonErrorCode):
+        if code.ui:
+            return code.slug, code.label
+        return fallback_base, code.label
+    return fallback_base, ""
 
 
 def _redact_email(email: str | None) -> str | None:
@@ -36,7 +53,10 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the hOn credentials."""
     _LOGGER.debug("ConfigFlow debug: starting validation for account %s", _redact_email(data.get("email")))
-    client = HonClient(email=data["email"], password=data["password"])
+    # validation=True: authenticate + count appliances only, NO MQTT and no
+    # per-appliance loads, so a slow/blocked realtime or a single dead endpoint can
+    # no longer make the whole validation hit the 60s loop cap (issue #30).
+    client = HonClient(email=data["email"], password=data["password"], validation=True)
 
     try:
         try:
@@ -46,12 +66,15 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             await client.async_complete_setup()
             _LOGGER.debug("ConfigFlow debug: client setup completed")
         except ImportError as err:
-            raise CannotConnect("required dependency not installed") from err
+            code = classify(err)
+            _LOGGER.error("Validation failed [%s]: required dependency not installed: %s", code.label, err)
+            raise CannotConnect(code) from err
         except Exception as err:
-            _LOGGER.error("Validation error: %s", err)
+            code = classify(err)
+            _LOGGER.error("Validation failed [%s]: %s", code.label, err)
             if _requires_reauth(err):
-                raise InvalidAuth(str(err)) from err
-            raise CannotConnect(str(err)) from err
+                raise InvalidAuth(code) from err
+            raise CannotConnect(code) from err
 
         try:
             _LOGGER.debug("ConfigFlow debug: fetching appliances for validation")
@@ -69,10 +92,11 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
                 ],
             )
         except Exception as err:
-            _LOGGER.error("Error fetching appliances during validation: %s", err)
+            code = classify(err)
+            _LOGGER.error("Validation failed [%s] fetching appliances: %s", code.label, err)
             if _requires_reauth(err):
-                raise InvalidAuth(str(err)) from err
-            raise CannotConnect(str(err)) from err
+                raise InvalidAuth(code) from err
+            raise CannotConnect(code) from err
     finally:
         try:
             _LOGGER.debug("ConfigFlow debug: closing client after validation")
@@ -105,6 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the first user step."""
         errors: dict[str, str] = {}
+        error_code = ""
 
         if user_input is not None:
             _LOGGER.debug(
@@ -120,15 +145,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
             try:
                 info = await validate_input(self.hass, user_input)
-            except CannotConnect:
-                _LOGGER.debug("ConfigFlow debug: validation failed cannot_connect")
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                _LOGGER.debug("ConfigFlow debug: validation failed invalid_auth")
-                errors["base"] = "invalid_auth"
+            except CannotConnect as err:
+                errors["base"], error_code = _error_base_and_code(err, "cannot_connect")
+                _LOGGER.debug("ConfigFlow debug: validation failed %s [%s]", errors["base"], error_code)
+            except InvalidAuth as err:
+                errors["base"], error_code = _error_base_and_code(err, "invalid_auth")
+                _LOGGER.debug("ConfigFlow debug: validation failed %s [%s]", errors["base"], error_code)
             except Exception:
                 _LOGGER.exception("Unexpected error")
                 errors["base"] = "unknown"
+                error_code = UNKNOWN.label
             else:
                 _LOGGER.debug(
                     "ConfigFlow debug: creating entry for account %s appliance_count=%s",
@@ -145,7 +171,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
             description_placeholders={
-                "docs_url": "https://github.com/tis24dev/addhOn"
+                "docs_url": "https://github.com/tis24dev/addhOn",
+                "error_code": error_code,
             },
         )
 
@@ -164,6 +191,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Ask for the password again (the email stays the entry's one)."""
         errors: dict[str, str] = {}
+        error_code = ""
         reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
@@ -173,15 +201,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data = {"email": email, "password": user_input["password"]}
             try:
                 await validate_input(self.hass, data)
-            except CannotConnect:
-                _LOGGER.debug("ConfigFlow debug: reauth failed cannot_connect")
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                _LOGGER.debug("ConfigFlow debug: reauth failed invalid_auth")
-                errors["base"] = "invalid_auth"
+            except CannotConnect as err:
+                errors["base"], error_code = _error_base_and_code(err, "cannot_connect")
+                _LOGGER.debug("ConfigFlow debug: reauth failed %s [%s]", errors["base"], error_code)
+            except InvalidAuth as err:
+                errors["base"], error_code = _error_base_and_code(err, "invalid_auth")
+                _LOGGER.debug("ConfigFlow debug: reauth failed %s [%s]", errors["base"], error_code)
             except Exception:
                 _LOGGER.exception("Unexpected error during reauth")
                 errors["base"] = "unknown"
+                error_code = UNKNOWN.label
             else:
                 # The credentials must belong to the same account: the email is
                 # not editable by the user, but we verify the unique_id anyway so
@@ -199,7 +228,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required("password"): str}),
             errors=errors,
-            description_placeholders={"email": email},
+            description_placeholders={"email": email, "error_code": error_code},
         )
 
 
@@ -246,9 +275,25 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
 
-class CannotConnect(HomeAssistantError):
+class _CodedFlowError(HomeAssistantError):
+    """Base for the two flow errors: optionally carries a HonErrorCode.
+
+    Accepts either a HonErrorCode (the new path) or a plain string/None (legacy
+    callers and tests). The carried code drives the precise UI key + the shown
+    ADDHON-NNN; a string is just the message with no code."""
+
+    def __init__(self, code: HonErrorCode | str | None = None) -> None:
+        if isinstance(code, HonErrorCode):
+            self.error_code: HonErrorCode | None = code
+            super().__init__(str(code))
+        else:
+            self.error_code = None
+            super().__init__("" if code is None else str(code))
+
+
+class CannotConnect(_CodedFlowError):
     """Connection error."""
 
 
-class InvalidAuth(HomeAssistantError):
+class InvalidAuth(_CodedFlowError):
     """Invalid credentials."""

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -111,6 +111,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "ConfigFlow debug: submit user step for account %s",
                 _redact_email(user_input.get("email")),
             )
+            # Set the unique_id and abort BEFORE the network validation, so re-adding
+            # an already-configured account is rejected without a costly hOn login +
+            # appliance fetch (rate-limited). Must be OUTSIDE the try below: the
+            # AbortFlow raised by _abort_if_unique_id_configured() would otherwise be
+            # swallowed by the broad `except Exception`. (#18)
+            await self.async_set_unique_id(user_input["email"].lower())
+            self._abort_if_unique_id_configured()
             try:
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
@@ -123,10 +130,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected error")
                 errors["base"] = "unknown"
             else:
-                # Avoid duplicate entries for the same account
-                await self.async_set_unique_id(user_input["email"].lower())
-                self._abort_if_unique_id_configured()
-
                 _LOGGER.debug(
                     "ConfigFlow debug: creating entry for account %s appliance_count=%s",
                     _redact_email(user_input.get("email")),

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -75,6 +75,12 @@ CONF_ENABLE_MQTT_DEBUG = "enable_mqtt_debug"
 # Confirmed from the diagnostics of the AS35PBPHRA-PRE device
 AC_ATTR_MODE         = "settings.machMode"
 AC_ATTR_TEMP         = "settings.tempSel"
+# Parameter NAMES inside the "settings" command (write side), distinct from the
+# dotted attribute paths above (read side): used to read the device's real
+# range/enum schema for the climate entity (setpoint range, hvac/fan modes).
+AC_TEMP_PARAM        = "tempSel"
+AC_MODE_PARAM        = "machMode"
+AC_FAN_PARAM         = "windSpeed"
 # tempIndoor / tempOutdoor are DIRECT attributes (not in settings), confirmed from diagnostics
 AC_ATTR_CURRENT_TEMP     = "tempIndoor"
 AC_ATTR_OUTDOOR_TEMP     = "tempOutdoor"

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -1,7 +1,13 @@
 """Shared debug logging helpers for Haier hOn."""
 from __future__ import annotations
 
+import re
+
 DEBUG_KEY_SAMPLE_LIMIT = 80
+
+# A MAC address in either ':' or '-' form (the hOn MQTT topic embeds the appliance
+# MAC, e.g. 'haier/things/3c-71-bf-bd-32-2c/event/appliancestatus/update').
+_MAC_RE = re.compile(r"[0-9a-fA-F]{2}(?:[:-][0-9a-fA-F]{2}){5}")
 
 
 def debug_key_sample(values: dict) -> list[str]:
@@ -110,12 +116,46 @@ def redact_mac(mac: str | None) -> str | None:
     return _REDACTED
 
 
+def redact_id(value, parent_id=None):
+    """Redact a device identifier (MAC / serial / code / nickname) or an entity
+    unique_id for logs.
+
+    A bare identifier is masked entirely -> '***'. When `parent_id` is given and is a
+    prefix of `value` (an entity unique_id is `f"{appliance_id}_{suffix}"`), ONLY the
+    identifier prefix is masked and the human-useful suffix is kept, e.g.
+    'AA:BB:..._program' -> '***_program', so the logs still say WHICH entity without
+    exposing the MAC. A falsy value is returned unchanged (so an `or <fallback>` at the
+    call site still works)."""
+    if not value:
+        return value
+    text = value if isinstance(value, str) else str(value)
+    if parent_id:
+        prefix = parent_id if isinstance(parent_id, str) else str(parent_id)
+        if prefix and text.startswith(prefix):
+            return _REDACTED + text[len(prefix):]
+    return _REDACTED
+
+
+def redact_topic(topic):
+    """Mask any MAC embedded in an MQTT topic, keeping the rest of the path.
+
+    'haier/things/3c-71-bf-bd-32-2c/event/appliancestatus/update' ->
+    'haier/things/***/event/appliancestatus/update'. The MAC is hard device identity;
+    the event path is the useful diagnostic part and is preserved. A falsy topic is
+    returned unchanged."""
+    if not topic:
+        return topic
+    return _MAC_RE.sub(_REDACTED, topic if isinstance(topic, str) else str(topic))
+
+
 __all__ = [
     "DEBUG_KEY_SAMPLE_LIMIT",
     "command_names",
     "debug_key_sample",
     "param_snapshot",
     "redact_email",
+    "redact_id",
     "redact_identity",
     "redact_mac",
+    "redact_topic",
 ]

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -46,10 +46,76 @@ def redact_email(email: str | None) -> str | None:
     return f"***@{domain}"
 
 
+_REDACTED = "***"
+
+# Identity/credential key names whose VALUE must be masked in logs. Matched by
+# EXACT key name, case-insensitive (not substring). Kept here (pure util, no HA
+# import) so the transport layer can redact before logging without reaching the
+# HA-layer diagnostics module. MUST stay a superset of diagnostics._TO_REDACT so
+# the log path redacts at least what the Download-Diagnostics path does (a
+# drift-guard test enforces it).
+_IDENTITY_KEYS = frozenset(
+    {
+        "serial",
+        "serialnumber",
+        "serial_number",
+        "mac",
+        "macaddress",
+        "mac_address",
+        "code",
+        "nickname",
+        "nick_name",
+        "email",
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "authorization",
+        "secret",
+        "transactionid",
+        "transaction_id",
+        "mobileid",
+        "mobile_id",
+    }
+)
+
+
+def redact_identity(obj):
+    """Deep-copy a mapping/list masking identity/credential VALUES to '***'.
+
+    Redaction is keyed on the dict KEY name (exact, case-insensitive) against
+    _IDENTITY_KEYS; everything else passes through. Non-container leaves are
+    returned unchanged. Pure (no HA import) and non-mutating (returns a copy), so
+    transport modules can redact a raw appliance/command dict before logging it.
+    """
+    if isinstance(obj, dict):
+        return {
+            key: (
+                _REDACTED
+                if isinstance(key, str) and key.lower() in _IDENTITY_KEYS
+                else redact_identity(val)
+            )
+            for key, val in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        return [redact_identity(item) for item in obj]
+    return obj
+
+
+def redact_mac(mac: str | None) -> str | None:
+    """Redact a single MAC value for logs. A MAC is entirely identity material, so
+    any non-empty value -> '***' (consistent with diagnostics); falsy -> None."""
+    if not mac:
+        return None
+    return _REDACTED
+
+
 __all__ = [
     "DEBUG_KEY_SAMPLE_LIMIT",
     "command_names",
     "debug_key_sample",
     "param_snapshot",
     "redact_email",
+    "redact_identity",
+    "redact_mac",
 ]

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -90,9 +90,13 @@ def redact_identity(obj):
     """Deep-copy a mapping/list masking identity/credential VALUES to '***'.
 
     Redaction is keyed on the dict KEY name (exact, case-insensitive) against
-    _IDENTITY_KEYS; everything else passes through. Non-container leaves are
-    returned unchanged. Pure (no HA import) and non-mutating (returns a copy), so
-    transport modules can redact a raw appliance/command dict before logging it.
+    _IDENTITY_KEYS. As a second layer, any MAC embedded in a STRING LEAF is masked
+    too (same _MAC_RE as redact_topic) -- so identity that arrives where key-name
+    redaction can't reach it (a bare list element, or a value under a benign key, e.g.
+    a malformed MQTT `parameters` scalar -- CR#4) does not slip through. Non-MAC
+    scalars pass through (a serial has no safe pattern -> documented residual; the
+    callers that can receive a bare scalar log only its type). Pure (no HA import) and
+    non-mutating (returns a copy), so transport modules can redact a raw dict for logs.
     """
     if isinstance(obj, dict):
         return {
@@ -105,6 +109,8 @@ def redact_identity(obj):
         }
     if isinstance(obj, (list, tuple)):
         return [redact_identity(item) for item in obj]
+    if isinstance(obj, str):
+        return _MAC_RE.sub(_REDACTED, obj)
     return obj
 
 

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -148,6 +148,35 @@ def redact_topic(topic):
     return _MAC_RE.sub(_REDACTED, topic if isinstance(topic, str) else str(topic))
 
 
+def redact_store(store):
+    """Redact a coordinator store dump for logs: mask the KEYS, keep the VALUES.
+
+    A coordinator store (e.g. PROGRAM_PENDING_STORE) is keyed by the appliance id
+    (a MAC-derived unique_id) -- hard identity -- and its values are non-identity
+    program codes (e.g. 'iot_auto'). `dict(store)` in a debug log would dump the raw
+    MAC/serial keys, and the AST redaction guard cannot catch a `dict(...)`-wrapped
+    arg, so use this. Keys are masked via redact_id (a bare id -> '***'); values pass
+    through unchanged (they ARE the diagnostic signal and carry no identity).
+
+    Distinct keys all mask to '***', which in a returned dict would collapse multiple
+    appliances' entries into one and silently drop their values -- so a colliding
+    masked key gets a stable insertion-order ordinal ('***', '***#2', ...) to preserve
+    the count and every value. Non-mapping input is returned unchanged (defensive, so
+    the dict(store)->redact_store(store) swap never changes behaviour on a bad type)."""
+    if not isinstance(store, dict):
+        return store
+    out: dict = {}
+    for key, value in store.items():
+        masked = redact_id(key)
+        if masked in out:
+            n = 2
+            while f"{masked}#{n}" in out:
+                n += 1
+            masked = f"{masked}#{n}"
+        out[masked] = value
+    return out
+
+
 __all__ = [
     "DEBUG_KEY_SAMPLE_LIMIT",
     "command_names",
@@ -157,5 +186,6 @@ __all__ = [
     "redact_id",
     "redact_identity",
     "redact_mac",
+    "redact_store",
     "redact_topic",
 ]

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -32,6 +32,7 @@ from .const import (
     DOMAIN,
     PROGRAM_PARAM_NAMES,
 )
+from .debug_utils import redact_id
 from .hon_commands import SETTINGS_COMMANDS, param_range, param_values
 
 _LOGGER = logging.getLogger(__name__)
@@ -379,7 +380,7 @@ def _appliance_block(appliance_id: str, data: Mapping) -> dict:
     _LOGGER.debug(
         "Diagnostics debug: appliance id=%s name=%s type=%s attrs=%d commands=%d "
         "unmapped_attrs=%d unmapped_params=%d",
-        appliance_id,
+        redact_id(appliance_id),
         data.get("name"),
         app_type,
         len(attributes),

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -408,6 +408,19 @@ def _coordinator(hass: HomeAssistant, entry: ConfigEntry):
     return entry_data.get("coordinator")
 
 
+def _last_error(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
+    """The last classified setup/update error code, for issue triage.
+
+    Static code+reason (no device identity), pulled from the client. None when no
+    failure has been recorded (or the client is absent, e.g. a failed setup)."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    client = entry_data.get("client")
+    code = getattr(client, "last_error_code", None)
+    if code is None:
+        return None
+    return {"code": code.label, "reason": code.reason_en}
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
@@ -436,6 +449,7 @@ async def async_get_config_entry_diagnostics(
             },
             "options": dict(entry.options),
         },
+        "last_error": _last_error(hass, entry),
         "appliances": appliances,
     }
 

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -1,0 +1,242 @@
+"""Stable error-code catalog for addhOn.
+
+Every setup/connection failure is mapped to a stable ``ADDHON-NNN`` code plus a
+short English reason. The code is shown in the config-flow UI and written to the
+logs and the downloadable diagnostics, so a user reporting a problem can quote a
+single stable token (e.g. ``ADDHON-320``) that pins the exact failure, and the
+catalog can be extended over time without renumbering (codes are append-only and
+their meaning is permanent).
+
+Pure module: NO Home Assistant / aiohttp / awscrt import, so the transport,
+client, config-flow and diagnostics layers can all import it without a cycle
+(mirrors ``debug_utils``). ``classify`` reuses the existing routing predicates in
+``hon_client`` (lazy import) so the catalog never diverges from the
+auth-vs-retryable classification the rest of the integration already relies on.
+
+The UI text (English AND Italian) lives in ``translations/{en,it}.json`` under
+``config.error.<slug>`` (Italian must stay out of the code, enforced by
+``tests/test_code_is_english.py``). ``reason_en`` here is used for the logs and
+diagnostics only.
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from dataclasses import dataclass
+
+CODE_PREFIX = "ADDHON"
+
+
+@dataclass(frozen=True)
+class HonErrorCode:
+    """One catalog entry: a stable number + a routing/UI flavour.
+
+    - ``requires_reauth`` mirrors ``hon_client._requires_reauth`` intent (auth
+      codes -> reauth/InvalidAuth, everything else -> cannot_connect/retry).
+    - ``ui`` marks the codes that can surface in the config-flow form and so need
+      a localized ``config.error.<slug>`` string; runtime-only codes (MQTT/AWS,
+      per-appliance) are logged with ``reason_en`` and never reach the form.
+    """
+
+    code: int
+    slug: str
+    reason_en: str
+    requires_reauth: bool = False
+    ui: bool = True
+
+    @property
+    def label(self) -> str:
+        return f"{CODE_PREFIX}-{self.code}"
+
+    def __str__(self) -> str:
+        return f"{self.label}: {self.reason_en}"
+
+
+_BY_SLUG: dict[str, HonErrorCode] = {}
+_BY_CODE: dict[int, HonErrorCode] = {}
+
+
+def _reg(
+    code: int, slug: str, reason_en: str, requires_reauth: bool = False, ui: bool = True
+) -> HonErrorCode:
+    entry = HonErrorCode(code, slug, reason_en, requires_reauth, ui)
+    if code in _BY_CODE:
+        raise ValueError(f"duplicate error code {code}")
+    if slug in _BY_SLUG:
+        raise ValueError(f"duplicate error slug {slug!r}")
+    _BY_CODE[code] = entry
+    _BY_SLUG[slug] = entry
+    return entry
+
+
+# --- The catalog (append-only; never reuse or renumber a code) ---------------
+# 1xx - credentials / auth steps (reauth)
+INVALID_CREDENTIALS = _reg(100, "invalid_credentials", "Invalid email or password", True)
+AUTH_INTRODUCE = _reg(110, "auth_introduce", "Login handshake failed", True)
+AUTH_LOGIN = _reg(120, "auth_login", "Login rejected (check email or password)", True)
+AUTH_GET_TOKEN = _reg(130, "auth_get_token", "Token retrieval failed", True)
+AUTH_API_AUTH = _reg(140, "auth_api_auth", "hOn API authorization failed", True)
+AUTH_REFRESH = _reg(150, "auth_refresh", "Session refresh failed", True, ui=False)
+# 2xx - appliance inventory / per-appliance (runtime, logged only)
+APPLIANCE_LIST_FAILED = _reg(200, "appliance_list_failed", "Could not fetch the appliance list")
+APPLIANCE_LIST_EMPTY = _reg(210, "appliance_list_empty", "No appliances on this account", ui=False)
+APPLIANCE_LOAD_FAILED = _reg(220, "appliance_load_failed", "Could not load appliance data", ui=False)
+APPLIANCE_DATA_MALFORMED = _reg(
+    230, "appliance_data_malformed", "Malformed appliance data", ui=False
+)
+# 3xx - realtime / AWS IoT (runtime only; validation never starts MQTT)
+AWS_TOKEN_FAILED = _reg(300, "aws_token_failed", "AWS IoT token request failed", ui=False)
+MQTT_CONNECT_TIMEOUT = _reg(310, "mqtt_connect_timeout", "MQTT connect timeout", ui=False)
+MQTT_SUBSCRIBE_TIMEOUT = _reg(320, "mqtt_subscribe_timeout", "MQTT subscribe timeout", ui=False)
+# 4xx - network / transport
+NETWORK_TIMEOUT = _reg(400, "network_timeout", "Network timeout contacting hOn")
+DNS_FAILURE = _reg(410, "dns_failure", "DNS resolution failed")
+TLS_FAILURE = _reg(420, "tls_failure", "TLS or certificate error")
+CONNECTION_REFUSED = _reg(
+    430, "connection_refused", "Could not connect to hOn (refused, reset or unreachable)"
+)
+RATE_LIMITED = _reg(440, "rate_limited", "Rate limited by hOn (try again later)")
+SERVER_ERROR = _reg(450, "server_error", "hOn server error")
+LOOP_TIMEOUT = _reg(460, "loop_timeout", "Setup timed out")
+DECODE_ERROR = _reg(470, "decode_error", "Unreadable server response")
+# 9xx - fallback
+UNKNOWN = _reg(999, "unknown", "Unknown error")
+
+
+def all_codes() -> tuple[HonErrorCode, ...]:
+    return tuple(_BY_CODE.values())
+
+
+def by_slug(slug: str) -> HonErrorCode | None:
+    return _BY_SLUG.get(slug)
+
+
+class HonCodedError(Exception):
+    """An exception that carries a :class:`HonErrorCode`.
+
+    Raised at the points where the original exception would otherwise be opaque
+    (the message-less 60s loop timeout, an MQTT subscribe timeout). ``classify``
+    returns the carried code verbatim, and ``hon_client._requires_reauth`` reads
+    ``.error_code.requires_reauth`` so the routing stays correct. The message must
+    NEVER contain device identity (only the code/reason/phase)."""
+
+    def __init__(
+        self, error_code: HonErrorCode, message: str = "", *, phase: str | None = None
+    ) -> None:
+        self.error_code = error_code
+        self.phase = phase
+        super().__init__(message or str(error_code))
+
+
+# Map a setup PHASE to the timeout-flavoured code used when that phase stalls
+# (the 60s loop cap, or a per-request aiohttp timeout). Only timeout-named codes
+# are used here so hon_client._is_retryable_server_error (string "timeout") keeps
+# returning True -> the failure is retried, never mistaken for a reauth.
+_PHASE_TIMEOUT: dict[str, HonErrorCode] = {
+    "mqtt_subscribe": MQTT_SUBSCRIBE_TIMEOUT,
+    "mqtt_connect": MQTT_CONNECT_TIMEOUT,
+    "aws_token": MQTT_CONNECT_TIMEOUT,
+    "load_appliances": NETWORK_TIMEOUT,
+    "load_appliance": NETWORK_TIMEOUT,
+    "connect": NETWORK_TIMEOUT,
+}
+
+
+def phase_timeout_code(phase: str | None) -> HonErrorCode:
+    """Timeout code for a stalled setup phase (empty/unknown -> LOOP_TIMEOUT)."""
+    if not phase:
+        return LOOP_TIMEOUT
+    if phase.startswith("load_appliance"):
+        return NETWORK_TIMEOUT
+    return _PHASE_TIMEOUT.get(phase, LOOP_TIMEOUT)
+
+
+def _is_timeout(err: BaseException) -> bool:
+    return isinstance(
+        err, (asyncio.TimeoutError, concurrent.futures.TimeoutError, TimeoutError)
+    )
+
+
+def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
+    """Map any exception to a stable :class:`HonErrorCode`.
+
+    Order is most-specific-first. A carried code wins; then rate-limit/5xx (which
+    must beat the auth-named-class rule, like the existing classifier); then
+    timeouts (attributed to ``phase`` when known); then TLS/DNS/refused; then the
+    native auth-step messages; finally the coarse buckets via the existing
+    ``hon_client`` predicates.
+    """
+    code = getattr(err, "error_code", None)
+    if isinstance(code, HonErrorCode):
+        return code
+
+    name = type(err).__name__.lower()
+    text = str(err).lower()
+    hay = f"{text} {name}"
+
+    if "429" in hay or "too many requests" in hay:
+        return RATE_LIMITED
+    if any(
+        token in hay
+        for token in (
+            "500",
+            "502",
+            "503",
+            "504",
+            "internal server error",
+            "server error",
+            "bad gateway",
+            "gateway timeout",
+            "temporarily unavailable",
+        )
+    ):
+        return SERVER_ERROR
+    if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
+        return phase_timeout_code(phase)
+    # TLS/certificate: key off the exception CLASS NAME or explicit certificate text,
+    # NOT a bare "ssl" in the message. aiohttp's ClientConnectorError __str__ ALWAYS
+    # contains "ssl:default" for ANY HTTPS connect failure (a plain outage, not a TLS
+    # problem), so matching bare "ssl" would mislabel the most common failure mode.
+    if (
+        "certificate" in hay
+        or "ssl" in name
+        or "sslcertverification" in text
+        or "certificate verify failed" in text
+    ):
+        return TLS_FAILURE
+    if (
+        "getaddrinfo" in hay
+        or "name or service not known" in hay
+        or "name resolution" in hay
+        or "nodename nor servname" in hay
+    ):
+        return DNS_FAILURE
+    if (
+        "refused" in hay
+        or "connection reset" in hay
+        or "reset by peer" in hay
+        or "cannot connect to host" in hay
+        or "network is unreachable" in text
+    ):
+        return CONNECTION_REFUSED
+    if "decode error" in hay:
+        return DECODE_ERROR
+    if "api_auth" in hay:
+        return AUTH_API_AUTH
+    if "get_token" in hay or "token page" in hay or "progressive" in hay:
+        return AUTH_GET_TOKEN
+    if "login page" in hay or "introduce" in hay or "no fwuid" in hay:
+        return AUTH_INTRODUCE
+    if "login:" in hay or "can't login" in hay or "login failed" in hay:
+        return AUTH_LOGIN
+    if "appliance" in hay and "empty" in hay:
+        return APPLIANCE_LIST_EMPTY
+
+    # Coarse fallback via the existing routing predicates (single source of truth).
+    from .hon_client import _is_auth_error, _is_retryable_server_error
+
+    if _is_retryable_server_error(err):
+        return SERVER_ERROR
+    if _is_auth_error(err):
+        return INVALID_CREDENTIALS
+    return UNKNOWN

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -8,7 +8,14 @@ import threading
 from typing import Any
 
 from .debug_utils import debug_key_sample, redact_email, redact_id, redact_mac
-from .error_codes import HonCodedError, classify, phase_timeout_code
+from .error_codes import (
+    APPLIANCE_LOAD_FAILED,
+    UNKNOWN,
+    HonCodedError,
+    HonErrorCode,
+    classify,
+    phase_timeout_code,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -241,6 +248,37 @@ def _requires_reauth(err: BaseException) -> bool:
     return (
         _is_auth_error(err) or _is_missing_session_error(err)
     ) and not _is_retryable_server_error(err)
+
+
+def _representative_failure(
+    failures: list[tuple[str, Exception]]
+) -> tuple[HonErrorCode, Exception | None]:
+    """Pick a representative (code, error) from per-appliance update failures (CR#6).
+
+    The all-failed (and first-poll) paths used to raise a bare RuntimeError, which
+    classify() maps to UNKNOWN (ADDHON-999) -- losing the real cause from the logs,
+    the UpdateFailed message and Download Diagnostics. This surfaces a MEANINGFUL,
+    NON-AUTH code instead: deterministically, the FIRST failure (in poll order) whose
+    classify() is neither UNKNOWN nor a reauth code; if none qualifies, fall back to
+    APPLIANCE_LOAD_FAILED (ADDHON-220) paired with the first error.
+
+    Rejecting reauth codes is what keeps routing correct. Every error here already
+    passed the non-auth gate (_requires_reauth was False at the call site), but
+    classify() is substring-based and could still name an auth code (e.g. a message
+    that merely contains "login")  -- surfacing it would flip the transient
+    UpdateFailed into a reauth (ConfigEntryAuthFailed). APPLIANCE_LOAD_FAILED is
+    requires_reauth=False, so the fallback stays non-auth too.
+    """
+    chosen: Exception | None = None  # the first failure, kept as the fallback cause
+    for _name, err in failures:
+        if chosen is None:
+            chosen = err
+        code = classify(err)
+        if code is not UNKNOWN and not code.requires_reauth:
+            return code, err
+    # No meaningful non-auth code found (or -- defensively -- an empty list, which the
+    # two gated call sites never pass): fall back to APPLIANCE_LOAD_FAILED, NEVER UNKNOWN.
+    return APPLIANCE_LOAD_FAILED, chosen
 
 
 class HonClient:
@@ -671,7 +709,7 @@ class HonClient:
 
         while True:
             data: dict[str, Any] = {}
-            failed_appliances: list[str] = []
+            failed_appliances: list[tuple[str, Exception]] = []
             retry_after_reauth = False
             try:
                 appliances = await self.async_get_appliances()
@@ -781,9 +819,17 @@ class HonClient:
                     # first refresh fails -> ConfigEntryNotReady -> HA retries setup until
                     # the full inventory loads. (Also surfaces genuine setup-time bugs.)
                     if not self._first_poll_done:
-                        raise RuntimeError(
-                            f"Error updating '{redact_id(_get_name(appliance))}': {err}"
-                        ) from err
+                        # Same code-preservation as the all-failed path (CR#6): a bare
+                        # RuntimeError would classify to UNKNOWN. Reuse the helper (with
+                        # a single failure) so the real non-auth cause is surfaced while
+                        # the STRICT first-poll semantics are unchanged (it still
+                        # re-raises -> UpdateFailed -> ConfigEntryNotReady -> HA retries).
+                        code, cause = _representative_failure(
+                            [(redact_id(_get_name(appliance)), err)]
+                        )
+                        raise HonCodedError(
+                            code, "Error updating an appliance on the first poll"
+                        ) from cause
                     # Steady state: per-appliance resilience. A non-auth failure on ONE
                     # appliance (a transient cloud 5xx that outlived the retries, a
                     # malformed payload, ...) must NOT blank EVERY device. Record it and
@@ -792,7 +838,7 @@ class HonClient:
                     # others stay live. A TOTAL failure (all errored -> empty data) is
                     # re-raised below so the coordinator marks the cycle failed instead of
                     # publishing an empty snapshot that silently blanks everything.
-                    failed_appliances.append(redact_id(_get_name(appliance)))
+                    failed_appliances.append((redact_id(_get_name(appliance)), err))
                     continue
 
             if retry_after_reauth:
@@ -801,11 +847,21 @@ class HonClient:
             if appliances and not data and failed_appliances:
                 # Every appliance failed this cycle: surface a failed update (the
                 # coordinator keeps its last good snapshot and retries) instead of
-                # returning an empty one that would blank all devices at once.
-                raise RuntimeError(
-                    "Update failed for all appliances: "
-                    + ", ".join(failed_appliances)
+                # returning an empty one that would blank all devices at once. Carry a
+                # representative NON-AUTH code so the ADDHON-NNN catalog reports the real
+                # cause instead of UNKNOWN (CR#6); the redacted names go to the WARNING,
+                # never into the HonCodedError message (its contract forbids identity).
+                code, cause = _representative_failure(failed_appliances)
+                _LOGGER.warning(
+                    "[%s] Update failed for all %d appliances: %s",
+                    code.label,
+                    len(failed_appliances),
+                    ", ".join(name for name, _err in failed_appliances),
                 )
+                raise HonCodedError(
+                    code,
+                    f"Update failed for all {len(failed_appliances)} appliance(s)",
+                ) from cause
 
             if failed_appliances:
                 _LOGGER.warning(
@@ -813,7 +869,7 @@ class HonClient:
                     "skipped (unavailable until next poll): %s",
                     len(data),
                     len(appliances),
-                    ", ".join(failed_appliances),
+                    ", ".join(name for name, _err in failed_appliances),
                 )
 
             _LOGGER.info("Loaded %d hOn devices with data", len(data))

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from typing import Any
 
-from .debug_utils import debug_key_sample, redact_email
+from .debug_utils import debug_key_sample, redact_email, redact_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def _debug_appliance_consumption(stage: str, appliance, attributes: dict | None 
         stage,
         _get_name(appliance),
         _get_type(appliance),
-        getattr(appliance, "unique_id", None) or _get_serial(appliance) or "<no-id>",
+        redact_mac(getattr(appliance, "unique_id", None) or _get_serial(appliance)) or "<no-id>",
         type(getattr(appliance, "statistics", None)).__name__,
         len(stats),
         debug_key_sample(stats),
@@ -663,7 +663,7 @@ class HonClient:
                     _LOGGER.debug(
                         "Discovery: appliance inventory from the cloud - %s",
                         "; ".join(
-                            f"type={_get_type(a)} mac={_get_mac(a) or '<no-mac>'} "
+                            f"type={_get_type(a)} mac={redact_mac(_get_mac(a)) or '<no-mac>'} "
                             f"name={_get_name(a)}"
                             for a in appliances
                         ),
@@ -686,7 +686,7 @@ class HonClient:
                         idx,
                         len(appliances),
                         _get_type(appliance),
-                        _get_mac(appliance) or "<no-mac>",
+                        redact_mac(_get_mac(appliance)) or "<no-mac>",
                         _get_name(appliance),
                     )
                     last_err = None
@@ -722,8 +722,8 @@ class HonClient:
                     _debug_appliance_consumption("coordinator snapshot", appliance, attributes)
                     _LOGGER.debug(
                         "Updated '%s' (type=%s, mac=%s, id=%s) - %d attributes",
-                        name, app_type, _get_mac(appliance) or "<no-mac>",
-                        appliance_id, len(attributes),
+                        name, app_type, redact_mac(_get_mac(appliance)) or "<no-mac>",
+                        redact_mac(appliance_id), len(attributes),
                     )
 
                 except Exception as err:

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from typing import Any
 
-from .debug_utils import debug_key_sample, redact_email, redact_mac
+from .debug_utils import debug_key_sample, redact_email, redact_id, redact_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ def _debug_appliance_consumption(stage: str, appliance, attributes: dict | None 
         "merged_keys=%d %s merged_values=%s; "
         "load_statistics=%s update=%s commands=%s",
         stage,
-        _get_name(appliance),
+        redact_id(_get_name(appliance)),
         _get_type(appliance),
         redact_mac(getattr(appliance, "unique_id", None) or _get_serial(appliance)) or "<no-id>",
         type(getattr(appliance, "statistics", None)).__name__,
@@ -517,7 +517,7 @@ class HonClient:
                                 _LOGGER.debug(
                                     "load_statistics after update() failed for '%s' "
                                     "(type=%s): %s",
-                                    _get_name(appliance),
+                                    redact_id(_get_name(appliance)),
                                     _get_type(appliance),
                                     err,
                                 )
@@ -526,7 +526,7 @@ class HonClient:
                             "(type=%s); statistics reloaded if available; "
                             "load_attributes/load_commands fallback not run in this cycle.",
                             len(attrs_after_update),
-                            _get_name(appliance),
+                            redact_id(_get_name(appliance)),
                             _get_type(appliance),
                         )
                         return
@@ -664,7 +664,7 @@ class HonClient:
                         "Discovery: appliance inventory from the cloud - %s",
                         "; ".join(
                             f"type={_get_type(a)} mac={redact_mac(_get_mac(a)) or '<no-mac>'} "
-                            f"name={_get_name(a)}"
+                            f"name={redact_id(_get_name(a))}"
                             for a in appliances
                         ),
                     )
@@ -687,7 +687,7 @@ class HonClient:
                         len(appliances),
                         _get_type(appliance),
                         redact_mac(_get_mac(appliance)) or "<no-mac>",
-                        _get_name(appliance),
+                        redact_id(_get_name(appliance)),
                     )
                     last_err = None
                     for attempt in range(3):
@@ -722,27 +722,27 @@ class HonClient:
                     _debug_appliance_consumption("coordinator snapshot", appliance, attributes)
                     _LOGGER.debug(
                         "Updated '%s' (type=%s, mac=%s, id=%s) - %d attributes",
-                        name, app_type, redact_mac(_get_mac(appliance)) or "<no-mac>",
+                        redact_id(name), app_type, redact_mac(_get_mac(appliance)) or "<no-mac>",
                         redact_mac(appliance_id), len(attributes),
                     )
 
                 except Exception as err:
                     _LOGGER.warning(
                         "Error updating '%s' (type=%s): %s",
-                        _get_name(appliance), _get_type(appliance), err,
+                        redact_id(_get_name(appliance)), _get_type(appliance), err,
                         exc_info=True,
                     )
                     if _requires_reauth(err):
                         if reauth_attempted:
                             raise RuntimeError(
                                 f"Haier auth error while updating "
-                                f"'{_get_name(appliance)}': {err}"
+                                f"'{redact_id(_get_name(appliance))}': {err}"
                             ) from err
                         _LOGGER.warning("Haier auth error, starting re-authentication")
                         if not await self._async_reauth():
                             raise RuntimeError(
                                 f"Haier auth error while updating "
-                                f"'{_get_name(appliance)}': {err}"
+                                f"'{redact_id(_get_name(appliance))}': {err}"
                             ) from err
                         reauth_attempted = True
                         retry_after_reauth = True
@@ -754,7 +754,7 @@ class HonClient:
                     # the full inventory loads. (Also surfaces genuine setup-time bugs.)
                     if not self._first_poll_done:
                         raise RuntimeError(
-                            f"Error updating '{_get_name(appliance)}': {err}"
+                            f"Error updating '{redact_id(_get_name(appliance))}': {err}"
                         ) from err
                     # Steady state: per-appliance resilience. A non-auth failure on ONE
                     # appliance (a transient cloud 5xx that outlived the retries, a
@@ -764,7 +764,7 @@ class HonClient:
                     # others stay live. A TOTAL failure (all errored -> empty data) is
                     # re-raised below so the coordinator marks the cycle failed instead of
                     # publishing an empty snapshot that silently blanks everything.
-                    failed_appliances.append(_get_name(appliance))
+                    failed_appliances.append(redact_id(_get_name(appliance)))
                     continue
 
             if retry_after_reauth:

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -259,6 +259,13 @@ class HonClient:
         self._hon_loop: asyncio.AbstractEventLoop | None = None
         self._hon_thread: threading.Thread | None = None
         self._lifecycle_lock = threading.RLock()
+        # Flipped True after the first poll that returns data. Until then the poll is
+        # STRICT (any per-appliance error re-raises -> ConfigEntryNotReady -> HA retries
+        # setup), because platform setup iterates the FIRST snapshot once and there is
+        # no dynamic discovery: an appliance missing from that snapshot would get NO
+        # entities until a reload. Steady-state polls are resilient (skip the failed
+        # appliance, keep the others).
+        self._first_poll_done = False
 
     # -- Dedicated loop management ---------------------------------------------
 
@@ -622,6 +629,7 @@ class HonClient:
 
         while True:
             data: dict[str, Any] = {}
+            failed_appliances: list[str] = []
             retry_after_reauth = False
             try:
                 appliances = await self.async_get_appliances()
@@ -725,14 +733,51 @@ class HonClient:
                         reauth_attempted = True
                         retry_after_reauth = True
                         break
-                    raise RuntimeError(
-                        f"Error updating '{_get_name(appliance)}': {err}"
-                    ) from err
+                    # FIRST poll: STRICT. Platform setup iterates this snapshot once and
+                    # there is no dynamic-discovery path, so an appliance absent from the
+                    # first snapshot would get NO entities until a reload. Re-raise so the
+                    # first refresh fails -> ConfigEntryNotReady -> HA retries setup until
+                    # the full inventory loads. (Also surfaces genuine setup-time bugs.)
+                    if not self._first_poll_done:
+                        raise RuntimeError(
+                            f"Error updating '{_get_name(appliance)}': {err}"
+                        ) from err
+                    # Steady state: per-appliance resilience. A non-auth failure on ONE
+                    # appliance (a transient cloud 5xx that outlived the retries, a
+                    # malformed payload, ...) must NOT blank EVERY device. Record it and
+                    # move on: this appliance is simply absent from the snapshot (its
+                    # entities go unavailable until the next poll succeeds) while the
+                    # others stay live. A TOTAL failure (all errored -> empty data) is
+                    # re-raised below so the coordinator marks the cycle failed instead of
+                    # publishing an empty snapshot that silently blanks everything.
+                    failed_appliances.append(_get_name(appliance))
+                    continue
 
             if retry_after_reauth:
                 continue
 
+            if appliances and not data and failed_appliances:
+                # Every appliance failed this cycle: surface a failed update (the
+                # coordinator keeps its last good snapshot and retries) instead of
+                # returning an empty one that would blank all devices at once.
+                raise RuntimeError(
+                    "Update failed for all appliances: "
+                    + ", ".join(failed_appliances)
+                )
+
+            if failed_appliances:
+                _LOGGER.warning(
+                    "Partial update: %d/%d appliances updated this cycle, "
+                    "skipped (unavailable until next poll): %s",
+                    len(data),
+                    len(appliances),
+                    ", ".join(failed_appliances),
+                )
+
             _LOGGER.info("Loaded %d hOn devices with data", len(data))
+            # From now on the poll is resilient (skip a failed appliance, keep the rest):
+            # all entities have been created from this first complete snapshot.
+            self._first_poll_done = True
             return data
 
     # -- Closing ---------------------------------------------------------------

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -266,6 +266,11 @@ class HonClient:
         # entities until a reload. Steady-state polls are resilient (skip the failed
         # appliance, keep the others).
         self._first_poll_done = False
+        # Realtime notify callback, kept on the CLIENT (not the session): the
+        # session is rebuilt on every setup/re-auth with its own _notify_function
+        # reset to None, so storing it here lets setup_sync re-apply it and the
+        # MQTT push survive a re-auth (#20).
+        self._notify_function: Any = None
 
     # -- Dedicated loop management ---------------------------------------------
 
@@ -450,6 +455,11 @@ class HonClient:
                 # Login + aiohttp session init, on the dedicated loop
                 self._api = self._run_on_hon_loop(self._hon_instance.__aenter__())
                 _LOGGER.info("Connection to hOn succeeded for %s", redact_email(self._email))
+                # Re-apply the realtime notify callback to the freshly built session
+                # (rebuilt on every setup/re-auth with _notify_function=None);
+                # without this the MQTT push is a permanent no-op after a re-auth (#20).
+                if self._notify_function is not None:
+                    self._hon_instance.subscribe_updates(self._notify_function)
             except Exception:
                 self._close_sync()
                 raise
@@ -614,13 +624,17 @@ class HonClient:
         return data
 
     def subscribe_updates(self, notify_function: Any) -> None:
-        """Register (or clear with None) the realtime notify callback on the session.
+        """Register (or clear with None) the realtime notify callback.
 
-        Raises if called before setup_sync (no session yet)."""
+        Stored on the client so it survives a re-auth (which rebuilds the session):
+        setup_sync re-applies it to the new session (#20). Forwarded to the current
+        session when one exists; if none exists (before setup, or after close on the
+        unload detach) it is just remembered -- NO raise, so subscribe_updates(None)
+        on unload is a clean no-op (#28)."""
+        self._notify_function = notify_function
         hon = self._hon_instance
-        if hon is None:
-            raise RuntimeError("subscribe_updates called before setup_sync")
-        hon.subscribe_updates(notify_function)
+        if hon is not None:
+            hon.subscribe_updates(notify_function)
 
     # -- Data polling ----------------------------------------------------------
 

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -8,6 +8,7 @@ import threading
 from typing import Any
 
 from .debug_utils import debug_key_sample, redact_email, redact_id, redact_mac
+from .error_codes import HonCodedError, classify, phase_timeout_code
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -231,6 +232,12 @@ def _is_missing_session_error(err: BaseException) -> bool:
 
 
 def _requires_reauth(err: BaseException) -> bool:
+    # A coded error already decided its routing (e.g. a phase-attributed loop timeout
+    # is non-reauth; an auth-step code is reauth). Duck-typed so this stays decoupled
+    # from error_codes.HonErrorCode and keeps working under the test stubs.
+    code = getattr(err, "error_code", None)
+    if code is not None and hasattr(code, "requires_reauth"):
+        return bool(code.requires_reauth)
     return (
         _is_auth_error(err) or _is_missing_session_error(err)
     ) and not _is_retryable_server_error(err)
@@ -251,9 +258,14 @@ class HonClient:
     _RUN_TIMEOUT = 60
     _CANCEL_TIMEOUT = 5
 
-    def __init__(self, email: str, password: str) -> None:
+    def __init__(self, email: str, password: str, validation: bool = False) -> None:
         self._email = email
         self._password = password
+        # validation=True (config-flow): authenticate + count appliances only, no MQTT
+        # and no per-appliance loads (issue #30). Runtime keeps the full setup.
+        self._validation = validation
+        # Last classified error code (for the downloadable diagnostics / log parity).
+        self.last_error_code: Any = None
         self._hon_instance = None
         self._api = None
         self._hon_loop: asyncio.AbstractEventLoop | None = None
@@ -344,7 +356,7 @@ class HonClient:
 
             try:
                 return future.result(timeout=self._RUN_TIMEOUT)
-            except concurrent.futures.TimeoutError:
+            except concurrent.futures.TimeoutError as timeout_err:
                 drain_future: concurrent.futures.Future = concurrent.futures.Future()
 
                 def _cancel_and_drain() -> None:
@@ -375,7 +387,14 @@ class HonClient:
                     drain_future.result(timeout=self._CANCEL_TIMEOUT)
                 except Exception as err:
                     _LOGGER.debug("Timeout while cancelling hOn task: %s", err)
-                raise
+                # The bare concurrent.futures.TimeoutError has no message and the
+                # cancelled coroutine's own exception is gone, so re-raise it as a
+                # phase-attributed coded error: the dedicated loop runs setup() on the
+                # hOn session, which records where it stalled (auth / appliance list /
+                # MQTT) in _setup_phase. This is what turns the #30 "spins then
+                # cannot_connect" into a precise ADDHON-NNN. (phase "" -> LOOP_TIMEOUT.)
+                phase = getattr(self._hon_instance, "_setup_phase", "") or ""
+                raise HonCodedError(phase_timeout_code(phase), phase=phase) from timeout_err
 
     def _cancel_pending_tasks(self, loop: asyncio.AbstractEventLoop) -> None:
         """Cancel leftover tasks before stopping the dedicated loop."""
@@ -449,7 +468,12 @@ class HonClient:
                 if self._hon_loop is None or not self._hon_loop.is_running():
                     self._start_hon_loop()
 
-                self._hon_instance = create_session(self._email, self._password)
+                self._hon_instance = create_session(
+                    self._email,
+                    self._password,
+                    enable_mqtt=not self._validation,
+                    minimal=self._validation,
+                )
                 _LOGGER.debug("Hon instance created")
 
                 # Login + aiohttp session init, on the dedicated loop
@@ -460,7 +484,11 @@ class HonClient:
                 # without this the MQTT push is a permanent no-op after a re-auth (#20).
                 if self._notify_function is not None:
                     self._hon_instance.subscribe_updates(self._notify_function)
-            except Exception:
+            except Exception as err:
+                self.last_error_code = classify(err)
+                _LOGGER.error(
+                    "hOn setup failed [%s]: %s", self.last_error_code.label, err
+                )
                 self._close_sync()
                 raise
 

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -561,6 +561,60 @@ class HonClient:
             _LOGGER.error("hOn re-authentication failed: %s", err)
             return False
 
+    # -- Realtime push (MQTT) --------------------------------------------------
+
+    @staticmethod
+    def _appliance_id(appliance: Any) -> str:
+        return (
+            getattr(appliance, "unique_id", None)
+            or _get_serial(appliance)
+            or str(id(appliance))
+        )
+
+    @staticmethod
+    def _build_appliance_entry(appliance: Any) -> dict[str, Any]:
+        """Coordinator entry for one appliance from its CURRENT in-memory state.
+
+        Shared by the HTTP poll (async_get_appliances_data) and the realtime
+        snapshot so the two never diverge in shape. Reads only, no network.
+        """
+        return {
+            "appliance": appliance,
+            "type": _get_type(appliance),
+            "name": _get_name(appliance),
+            "model": _get_model(appliance),
+            "serial": _get_serial(appliance),
+            "mac": _get_mac(appliance),
+            "attributes": _get_attributes(appliance),
+            "statistics": _debug_container_to_dict(
+                getattr(appliance, "statistics", None), "statistics"
+            ),
+            "settings": dict(appliance.settings) if hasattr(appliance, "settings") else {},
+        }
+
+    def build_realtime_snapshot(self) -> dict[str, Any]:
+        """Coordinator snapshot from the appliances already mutated in-memory by the
+        MQTT push (NO HTTP poll). Built on the awscrt thread by the notify callback;
+        a failing appliance is skipped, never the whole snapshot."""
+        hon = self._hon_instance
+        appliances = getattr(hon, "appliances", None) or [] if hon is not None else []
+        data: dict[str, Any] = {}
+        for appliance in appliances:
+            try:
+                data[self._appliance_id(appliance)] = self._build_appliance_entry(appliance)
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("Realtime snapshot: skipping an appliance: %s", err)
+        return data
+
+    def subscribe_updates(self, notify_function: Any) -> None:
+        """Register (or clear with None) the realtime notify callback on the session.
+
+        Raises if called before setup_sync (no session yet)."""
+        hon = self._hon_instance
+        if hon is None:
+            raise RuntimeError("subscribe_updates called before setup_sync")
+        hon.subscribe_updates(notify_function)
+
     # -- Data polling ----------------------------------------------------------
 
     async def async_get_appliances_data(self) -> dict[str, Any]:
@@ -638,28 +692,11 @@ class HonClient:
                     if last_err is not None:
                         raise last_err
 
-                    appliance_id = (
-                        getattr(appliance, "unique_id", None)
-                        or _get_serial(appliance)
-                        or str(id(appliance))
-                    )
+                    appliance_id = self._appliance_id(appliance)
                     attributes = _get_attributes(appliance)
                     name = _get_name(appliance)
                     app_type = _get_type(appliance)
-
-                    data[appliance_id] = {
-                        "appliance": appliance,
-                        "type": app_type,
-                        "name": name,
-                        "model": _get_model(appliance),
-                        "serial": _get_serial(appliance),
-                        "mac": _get_mac(appliance),
-                        "attributes": attributes,
-                        "statistics": _debug_container_to_dict(
-                            getattr(appliance, "statistics", None), "statistics"
-                        ),
-                        "settings": dict(appliance.settings) if hasattr(appliance, "settings") else {},
-                    }
+                    data[appliance_id] = self._build_appliance_entry(appliance)
                     _debug_appliance_consumption("coordinator snapshot", appliance, attributes)
                     _LOGGER.debug(
                         "Updated '%s' (type=%s, mac=%s, id=%s) - %d attributes",

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.1.0"
+  "version": "5.2.0"
 }

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -47,6 +47,7 @@ from .const import (
     APPLIANCE_WC,
     DOMAIN,
 )
+from .debug_utils import redact_id
 from .hon_commands import (
     async_send_command,
     find_settings_param,
@@ -238,7 +239,7 @@ async def async_setup_entry(
             "Number debug: '%s' (type=%s, id=%s) -> %d/%d numbers %s",
             data.get("name", "Haier"),
             app_type,
-            appliance_id,
+            redact_id(appliance_id),
             len(created),
             len(NUMBERS.get(app_type, ())),
             created,
@@ -284,7 +285,7 @@ class HonNumber(HonBaseEntity, NumberEntity):
             )
         _LOGGER.debug(
             "Number debug: init '%s' id=%s param=%s cmd=%s range=%s",
-            self._attr_unique_id, appliance_id, description.param, command_name, self._live_range,
+            redact_id(self._attr_unique_id, appliance_id), redact_id(appliance_id), description.param, command_name, self._live_range,
         )
 
     @property
@@ -350,7 +351,7 @@ class HonNumber(HonBaseEntity, NumberEntity):
         try:
             _LOGGER.debug(
                 "Number debug: set %s=%s (cmd=%s) id=%s",
-                param, send_value, self._command_name, self._appliance_id,
+                param, send_value, self._command_name, redact_id(self._appliance_id),
             )
             await async_send_command(
                 self.hass, client, appliance, self._command_name, {param: send_value}

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import math
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -46,7 +47,12 @@ from .const import (
     APPLIANCE_WC,
     DOMAIN,
 )
-from .hon_commands import async_send_command, find_settings_param, param_range
+from .hon_commands import (
+    async_send_command,
+    find_settings_param,
+    param_range,
+    param_values,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,6 +131,65 @@ NUMBERS: dict[str, tuple[HonNumberEntityDescription, ...]] = {
 }
 
 
+def _is_enum_param(param) -> bool:
+    """True if the parameter is an enum (no numeric range), not a range parameter.
+
+    Mirrors param_range()'s internal duck-type: a range parameter exposes min/max/step,
+    an enum does not. We test this directly (instead of `param_values()` being non-empty)
+    because HonParameterRange ALSO has a `.values` property - and on a malformed range it
+    can loop forever - so `.values` cannot discriminate enum from range.
+    """
+    return not all(hasattr(param, attr) for attr in ("min", "max", "step"))
+
+
+def _numeric_enum_set(param) -> list[float] | None:
+    """Sorted distinct NUMERIC values of an enum param, or None.
+
+    Returns None if the enum has no values or ANY value is non-numeric (a mode-style
+    enum like ['low','high'] is not a sensible number control -> the caller skips it
+    rather than fabricating bounds).
+    """
+    out: list[float] = []
+    for value in param_values(param):
+        try:
+            out.append(float(str(value).replace(",", ".")))
+        except (TypeError, ValueError):
+            return None
+    if not out:
+        return None
+    return sorted(set(out))
+
+
+def _enum_step(values: list[float]) -> float:
+    """A step that TILES a discrete numeric set so every member is reachable from min.
+
+    For an integer-valued set this is the gcd of the gaps (e.g. {0,2,5} -> gcd(2,3)=1,
+    so HA offers 0..5 and the membership check rejects 1/3/4; {0,2,4} -> 2, an exact
+    tiling). For a non-integer set it falls back to the smallest gap. With NumberMode.BOX
+    the step is mostly HA-side validation; the authoritative guard is the membership
+    check in async_set_native_value.
+    """
+    if len(values) < 2:
+        return 1.0
+    diffs = [round(b - a, 6) for a, b in zip(values, values[1:])]
+    if all(float(v).is_integer() for v in values):
+        gcd = 0
+        for diff in diffs:
+            gcd = math.gcd(gcd, int(round(diff)))
+        return float(gcd) if gcd else 1.0
+    smallest = min(diffs)
+    return smallest if smallest > 0 else 1.0
+
+
+def _value_in_set(value: float, enum_set: list[float]) -> bool:
+    """Membership in a discrete numeric set with a small float tolerance."""
+    try:
+        wanted = float(value)
+    except (TypeError, ValueError):
+        return False
+    return any(abs(wanted - allowed) < 1e-6 for allowed in enum_set)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -142,8 +207,31 @@ async def async_setup_entry(
             if found is None:
                 continue
             command_name, param = found
+            # An enum-typed setpoint (e.g. tempSelZ3 = ['0','2','5'] on some multidoor
+            # models) has no min/max/step, so a plain number would fabricate 0..100
+            # bounds and the cloud enum setter would reject every legitimate pick. Derive
+            # the discrete numeric set instead; a non-numeric enum is not a number control
+            # at all -> skip it (gate off) rather than offer fabricated bounds.
+            enum_set: list[float] | None = None
+            if _is_enum_param(param):
+                enum_set = _numeric_enum_set(param)
+                if enum_set is None:
+                    _LOGGER.debug(
+                        "Number debug: skip non-numeric enum setpoint '%s' (param=%s)",
+                        description.key,
+                        description.param,
+                    )
+                    continue
             entities.append(
-                HonNumber(coordinator, appliance_id, description, command_name, param, client)
+                HonNumber(
+                    coordinator,
+                    appliance_id,
+                    description,
+                    command_name,
+                    param,
+                    client,
+                    enum_set,
+                )
             )
             created.append(description.key)
         _LOGGER.debug(
@@ -171,20 +259,29 @@ class HonNumber(HonBaseEntity, NumberEntity):
         command_name: str,
         param,
         client=None,
+        enum_set: list[float] | None = None,
     ) -> None:
         super().__init__(coordinator, appliance_id, client)
         self.entity_description = description
         self._command_name = command_name
         self._param = param
+        # Discrete numeric set for an enum-typed setpoint (None for a normal range):
+        # fixes the bounds AND the picked value is validated against it before sending.
+        self._enum_set = enum_set
         self._attr_translation_key = description.translation_key or description.key
         self._attr_unique_id = f"{appliance_id}_{description.key}"
         # Range snapshot used as fallback; the live bounds are re-read from the
-        # parameter on each access (the engine rules can change them at runtime).
-        self._fallback_range = param_range(param) or (
-            description.fallback_min,
-            description.fallback_max,
-            description.fallback_step,
-        )
+        # parameter on each access (the engine rules can change them at runtime). For an
+        # enum the "range" is derived from the discrete set (min/max + a tiling step),
+        # never the fabricated 0..100 default.
+        if enum_set:
+            self._fallback_range = (enum_set[0], enum_set[-1], _enum_step(enum_set))
+        else:
+            self._fallback_range = param_range(param) or (
+                description.fallback_min,
+                description.fallback_max,
+                description.fallback_step,
+            )
         _LOGGER.debug(
             "Number debug: init '%s' id=%s param=%s cmd=%s range=%s",
             self._attr_unique_id, appliance_id, description.param, command_name, self._live_range,
@@ -228,6 +325,21 @@ class HonNumber(HonBaseEntity, NumberEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="appliance_or_client_unavailable",
+            )
+        # Enum setpoint: reject a value outside the discrete set up front (clear message,
+        # no pointless cloud round-trip) instead of letting the cloud enum setter raise an
+        # opaque ValueError that would surface as a generic command_error.
+        if self._enum_set is not None and not _value_in_set(value, self._enum_set):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_setpoint",
+                translation_placeholders={
+                    "value": str(value),
+                    "allowed": ", ".join(
+                        str(int(v)) if float(v).is_integer() else str(v)
+                        for v in self._enum_set
+                    ),
+                },
             )
         # ALWAYS send a string: the client's str_to_float does `int(string)` and catches
         # only ValueError, so a fractional float (5.5) would be truncated to 5

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -182,13 +182,37 @@ def _enum_step(values: list[float]) -> float:
     return smallest if smallest > 0 else 1.0
 
 
-def _value_in_set(value: float, enum_set: list[float]) -> bool:
-    """Membership in a discrete numeric set with a small float tolerance."""
+# Tolerance for matching a UI value to a discrete enum member. A value can drift from
+# the canonical member by float arithmetic (e.g. a step-0.5 set: min + n*step). ONE
+# source for both the membership guard and the snap so they can never disagree.
+_SET_EPSILON = 1e-6
+
+
+def _snap_to_set(value: float, enum_set: list[float]) -> float | None:
+    """Nearest enum member within _SET_EPSILON of `value`, else None (incl. non-float).
+
+    The caller must SERIALIZE this snapped (canonical) member, NOT the raw drifted
+    value -- otherwise a tolerated value like 2.0000001 is sent as "2.0000001" and the
+    cloud enum setter rejects it (clean_value not in the allowed set), surfacing as an
+    opaque command_error instead of being applied (CR#7)."""
     try:
         wanted = float(value)
     except (TypeError, ValueError):
-        return False
-    return any(abs(wanted - allowed) < 1e-6 for allowed in enum_set)
+        return None
+    best: float | None = None
+    best_delta = _SET_EPSILON
+    for allowed in enum_set:
+        delta = abs(wanted - allowed)
+        if delta < best_delta:
+            best, best_delta = allowed, delta
+    return best
+
+
+def _value_in_set(value: float, enum_set: list[float]) -> bool:
+    """Membership in a discrete numeric set with a small float tolerance.
+
+    Thin predicate over _snap_to_set so the guard and the snap share one tolerance."""
+    return _snap_to_set(value, enum_set) is not None
 
 
 async def async_setup_entry(
@@ -330,18 +354,23 @@ class HonNumber(HonBaseEntity, NumberEntity):
         # Enum setpoint: reject a value outside the discrete set up front (clear message,
         # no pointless cloud round-trip) instead of letting the cloud enum setter raise an
         # opaque ValueError that would surface as a generic command_error.
-        if self._enum_set is not None and not _value_in_set(value, self._enum_set):
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="invalid_setpoint",
-                translation_placeholders={
-                    "value": str(value),
-                    "allowed": ", ".join(
-                        str(int(v)) if float(v).is_integer() else str(v)
-                        for v in self._enum_set
-                    ),
-                },
-            )
+        if self._enum_set is not None:
+            snapped = _snap_to_set(value, self._enum_set)
+            if snapped is None:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_setpoint",
+                    translation_placeholders={
+                        "value": str(value),  # the original drifted value, for the user
+                        "allowed": ", ".join(
+                            str(int(v)) if float(v).is_integer() else str(v)
+                            for v in self._enum_set
+                        ),
+                    },
+                )
+            # Snap to the canonical member so the serialize below emits the exact enum
+            # string ("2", "10.5"), not the drifted "2.0000001" the cloud would reject.
+            value = snapped
         # ALWAYS send a string: the client's str_to_float does `int(string)` and catches
         # only ValueError, so a fractional float (5.5) would be truncated to 5
         # WITHOUT error. The string "5.5" instead stays 5.5 and the range setter

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -16,7 +16,7 @@ from .const import (
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_STORE,
 )
-from .debug_utils import redact_id
+from .debug_utils import redact_id, redact_store
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -302,12 +302,12 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
             "Select debug: before selection option=%s code=%s store=%s",
             option,
             code,
-            dict(store),
+            redact_store(store),
         )
         store[self._appliance_id] = code
         _LOGGER.info(
             "Select: program '%s' (code=%s) set; start it with 'Avvia programma'",
             option, code,
         )
-        _LOGGER.debug("Select debug: after selection store=%s", dict(store))
+        _LOGGER.debug("Select debug: after selection store=%s", redact_store(store))
         self.async_write_ha_state()

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -16,6 +16,7 @@ from .const import (
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_STORE,
 )
+from .debug_utils import redact_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,12 +56,12 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Select debug: evaluating appliance '%s' id=%s type=%s commands=%s",
             data.get("name"),
-            appliance_id,
+            redact_id(appliance_id),
             app_type,
             _command_names(appliance),
         )
         if app_type not in APPLIANCE_WASH_GROUP:
-            _LOGGER.debug("Select debug: appliance id=%s ignored, type=%s", appliance_id, app_type)
+            _LOGGER.debug("Select debug: appliance id=%s ignored, type=%s", redact_id(appliance_id), app_type)
             continue
         if HonProgramSelect.supports_appliance(appliance):
             entities.append(HonProgramSelect(coordinator, appliance_id, client))
@@ -70,7 +71,7 @@ async def async_setup_entry(
                 "Select debug: no program select for '%s' id=%s; "
                 "no source command with parameters %s",
                 data.get("name"),
-                appliance_id,
+                redact_id(appliance_id),
                 PROGRAM_PARAM_NAMES,
             )
     async_add_entities(entities)
@@ -95,8 +96,8 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         self._attr_options = list(self._program_reverse.keys())
         _LOGGER.debug(
             "Select debug: initialized '%s' id=%s programs=%d map=%s",
-            self._attr_unique_id,
-            appliance_id,
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
             len(self._program_map),
             self._program_map,
         )
@@ -223,14 +224,14 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
             if label is not None:
                 _LOGGER.debug(
                     "Select debug: current_option uses pending id=%s code=%s label=%s",
-                    self._appliance_id,
+                    redact_id(self._appliance_id),
                     pending,
                     label,
                 )
                 return label
             _LOGGER.debug(
                 "Select debug: current_option pending id=%s code=%s not present in map=%s",
-                self._appliance_id,
+                redact_id(self._appliance_id),
                 pending,
                 self._program_map,
             )
@@ -281,7 +282,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
                 token,
                 self._program_map,
             )
-        _LOGGER.debug("Select debug: current_option not available for id=%s", self._appliance_id)
+        _LOGGER.debug("Select debug: current_option not available for id=%s", redact_id(self._appliance_id))
         return None
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -91,6 +91,7 @@ from .const import (
     WM_ATTR_TOTAL_WATER,
     WM_STATE_MAP,
 )
+from .debug_utils import redact_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -859,7 +860,7 @@ async def async_setup_entry(
             "Sensor debug: '%s' (type=%s, id=%s) -> %d/%d sensors %s",
             data.get("name", "Haier"),
             app_type,
-            appliance_id,
+            redact_id(appliance_id),
             len(created),
             len(descriptions),
             created,

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -125,6 +125,10 @@ class HonSensorEntityDescription(SensorEntityDescription):
     # Used for params reported under different names across models (e.g. a
     # dishwasher wash temperature under `temp` or `temperature`).
     attr_fallbacks: tuple[str, ...] = ()
+    # When True, a zero/empty primary value is treated as a placeholder MISS so the
+    # attr_fallbacks chain keeps looking (e.g. actualWeight=0 -> weight=3). Opt-in:
+    # other sensors may legitimately report 0, so this never changes their behavior.
+    zero_is_missing: bool = False
 
 
 # State + remaining time: identical for washer/washer-dryer/tumble dryer.
@@ -407,6 +411,7 @@ _ESTIMATED_WEIGHT = HonSensorEntityDescription(
     icon="mdi:weight-kilogram",
     attr_key="actualWeight",
     attr_fallbacks=("weight",),
+    zero_is_missing=True,  # actualWeight=0 is a placeholder -> fall back to weight
     native_unit_of_measurement=UnitOfMass.KILOGRAMS,
     device_class=SensorDeviceClass.WEIGHT,
     state_class=SensorStateClass.MEASUREMENT,
@@ -669,6 +674,7 @@ _DISHWASHER: tuple[HonSensorEntityDescription, ...] = (
         # real DW) on some models and `temperature` on others; gate/read both.
         attr_key="temp",
         attr_fallbacks=("temperature",),
+        zero_is_missing=True,  # temp=0 is an idle placeholder -> fall back to temperature
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -889,6 +895,17 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+def _is_zeroish(value) -> bool:
+    """True for a placeholder zero/empty value (so a zero_is_missing fallback chain
+    keeps looking). Handles ints, floats and numeric strings ('0', '0.0')."""
+    if value == "":
+        return True
+    try:
+        return float(value) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
 class HonSensor(HonBaseEntity, SensorEntity):
     """Haier hOn sensor driven by HonSensorEntityDescription."""
 
@@ -907,9 +924,10 @@ class HonSensor(HonBaseEntity, SensorEntity):
 
     @property
     def native_value(self):
+        skip_zero = self.entity_description.zero_is_missing
         raw = self._get_attr(self.entity_description.attr_key)
         for fallback in self.entity_description.attr_fallbacks:
-            if raw is not None:
+            if raw is not None and not (skip_zero and _is_zeroish(raw)):
                 break
             raw = self._get_attr(fallback)
         value_fn = self.entity_description.value_fn

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -21,6 +21,7 @@ from .const import (
     DOMAIN,
     WM_ATTR_STATUS,
 )
+from .debug_utils import redact_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Switch debug: evaluating appliance '%s' id=%s type=%s commands=%s",
             data.get("name"),
-            appliance_id,
+            redact_id(appliance_id),
             app_type,
             _command_names(appliance),
         )
@@ -99,13 +100,13 @@ async def async_setup_entry(
                 cmds = getattr(appliance, "commands", None)
                 cmds = cmds if isinstance(cmds, dict) else {}
                 if "pauseProgram" in cmds and "resumeProgram" in cmds:
-                    _LOGGER.debug("Switch debug: creating pause switch for id=%s", appliance_id)
+                    _LOGGER.debug("Switch debug: creating pause switch for id=%s", redact_id(appliance_id))
                     entities.append(HonWashingMachinePauseSwitch(coordinator, appliance_id, client))
                     _LOGGER.info("Added switch: %s", data.get("name"))
                 else:
                     _LOGGER.debug(
                         "Switch debug: pause switch not created for id=%s; pause/resume missing",
-                        appliance_id,
+                        redact_id(appliance_id),
                     )
         elif app_type == APPLIANCE_AC:
             created: list[str] = []
@@ -117,10 +118,10 @@ async def async_setup_entry(
                 created.append(desc.key)
             _LOGGER.debug(
                 "Switch debug: AC '%s' id=%s -> %d switches %s",
-                data.get("name"), appliance_id, len(created), created,
+                data.get("name"), redact_id(appliance_id), len(created), created,
             )
         else:
-            _LOGGER.debug("Switch debug: appliance id=%s ignored, type=%s", appliance_id, app_type)
+            _LOGGER.debug("Switch debug: appliance id=%s ignored, type=%s", redact_id(appliance_id), app_type)
     # Account-level debug switches (one set per config entry, independent of the
     # appliances): they mirror the two persisted toggles of the Options flow.
     sw_version = entry_data.get("integration_version")
@@ -153,7 +154,7 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
         super().__init__(coordinator, appliance_id, client)
         self._attr_unique_id = f"{appliance_id}_pause"
         self._attr_translation_key = "pause"
-        _LOGGER.debug("Switch debug: initialized '%s' id=%s", self._attr_unique_id, appliance_id)
+        _LOGGER.debug("Switch debug: initialized '%s' id=%s", redact_id(self._attr_unique_id, appliance_id), redact_id(appliance_id))
 
     @property
     def is_on(self) -> bool:
@@ -162,8 +163,8 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
         is_paused = str(val) == "3"
         _LOGGER.debug(
             "Switch debug: is_on '%s' id=%s machMode=%s -> %s",
-            self._attr_unique_id,
-            self._appliance_id,
+            redact_id(self._attr_unique_id, self._appliance_id),
+            redact_id(self._appliance_id),
             val,
             is_paused,
         )
@@ -181,7 +182,7 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             "Switch debug: sending pause command '%s' value=%s id=%s commands=%s",
             command_name,
             pause_value,
-            self._appliance_id,
+            redact_id(self._appliance_id),
             _command_names(appliance),
         )
         try:
@@ -245,7 +246,7 @@ class HonAcSwitch(HonBaseEntity, SwitchEntity):
             self._attr_icon = description.icon
         _LOGGER.debug(
             "Switch debug: initialized AC switch '%s' id=%s param=%s",
-            self._attr_unique_id, appliance_id, description.param,
+            redact_id(self._attr_unique_id, appliance_id), redact_id(appliance_id), description.param,
         )
 
     @property
@@ -271,7 +272,7 @@ class HonAcSwitch(HonBaseEntity, SwitchEntity):
             )
         param = self._desc.param
         try:
-            _LOGGER.debug("Switch debug: AC set %s=%s id=%s", param, value, self._appliance_id)
+            _LOGGER.debug("Switch debug: AC set %s=%s id=%s", param, value, redact_id(self._appliance_id))
             await async_send_settings(self.hass, client, appliance, {param: value})
             await self._async_request_command_refresh()
         except HomeAssistantError:

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -652,6 +652,9 @@
     "command_error": {
       "message": "Command failed: {error}"
     },
+    "invalid_setpoint": {
+      "message": "Value {value} is not allowed (allowed: {allowed})."
+    },
     "program_not_found": {
       "message": "Program \"{program}\" was not found."
     },

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -46,7 +46,7 @@
   "services": {
     "set_log_level": {
       "name": "Set diagnostic log level",
-      "description": "Change the log level of the Haier hOn integration and the pyhOn loggers used to diagnose login, device discovery, reauth and polling. Use \"debug\" when devices do not appear, then return to \"warning\" to reduce noise. Does not enable MQTT realtime noise: for that use the dedicated set_mqtt_log_level service.",
+      "description": "Change the log level of the Haier hOn integration and the native hOn client loggers used to diagnose login, device discovery, reauth and polling. Use \"debug\" when devices do not appear, then return to \"warning\" to reduce noise. Does not enable MQTT realtime noise: for that use the dedicated set_mqtt_log_level service.",
       "fields": {
         "level": {
           "name": "Level",
@@ -56,11 +56,11 @@
     },
     "set_mqtt_log_level": {
       "name": "Set MQTT log level",
-      "description": "Change the log level of the pyhOn MQTT realtime channel. By default the reconnect-attempt noise is silenced (warning). Set \"debug\" to diagnose realtime push problems, then \"warning\" to silence it again. Not persistent: it returns to silenced after a Home Assistant restart.",
+      "description": "Change the log level of the hOn MQTT realtime channel. By default the reconnect-attempt noise is silenced (warning). Set \"debug\" to diagnose realtime push problems, then \"warning\" to silence it again. Not persistent: it returns to silenced after a Home Assistant restart.",
       "fields": {
         "level": {
           "name": "Level",
-          "description": "Log level to apply to the pyhOn MQTT realtime channel."
+          "description": "Log level to apply to the hOn MQTT realtime channel."
         }
       }
     }

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -18,8 +18,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Unable to connect to hOn servers. Check your internet connection.",
-      "invalid_auth": "Invalid credentials. Check your email and password.",
+      "cannot_connect": "Unable to connect to hOn servers. Check your internet connection. ({error_code})",
+      "invalid_auth": "Invalid credentials. Check your email and password. ({error_code})",
       "unknown": "Unexpected error. Check Home Assistant logs. ({error_code})",
       "invalid_credentials": "Invalid email or password. ({error_code})",
       "auth_introduce": "Could not start the hOn login. ({error_code})",

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -20,7 +20,21 @@
     "error": {
       "cannot_connect": "Unable to connect to hOn servers. Check your internet connection.",
       "invalid_auth": "Invalid credentials. Check your email and password.",
-      "unknown": "Unexpected error. Check Home Assistant logs."
+      "unknown": "Unexpected error. Check Home Assistant logs. ({error_code})",
+      "invalid_credentials": "Invalid email or password. ({error_code})",
+      "auth_introduce": "Could not start the hOn login. ({error_code})",
+      "auth_login": "Login rejected - check your email and password. ({error_code})",
+      "auth_get_token": "Could not retrieve the hOn session token. ({error_code})",
+      "auth_api_auth": "hOn rejected the API authorization. ({error_code})",
+      "appliance_list_failed": "Could not fetch your appliance list. ({error_code})",
+      "network_timeout": "Timed out contacting the hOn servers. Check your internet connection. ({error_code})",
+      "dns_failure": "Could not resolve the hOn servers (DNS). Check your network and DNS. ({error_code})",
+      "tls_failure": "TLS/certificate error contacting hOn. Check the system date/time and network. ({error_code})",
+      "connection_refused": "Could not connect to the hOn servers (refused, reset or unreachable). Check your network and firewall. ({error_code})",
+      "rate_limited": "Too many requests to hOn. Wait a few minutes and try again. ({error_code})",
+      "server_error": "The hOn servers returned an error. Try again later. ({error_code})",
+      "loop_timeout": "hOn setup timed out. Check your internet connection and try again. ({error_code})",
+      "decode_error": "Unreadable response from the hOn servers. Try again later. ({error_code})"
     },
     "abort": {
       "already_configured": "This hOn account is already configured.",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -20,7 +20,21 @@
     "error": {
       "cannot_connect": "Impossibile connettersi ai server hOn. Controlla la connessione internet.",
       "invalid_auth": "Credenziali non valide. Controlla email e password.",
-      "unknown": "Errore imprevisto. Controlla i log di Home Assistant."
+      "unknown": "Errore imprevisto. Controlla i log di Home Assistant. ({error_code})",
+      "invalid_credentials": "Email o password non validi. ({error_code})",
+      "auth_introduce": "Impossibile avviare il login hOn. ({error_code})",
+      "auth_login": "Login rifiutato: controlla email e password. ({error_code})",
+      "auth_get_token": "Impossibile recuperare il token di sessione hOn. ({error_code})",
+      "auth_api_auth": "hOn ha rifiutato l'autorizzazione API. ({error_code})",
+      "appliance_list_failed": "Impossibile recuperare la lista dei dispositivi. ({error_code})",
+      "network_timeout": "Timeout nel contattare i server hOn. Controlla la connessione internet. ({error_code})",
+      "dns_failure": "Impossibile risolvere i server hOn (DNS). Controlla rete e DNS. ({error_code})",
+      "tls_failure": "Errore TLS/certificato nel contattare hOn. Controlla data/ora di sistema e rete. ({error_code})",
+      "connection_refused": "Impossibile connettersi ai server hOn (rifiutata, interrotta o irraggiungibile). Controlla rete e firewall. ({error_code})",
+      "rate_limited": "Troppe richieste a hOn. Attendi qualche minuto e riprova. ({error_code})",
+      "server_error": "I server hOn hanno restituito un errore. Riprova più tardi. ({error_code})",
+      "loop_timeout": "Timeout durante la configurazione hOn. Controlla la connessione e riprova. ({error_code})",
+      "decode_error": "Risposta illeggibile dai server hOn. Riprova più tardi. ({error_code})"
     },
     "abort": {
       "already_configured": "Questo account hOn è già configurato.",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -652,6 +652,9 @@
     "command_error": {
       "message": "Comando non riuscito: {error}"
     },
+    "invalid_setpoint": {
+      "message": "Il valore {value} non è ammesso (ammessi: {allowed})."
+    },
     "program_not_found": {
       "message": "Programma \"{program}\" non trovato."
     },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -46,7 +46,7 @@
   "services": {
     "set_log_level": {
       "name": "Imposta livello log diagnostico",
-      "description": "Cambia il livello di log dell'integrazione Haier hOn e dei logger pyhOn utili a diagnosticare login, discovery dispositivi, reauth e polling. Usa \"debug\" quando i dispositivi non appaiono, poi torna a \"warning\" per ridurre il rumore. Non abilita il rumore MQTT realtime: per quello usa il service dedicato set_mqtt_log_level.",
+      "description": "Cambia il livello di log dell'integrazione Haier hOn e dei logger del client hOn nativo utili a diagnosticare login, discovery dispositivi, reauth e polling. Usa \"debug\" quando i dispositivi non appaiono, poi torna a \"warning\" per ridurre il rumore. Non abilita il rumore MQTT realtime: per quello usa il service dedicato set_mqtt_log_level.",
       "fields": {
         "level": {
           "name": "Livello",
@@ -56,11 +56,11 @@
     },
     "set_mqtt_log_level": {
       "name": "Imposta livello log MQTT",
-      "description": "Cambia il livello di log del canale MQTT realtime di pyhOn. Di default il rumore dei tentativi di riconnessione è silenziato (warning). Imposta \"debug\" per diagnosticare i problemi di push realtime, poi \"warning\" per risilenziare. Non persiste: al riavvio di Home Assistant torna silenziato.",
+      "description": "Cambia il livello di log del canale MQTT realtime hOn. Di default il rumore dei tentativi di riconnessione è silenziato (warning). Imposta \"debug\" per diagnosticare i problemi di push realtime, poi \"warning\" per risilenziare. Non persiste: al riavvio di Home Assistant torna silenziato.",
       "fields": {
         "level": {
           "name": "Livello",
-          "description": "Livello di log da applicare al canale MQTT realtime di pyhOn."
+          "description": "Livello di log da applicare al canale MQTT realtime hOn."
         }
       }
     }

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -18,8 +18,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Impossibile connettersi ai server hOn. Controlla la connessione internet.",
-      "invalid_auth": "Credenziali non valide. Controlla email e password.",
+      "cannot_connect": "Impossibile connettersi ai server hOn. Controlla la connessione internet. ({error_code})",
+      "invalid_auth": "Credenziali non valide. Controlla email e password. ({error_code})",
       "unknown": "Errore imprevisto. Controlla i log di Home Assistant. ({error_code})",
       "invalid_credentials": "Email o password non validi. ({error_code})",
       "auth_introduce": "Impossibile avviare il login hOn. ({error_code})",

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -372,6 +372,49 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         # No refresh after a failed command.
         self.assertEqual(0, coord.refreshes)
 
+    async def test_hvac_modes_derived_from_enum(self) -> None:
+        # Device exposes only auto+cool: HEAT/DRY/FAN_ONLY must NOT be offered.
+        entity, _, _ = _climate({"machMode": Param("0", values=["0", "1"])})
+        self.assertEqual([HVACMode.OFF, HVACMode.AUTO, HVACMode.COOL], entity._attr_hvac_modes)
+        self.assertNotIn(HVACMode.HEAT, entity._attr_hvac_modes)
+
+    async def test_hvac_modes_full_when_all_enum_values(self) -> None:
+        entity, _, _ = _climate(
+            {"machMode": Param("1", values=["0", "1", "2", "4", "6"])}
+        )
+        self.assertEqual(
+            [
+                HVACMode.OFF,
+                HVACMode.AUTO,
+                HVACMode.COOL,
+                HVACMode.DRY,
+                HVACMode.HEAT,
+                HVACMode.FAN_ONLY,
+            ],
+            entity._attr_hvac_modes,
+        )
+
+    async def test_hvac_modes_fallback_when_enum_absent(self) -> None:
+        # machMode present but no enum values -> full HA list (no regression).
+        entity, _, _ = _climate({"machMode": Param("0")})
+        self.assertEqual(6, len(entity._attr_hvac_modes))
+        self.assertIn(HVACMode.HEAT, entity._attr_hvac_modes)
+
+    async def test_hvac_modes_fallback_when_param_missing(self) -> None:
+        entity, _, _ = _climate({"onOffStatus": Param("0")})  # no machMode
+        self.assertIn(HVACMode.OFF, entity._attr_hvac_modes)
+        self.assertIn(HVACMode.HEAT, entity._attr_hvac_modes)
+
+    async def test_fan_modes_derived_from_enum(self) -> None:
+        # windSpeed exposes only auto+high (enum order preserved).
+        entity, _, _ = _climate({"windSpeed": Param("5", values=["5", "1"])})
+        self.assertEqual(["auto", "high"], entity._attr_fan_modes)
+        self.assertNotIn("medium", entity._attr_fan_modes)
+
+    async def test_fan_modes_fallback_when_param_missing(self) -> None:
+        entity, _, _ = _climate({"onOffStatus": Param("0")})  # no windSpeed
+        self.assertEqual({"auto", "low", "medium", "high"}, set(entity._attr_fan_modes))
+
     async def test_appliance_unavailable_raises(self) -> None:
         coordinator = FakeCoordinator({})  # no appliance data
         entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -177,15 +177,25 @@ def _climate_failing(params: dict):
 class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
     """climate.HaierClimateEntity send semantics."""
 
-    async def test_turn_on_sends_cool(self) -> None:
-        # machMode seeded with a junk value to prove the code overwrites it.
-        entity, settings, coord = _climate(
-            {"onOffStatus": Param("0"), "machMode": Param("9")}
-        )
+    async def test_turn_on_sends_only_onoff_preserving_mode(self) -> None:
+        # No machMode in the command: turn_on must send ONLY onOffStatus=1 so the
+        # device keeps its last mode. If it tried to send machMode, async_send_command
+        # would raise "Parameter(s) not found" and the assert would fail.
+        entity, settings, coord = _climate({"onOffStatus": Param("0")})
         await entity.async_turn_on()
-        self.assertEqual({"onOffStatus": "1", "machMode": "1"}, settings.sent)
+        self.assertEqual({"onOffStatus": "1"}, settings.sent)
         self.assertEqual(1, settings.send_calls)
         self.assertEqual(1, coord.refreshes)
+
+    async def test_turn_on_does_not_force_cool(self) -> None:
+        # Regression on #16: with a machMode present, turn_on must NOT overwrite it
+        # (old code forced COOL="1"). Sending only onOffStatus leaves machMode as-is.
+        entity, settings, _ = _climate(
+            {"onOffStatus": Param("0"), "machMode": Param("4")}
+        )
+        await entity.async_turn_on()
+        self.assertEqual("4", settings.sent["machMode"])
+        self.assertEqual("1", settings.sent["onOffStatus"])
 
     async def test_turn_off_sends_only_onoff(self) -> None:
         # No machMode in the command: if turn_off tried to send it, async_send_command

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -206,6 +206,27 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({"onOffStatus": "0"}, settings.sent)
         self.assertEqual(1, settings.send_calls)
 
+    async def test_turn_on_send_failure_raises_command_error(self) -> None:
+        entity, settings, coord = _climate_failing({"onOffStatus": Param("0")})
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_turn_on()
+        self.assertEqual("command_error", getattr(ctx.exception, "translation_key", None))
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual(0, coord.refreshes)
+
+    async def test_turn_on_client_none_raises(self) -> None:
+        settings = RecordingCommand({"onOffStatus": Param("0")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", None)
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_turn_on()
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+        self.assertEqual(0, settings.send_calls)
+
     async def test_set_hvac_mode_maps_each_mode(self) -> None:
         # Golden codes from AS35: auto=0, cool=1, dry=2, heat=4, fan_only=6.
         cases = [
@@ -403,6 +424,14 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
             ],
             entity._attr_hvac_modes,
         )
+
+    async def test_hvac_modes_skips_unmapped_enum_code(self) -> None:
+        # Real devices may report machMode codes not in AC_MODE_MAP (e.g. "3","7"):
+        # they must be skipped, not crash the entity construction.
+        entity, _, _ = _climate(
+            {"machMode": Param("0", values=["0", "1", "3", "7"])}
+        )
+        self.assertEqual([HVACMode.OFF, HVACMode.AUTO, HVACMode.COOL], entity._attr_hvac_modes)
 
     async def test_hvac_modes_fallback_when_enum_absent(self) -> None:
         # machMode present but no enum values -> full HA list (no regression).

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -251,6 +251,21 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         await entity.async_set_hvac_mode(HVACMode.OFF)
         self.assertEqual({"onOffStatus": "0"}, settings.sent)
 
+    async def test_set_hvac_mode_client_none_raises(self) -> None:
+        # client None: must surface appliance_or_client_unavailable (check moved
+        # before the try), NOT be rewrapped into command_error.
+        settings = RecordingCommand({"onOffStatus": Param("0"), "machMode": Param("0")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", None)
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+        self.assertEqual(0, settings.send_calls)
+
     async def test_set_hvac_mode_unknown_defaults_to_cool(self) -> None:
         # A mode whose .value is not in the map must fall back to "1" (cool),
         # exercising the AC_MODE_MAP_REVERSE.get(..., "1") default literal.
@@ -455,11 +470,32 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({"auto", "low", "medium", "high"}, set(entity._attr_fan_modes))
 
     async def test_appliance_unavailable_raises(self) -> None:
+        # Appliance missing (client valid): must surface the specific key from the
+        # pre-try guard, not a generic command_error from the except below.
         coordinator = FakeCoordinator({})  # no appliance data
         entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
         entity.hass = FakeHass()
-        with self.assertRaises(Exception):
+        with self.assertRaises(HomeAssistantError) as ctx:
             await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+
+    async def test_turn_off_client_none_raises(self) -> None:
+        # turn_off delegates to set_hvac_mode(OFF); with client None the pre-try
+        # guard must surface the specific key through the delegation chain.
+        settings = RecordingCommand({"onOffStatus": Param("1")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", None)
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_turn_off()
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+        self.assertEqual(0, settings.send_calls)
 
 
 class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -1,0 +1,503 @@
+"""Tests for the AC write-path: climate setters, AC switches, and the shared
+``ac_command`` sender.
+
+This is the path that sends real commands to a physical air conditioner. Before
+these tests it had NO coverage on the *send* (only translation-key and
+parameter-name checks existed), so a mutant inverting ON/OFF, swapping a
+mode/fan map key, truncating the setpoint, or flipping swing on/off would have
+survived the whole suite. See diagnostics/addhon-deep-audit-2026-06-22.md #2.
+
+Assertions are made on ``RecordingCommand.sent`` -- the payload frozen at the
+moment ``send()`` is called, i.e. exactly what reaches the device -- not on the
+parameter objects' residual internal state. Expected codes are hard-coded golden
+values (from the real AS35PBPHRA-PRE dump in diagnostics/live-2026-06-22/), NOT
+imported from const.py: importing the maps would let a map mutation pass
+unnoticed because test and code would share the bug.
+
+The Home Assistant stubs and the Fake* harness are reused from
+``test_program_select`` (importing it installs the stubs at module load), with a
+local ``RecordingCommand`` that also captures the sent payload.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Importing test_program_select runs _install_homeassistant_stubs() at module
+# load, so the homeassistant.* modules exist before we import climate/switch.
+from test_program_select import (  # noqa: E402
+    FakeClient,
+    FakeCoordinator,
+    FakeHass,
+    Param,
+    _ac,
+)
+
+from homeassistant.components.climate.const import HVACMode  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+# test_program_select's CoordinatorEntity stub omits `available`, but
+# HonBaseEntity.available calls super().available. The base class is bound when
+# base_entity is first imported, so we must install a CoordinatorEntity that
+# exposes `available` (like the real one: coordinator.last_update_success) BEFORE
+# importing the addhon entities below -- otherwise this module, collected first,
+# would bind HonBaseEntity to a base without `available` and break
+# test_entity_availability. Mirrors the force-assign in test_entity_availability.
+import homeassistant.helpers.update_coordinator as _uc  # noqa: E402
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+        self.hass = getattr(coordinator, "hass", None)
+
+    def async_write_ha_state(self) -> None:
+        self.state_writes = getattr(self, "state_writes", 0) + 1
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+
+_uc.CoordinatorEntity = _CoordinatorEntity
+
+from custom_components.addhon import ac_command, climate, switch  # noqa: E402
+from custom_components.addhon.const import (  # noqa: E402
+    AC_FAN_MAP_REVERSE,
+    AC_MODE_MAP_REVERSE,
+)
+
+# The shared stub's ClimateEntityFeature lacks SWING_MODE (the existing climate
+# test never builds a swing-capable AC), but capability-gated swing needs it.
+# climate reads ClimateEntityFeature as a module global at construction time, so
+# rebinding it here is enough; the flag values are irrelevant to these tests.
+import enum as _enum  # noqa: E402
+
+
+class _ClimateFeature(_enum.IntFlag):
+    TARGET_TEMPERATURE = 1
+    FAN_MODE = 2
+    TURN_ON = 4
+    TURN_OFF = 8
+    SWING_MODE = 16
+
+
+climate.ClimateEntityFeature = _ClimateFeature
+
+
+class RecordingCommand:
+    """Captures the payload at send() time (kept in sync with the harness in
+    test_number_setpoints.RecordingCommand, plus a `.sent` snapshot)."""
+
+    def __init__(self, parameters=None) -> None:
+        self.parameters = parameters or {}
+        self.send_calls = 0
+        self.sent = None
+
+    async def send(self) -> None:
+        self.send_calls += 1
+        self.sent = {k: p.value for k, p in self.parameters.items()}
+
+
+class FailingCommand(RecordingCommand):
+    """Records the send attempt, then fails -- to exercise the rollback path."""
+
+    async def send(self) -> None:
+        self.send_calls += 1
+        raise RuntimeError("boom")
+
+
+class DomainErrorCommand(RecordingCommand):
+    """send() raises a HomeAssistantError with a specific translation_key, to
+    check the `except HomeAssistantError: raise` re-raise (must NOT be rewrapped
+    into a generic command_error)."""
+
+    def __init__(self, parameters=None, key="boom_key") -> None:
+        super().__init__(parameters)
+        self._key = key
+
+    async def send(self) -> None:
+        self.send_calls += 1
+        raise HomeAssistantError(translation_domain="addhon", translation_key=self._key)
+
+
+class RuleParam:
+    """Parameter whose value setter ALSO mutates `.values` (like the real rules
+    mutate siblings). Used to prove the rollback restores the full __dict__
+    (values too), not just `.value`."""
+
+    def __init__(self, value, values) -> None:
+        self._value = value
+        self.values = list(values)
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, v) -> None:
+        self._value = v
+        self.values = ["MUTATED"]
+
+
+def _climate(params: dict, attributes: dict | None = None):
+    """Build an AC climate entity whose `settings` command has `params`."""
+    settings = RecordingCommand(params)
+    coordinator = FakeCoordinator(_ac({"settings": settings}, attributes))
+    entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+    entity.hass = FakeHass()
+    return entity, settings, coordinator
+
+
+def _climate_failing(params: dict):
+    settings = FailingCommand(params)
+    coordinator = FakeCoordinator(_ac({"settings": settings}))
+    entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+    entity.hass = FakeHass()
+    return entity, settings, coordinator
+
+
+class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
+    """climate.HaierClimateEntity send semantics."""
+
+    async def test_turn_on_sends_cool(self) -> None:
+        # machMode seeded with a junk value to prove the code overwrites it.
+        entity, settings, coord = _climate(
+            {"onOffStatus": Param("0"), "machMode": Param("9")}
+        )
+        await entity.async_turn_on()
+        self.assertEqual({"onOffStatus": "1", "machMode": "1"}, settings.sent)
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_turn_off_sends_only_onoff(self) -> None:
+        # No machMode in the command: if turn_off tried to send it, async_send_command
+        # would raise "Parameter(s) not found" and the assert would fail. So this also
+        # proves OFF does NOT touch machMode.
+        entity, settings, _ = _climate({"onOffStatus": Param("1")})
+        await entity.async_turn_off()
+        self.assertEqual({"onOffStatus": "0"}, settings.sent)
+        self.assertEqual(1, settings.send_calls)
+
+    async def test_set_hvac_mode_maps_each_mode(self) -> None:
+        # Golden codes from AS35: auto=0, cool=1, dry=2, heat=4, fan_only=6.
+        cases = [
+            (HVACMode.COOL, "1"),
+            (HVACMode.HEAT, "4"),
+            (HVACMode.AUTO, "0"),
+            (HVACMode.DRY, "2"),
+            (HVACMode.FAN_ONLY, "6"),
+        ]
+        for mode, code in cases:
+            with self.subTest(mode=mode):
+                entity, settings, _ = _climate(
+                    {"onOffStatus": Param("0"), "machMode": Param("0")}
+                )
+                await entity.async_set_hvac_mode(mode)
+                self.assertEqual(
+                    {"onOffStatus": "1", "machMode": code}, settings.sent
+                )
+
+    async def test_set_hvac_mode_off_branch(self) -> None:
+        entity, settings, _ = _climate({"onOffStatus": Param("1")})
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        self.assertEqual({"onOffStatus": "0"}, settings.sent)
+
+    async def test_set_hvac_mode_unknown_defaults_to_cool(self) -> None:
+        # A mode whose .value is not in the map must fall back to "1" (cool),
+        # exercising the AC_MODE_MAP_REVERSE.get(..., "1") default literal.
+        entity, settings, _ = _climate(
+            {"onOffStatus": Param("0"), "machMode": Param("0")}
+        )
+        await entity.async_set_hvac_mode(types.SimpleNamespace(value="not_a_real_mode"))
+        self.assertEqual({"onOffStatus": "1", "machMode": "1"}, settings.sent)
+
+    async def test_set_temperature_client_none_raises(self) -> None:
+        # Appliance present but client None: the client check (distinct from the
+        # appliance one) runs BEFORE the try, so it raises the specific key and
+        # sends nothing. A mutant dropping the client check would instead fall
+        # through and surface a generic command_error.
+        settings = RecordingCommand({"tempSel": Param("16")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", None)
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_temperature(temperature=22)
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+        self.assertEqual(0, settings.send_calls)
+
+    async def test_swing_reraises_domain_error_unchanged(self) -> None:
+        # A HomeAssistantError surfacing from the send must propagate with its own
+        # translation_key, NOT be rewrapped into "command_error".
+        settings = DomainErrorCommand(
+            {"windDirectionVertical": Param("2", values=["2", "8"])}, key="inner_key"
+        )
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_swing_mode("on")
+        self.assertEqual("inner_key", getattr(ctx.exception, "translation_key", None))
+
+    async def test_set_temperature_truncates_to_int_string(self) -> None:
+        entity, settings, _ = _climate({"tempSel": Param("16")})
+        await entity.async_set_temperature(temperature=23.7)
+        # int() truncates (not round); sent as a string, never "23.7"/"24".
+        self.assertEqual({"tempSel": "23"}, settings.sent)
+
+    async def test_set_temperature_without_temperature_is_noop(self) -> None:
+        entity, settings, coord = _climate({"tempSel": Param("16")})
+        await entity.async_set_temperature(target_temp_high=25)
+        self.assertEqual(0, settings.send_calls)
+        self.assertIsNone(settings.sent)
+        self.assertEqual(0, coord.refreshes)
+
+    async def test_set_fan_mode_maps_each_speed(self) -> None:
+        # Golden codes from AS35: high=1, medium=2, low=3, auto=5.
+        for fan, code in [("auto", "5"), ("high", "1"), ("medium", "2"), ("low", "3")]:
+            with self.subTest(fan=fan):
+                entity, settings, _ = _climate({"windSpeed": Param("5")})
+                await entity.async_set_fan_mode(fan)
+                self.assertEqual({"windSpeed": code}, settings.sent)
+
+    async def test_set_fan_mode_unknown_defaults_to_auto(self) -> None:
+        entity, settings, _ = _climate({"windSpeed": Param("1")})
+        await entity.async_set_fan_mode("nonsense")
+        self.assertEqual({"windSpeed": "5"}, settings.sent)
+
+    async def test_set_swing_on_sends_8(self) -> None:
+        entity, settings, _ = _climate(
+            {"windDirectionVertical": Param("2", values=["2", "4", "5", "8"])}
+        )
+        await entity.async_set_swing_mode("on")
+        self.assertEqual({"windDirectionVertical": "8"}, settings.sent)
+
+    async def test_set_swing_off_prefers_fixed_2(self) -> None:
+        entity, settings, _ = _climate(
+            {"windDirectionVertical": Param("8", values=["0", "2", "4", "8"])}
+        )
+        await entity.async_set_swing_mode("off")
+        # OFF must pick a fixed position; never 8 (swing) and never 0.
+        self.assertEqual({"windDirectionVertical": "2"}, settings.sent)
+
+    async def test_set_swing_off_first_fixed_when_no_2(self) -> None:
+        entity, settings, _ = _climate(
+            {"windDirectionVertical": Param("8", values=["4", "5", "8"])}
+        )
+        await entity.async_set_swing_mode("off")
+        self.assertEqual({"windDirectionVertical": "4"}, settings.sent)
+
+    async def test_set_swing_not_supported_raises(self) -> None:
+        # settings has no windDirectionVertical -> swing unsupported.
+        entity, settings, _ = _climate({"onOffStatus": Param("0")})
+        with self.assertRaises(Exception) as ctx:
+            await entity.async_set_swing_mode("on")
+        self.assertEqual("swing_not_supported", getattr(ctx.exception, "translation_key", None))
+        self.assertEqual(0, settings.send_calls)
+
+    async def test_set_swing_position_not_allowed_raises(self) -> None:
+        # "8" requested for ON but not among the allowed values.
+        entity, settings, _ = _climate(
+            {"windDirectionVertical": Param("2", values=["2", "4", "5"])}
+        )
+        with self.assertRaises(Exception) as ctx:
+            await entity.async_set_swing_mode("on")
+        self.assertEqual(
+            "swing_position_not_allowed", getattr(ctx.exception, "translation_key", None)
+        )
+        self.assertEqual(0, settings.send_calls)
+
+    async def test_hvac_mode_send_failure_rolls_back(self) -> None:
+        entity, settings, coord = _climate_failing(
+            {"onOffStatus": Param("0"), "machMode": Param("0")}
+        )
+        with self.assertRaises(Exception):
+            await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual(1, settings.send_calls)
+        # Rollback restored the pre-send values.
+        self.assertEqual("0", settings.parameters["onOffStatus"].value)
+        self.assertEqual("0", settings.parameters["machMode"].value)
+        # No refresh after a failed command.
+        self.assertEqual(0, coord.refreshes)
+
+    async def test_appliance_unavailable_raises(self) -> None:
+        coordinator = FakeCoordinator({})  # no appliance data
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+        entity.hass = FakeHass()
+        with self.assertRaises(Exception):
+            await entity.async_set_hvac_mode(HVACMode.COOL)
+
+
+class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
+    """switch.HonAcSwitch send semantics."""
+
+    _DESC = switch.HonAcSwitchDescription(key="eco", param="echoStatus", icon="mdi:leaf")
+
+    def _switch(self, params: dict, attributes: dict | None = None, *, failing=False):
+        cmd = (FailingCommand if failing else RecordingCommand)(params)
+        coordinator = FakeCoordinator(_ac({"settings": cmd}, attributes))
+        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, FakeClient())
+        entity.hass = FakeHass()
+        return entity, cmd, coordinator
+
+    async def test_turn_on_sends_1(self) -> None:
+        entity, cmd, coord = self._switch({"echoStatus": Param("0")})
+        await entity.async_turn_on()
+        self.assertEqual({"echoStatus": "1"}, cmd.sent)
+        self.assertEqual(1, cmd.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_turn_off_sends_0(self) -> None:
+        entity, cmd, _ = self._switch({"echoStatus": Param("1")})
+        await entity.async_turn_off()
+        self.assertEqual({"echoStatus": "0"}, cmd.sent)
+
+    async def test_is_on_reads_param(self) -> None:
+        on, _, _ = self._switch({"echoStatus": Param("1")}, {"echoStatus": "1"})
+        off, _, _ = self._switch({"echoStatus": Param("0")}, {"echoStatus": "0"})
+        absent, _, _ = self._switch({"echoStatus": Param("0")}, {})
+        self.assertIs(True, on.is_on)
+        self.assertIs(False, off.is_on)
+        self.assertIsNone(absent.is_on)
+
+    async def test_send_failure_rolls_back(self) -> None:
+        entity, cmd, _ = self._switch({"echoStatus": Param("0")}, failing=True)
+        with self.assertRaises(Exception):
+            await entity.async_turn_on()
+        self.assertEqual(1, cmd.send_calls)
+        self.assertEqual("0", cmd.parameters["echoStatus"].value)
+
+    async def test_set_param_client_none_raises(self) -> None:
+        cmd = RecordingCommand({"echoStatus": Param("0")})
+        coordinator = FakeCoordinator(_ac({"settings": cmd}))
+        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, None)
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_turn_on()
+        self.assertEqual(
+            "appliance_or_client_unavailable",
+            getattr(ctx.exception, "translation_key", None),
+        )
+        self.assertEqual(0, cmd.send_calls)
+
+    async def test_reraises_domain_error_unchanged(self) -> None:
+        cmd = DomainErrorCommand({"echoStatus": Param("0")}, key="inner_sw")
+        coordinator = FakeCoordinator(_ac({"settings": cmd}))
+        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, FakeClient())
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_turn_on()
+        self.assertEqual("inner_sw", getattr(ctx.exception, "translation_key", None))
+
+
+class AcCommandUnitTest(unittest.IsolatedAsyncioTestCase):
+    """Pure helpers of ac_command + the requested-value-wins integration."""
+
+    def test_reverse_maps_are_exact(self) -> None:
+        self.assertEqual(
+            {"auto": "0", "cool": "1", "dry": "2", "heat": "4", "fan_only": "6"},
+            AC_MODE_MAP_REVERSE,
+        )
+        self.assertEqual(
+            {"auto": "5", "low": "3", "medium": "2", "high": "1"},
+            AC_FAN_MAP_REVERSE,
+        )
+
+    def test_fixed_vertical_value(self) -> None:
+        self.assertEqual("2", ac_command.fixed_vertical_value(["2", "4", "8"]))
+        self.assertEqual("4", ac_command.fixed_vertical_value(["4", "5", "8"]))
+        self.assertEqual("8", ac_command.fixed_vertical_value(["8"]))
+        self.assertEqual("8", ac_command.fixed_vertical_value([]))
+
+    def test_param_allowed_values(self) -> None:
+        self.assertEqual(
+            ["2", "4", "8"], ac_command.param_allowed_values(Param(values=["2", 4, "8"]))
+        )
+        self.assertEqual([], ac_command.param_allowed_values(Param(values=None)))
+
+    def test_sanitize_vertical_resets_when_not_allowed(self) -> None:
+        param = Param("0", values=["2", "4", "8"])
+        ac_command.sanitize_wind_direction({"windDirectionVertical": param})
+        self.assertEqual("2", param.value)
+
+    def test_sanitize_keeps_allowed_value(self) -> None:
+        param = Param("4", values=["2", "4", "8"])
+        ac_command.sanitize_wind_direction({"windDirectionVertical": param})
+        self.assertEqual("4", param.value)
+
+    def test_sanitize_horizontal_picks_non_zero(self) -> None:
+        # current "9" is NOT allowed -> horizontal branch picks the first non-"0".
+        param = Param("9", values=["0", "3", "5"])
+        ac_command.sanitize_wind_direction({"windDirectionHorizontal": param})
+        self.assertEqual("3", param.value)
+
+    async def test_requested_value_wins_over_sanitize(self) -> None:
+        # Order-discriminant: the requested windDirectionVertical="8" is NOT among
+        # the allowed values, so sanitize WOULD rewrite it. Only if pre_send runs
+        # BEFORE the requested params are applied does "8" survive on the wire.
+        # (If the order were swapped, pre_send would see "8", find it disallowed and
+        # reset it to the fixed value "2".) The untouched windDirectionHorizontal=9
+        # (not allowed) still gets sanitized to the first non-zero allowed ("3").
+        wdv = Param("0", values=["2", "4"])  # no "8"
+        wdh = Param("9", values=["0", "3"])
+        settings = RecordingCommand(
+            {"windDirectionVertical": wdv, "windDirectionHorizontal": wdh}
+        )
+        appliance = _ac({"settings": settings})["ac-1"]["appliance"]
+        await ac_command.async_send_settings(
+            FakeHass(), FakeClient(), appliance, {"windDirectionVertical": "8"}
+        )
+        self.assertEqual(
+            {"windDirectionVertical": "8", "windDirectionHorizontal": "3"}, settings.sent
+        )
+
+    async def test_sanitize_skips_when_allowed_empty(self) -> None:
+        # A wind-direction param with no enum values must be left untouched, never
+        # silently forced to "8" (swing). The send carries another param so the
+        # command actually goes out.
+        wdv = Param("0", values=None)
+        settings = RecordingCommand(
+            {"windDirectionVertical": wdv, "tempSel": Param("16")}
+        )
+        appliance = _ac({"settings": settings})["ac-1"]["appliance"]
+        await ac_command.async_send_settings(
+            FakeHass(), FakeClient(), appliance, {"tempSel": "20"}
+        )
+        self.assertEqual("0", wdv.value)
+
+    async def test_missing_param_raises(self) -> None:
+        settings = RecordingCommand({"tempSel": Param("16")})
+        appliance = _ac({"settings": settings})["ac-1"]["appliance"]
+        with self.assertRaises(RuntimeError) as ctx:
+            await ac_command.async_send_settings(
+                FakeHass(), FakeClient(), appliance, {"ghostParam": "1"}
+            )
+        self.assertIn("not found", str(ctx.exception).lower())
+        self.assertEqual(0, settings.send_calls)
+
+    async def test_rollback_restores_full_dict_not_just_value(self) -> None:
+        # The rollback restores __dict__ (value AND values/min/max), not only value.
+        # RuleParam mutates .values on assignment; after a failed send both must
+        # be back to their pre-send state.
+        param = RuleParam("16", ["16", "17"])
+        settings = FailingCommand({"tempSel": param})
+        appliance = _ac({"settings": settings})["ac-1"]["appliance"]
+        with self.assertRaises(Exception):
+            await ac_command.async_send_settings(
+                FakeHass(), FakeClient(), appliance, {"tempSel": "20"}
+            )
+        self.assertEqual("16", param.value)
+        self.assertEqual(["16", "17"], param.values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -388,7 +388,7 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
     async def test_set_swing_not_supported_raises(self) -> None:
         # settings has no windDirectionVertical -> swing unsupported.
         entity, settings, _ = _climate({"onOffStatus": Param("0")})
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(HomeAssistantError) as ctx:
             await entity.async_set_swing_mode("on")
         self.assertEqual("swing_not_supported", getattr(ctx.exception, "translation_key", None))
         self.assertEqual(0, settings.send_calls)
@@ -398,7 +398,7 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         entity, settings, _ = _climate(
             {"windDirectionVertical": Param("2", values=["2", "4", "5"])}
         )
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(HomeAssistantError) as ctx:
             await entity.async_set_swing_mode("on")
         self.assertEqual(
             "swing_position_not_allowed", getattr(ctx.exception, "translation_key", None)
@@ -409,7 +409,7 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         entity, settings, coord = _climate_failing(
             {"onOffStatus": Param("0"), "machMode": Param("0")}
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(HomeAssistantError):
             await entity.async_set_hvac_mode(HVACMode.COOL)
         self.assertEqual(1, settings.send_calls)
         # Rollback restored the pre-send values.
@@ -532,7 +532,7 @@ class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_failure_rolls_back(self) -> None:
         entity, cmd, _ = self._switch({"echoStatus": Param("0")}, failing=True)
-        with self.assertRaises(Exception):
+        with self.assertRaises(HomeAssistantError):
             await entity.async_turn_on()
         self.assertEqual(1, cmd.send_calls)
         self.assertEqual("0", cmd.parameters["echoStatus"].value)
@@ -652,7 +652,7 @@ class AcCommandUnitTest(unittest.IsolatedAsyncioTestCase):
         param = RuleParam("16", ["16", "17"])
         settings = FailingCommand({"tempSel": param})
         appliance = _ac({"settings": settings})["ac-1"]["appliance"]
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             await ac_command.async_send_settings(
                 FakeHass(), FakeClient(), appliance, {"tempSel": "20"}
             )

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -127,6 +127,17 @@ class DomainErrorCommand(RecordingCommand):
         raise HomeAssistantError(translation_domain="addhon", translation_key=self._key)
 
 
+class RangeParam:
+    """Range parameter stub exposing min/max/step (Param has only value/values),
+    so the climate entity can read the device's real setpoint range."""
+
+    def __init__(self, value, *, mn, mx, step) -> None:
+        self.value = value
+        self.min = mn
+        self.max = mx
+        self.step = step
+
+
 class RuleParam:
     """Parameter whose value setter ALSO mutates `.values` (like the real rules
     mutate siblings). Used to prove the rollback restores the full __dict__
@@ -248,11 +259,43 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
             await entity.async_set_swing_mode("on")
         self.assertEqual("inner_key", getattr(ctx.exception, "translation_key", None))
 
-    async def test_set_temperature_truncates_to_int_string(self) -> None:
+    async def test_set_temperature_integer_sent_clean(self) -> None:
         entity, settings, _ = _climate({"tempSel": Param("16")})
-        await entity.async_set_temperature(temperature=23.7)
-        # int() truncates (not round); sent as a string, never "23.7"/"24".
+        await entity.async_set_temperature(temperature=23.0)
+        # Integer-valued: clean int string, never "23.0".
         self.assertEqual({"tempSel": "23"}, settings.sent)
+
+    async def test_set_temperature_fractional_not_truncated(self) -> None:
+        entity, settings, _ = _climate({"tempSel": Param("16")})
+        await entity.async_set_temperature(temperature=23.5)
+        # Fractional value keeps its decimals (no int() truncation to "23"); the
+        # engine Range setter validates it against the device step/grid.
+        self.assertEqual({"tempSel": "23.5"}, settings.sent)
+
+    async def test_temp_range_read_from_device(self) -> None:
+        entity, _, _ = _climate(
+            {"tempSel": RangeParam("20", mn=18, mx=28, step=0.5)}
+        )
+        self.assertEqual(18.0, entity.min_temp)
+        self.assertEqual(28.0, entity.max_temp)
+        self.assertEqual(0.5, entity.target_temperature_step)
+
+    async def test_temp_range_is_live_not_snapshot(self) -> None:
+        # The range is read live from the parameter (like number.py), so a runtime
+        # change to the device's min/max/step is reflected, not frozen at __init__.
+        param = RangeParam("20", mn=18, mx=28, step=1)
+        entity, _, _ = _climate({"tempSel": param})
+        param.min, param.max, param.step = 10.0, 32.0, 0.5
+        self.assertEqual(10.0, entity.min_temp)
+        self.assertEqual(32.0, entity.max_temp)
+        self.assertEqual(0.5, entity.target_temperature_step)
+
+    async def test_temp_range_fallback_when_not_a_range(self) -> None:
+        # tempSel present but without min/max/step -> fallback (16, 30, 1.0).
+        entity, _, _ = _climate({"tempSel": Param("20")})
+        self.assertEqual(16.0, entity.min_temp)
+        self.assertEqual(30.0, entity.max_temp)
+        self.assertEqual(1.0, entity.target_temperature_step)
 
     async def test_set_temperature_without_temperature_is_noop(self) -> None:
         entity, settings, coord = _climate({"tempSel": Param("16")})

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -86,5 +86,64 @@ class AuthErrorClassificationTest(unittest.TestCase):
         self.assertTrue(hc._is_auth_error(RuntimeError("token expired")))
 
 
+class CoordinatorErrorClassificationTest(unittest.TestCase):
+    """#11: the setup/update error branches wrap _requires_reauth into the right HA
+    exception. Previously only _requires_reauth was tested in isolation, so a swapped
+    branch (auth -> UpdateFailed instead of ConfigEntryAuthFailed) passed the suite.
+    These exercise the extracted classifiers directly."""
+
+    def _imports(self):
+        from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        from custom_components.addhon import _raise_setup_error, _raise_update_error
+
+        return (
+            ConfigEntryAuthFailed, ConfigEntryNotReady, UpdateFailed,
+            _raise_setup_error, _raise_update_error,
+        )
+
+    def test_setup_auth_error_is_config_entry_auth_failed(self) -> None:
+        AuthFailed, _NotReady, _UF, setup, _upd = self._imports()
+        with self.assertRaises(AuthFailed):
+            setup(NativeAuthError("login failed (status 200)"))
+
+    def test_setup_generic_error_is_config_entry_not_ready(self) -> None:
+        _AF, NotReady, _UF, setup, _upd = self._imports()
+        with self.assertRaises(NotReady):
+            setup(RuntimeError("network down"))
+
+    def test_setup_retryable_5xx_is_not_ready_not_auth(self) -> None:
+        # Auth-named class but a 5xx message -> retryable wins -> NotReady (retry),
+        # NOT a reauth prompt.
+        _AF, NotReady, _UF, setup, _upd = self._imports()
+        with self.assertRaises(NotReady):
+            setup(NativeAuthError("boom status 500"))
+
+    def test_update_auth_error_is_config_entry_auth_failed(self) -> None:
+        AuthFailed, _NotReady, _UF, _setup, upd = self._imports()
+        with self.assertRaises(AuthFailed):
+            upd(HonAuthenticationError("Can't login"))
+
+    def test_update_generic_error_is_update_failed(self) -> None:
+        _AF, _NotReady, UpdateFailed, _setup, upd = self._imports()
+        with self.assertRaises(UpdateFailed):
+            upd(RuntimeError("transient 503-less generic error"))
+
+    def test_update_retryable_5xx_is_update_failed_not_auth(self) -> None:
+        _AF, _NotReady, UpdateFailed, _setup, upd = self._imports()
+        with self.assertRaises(UpdateFailed):
+            upd(NativeAuthError("boom status 500"))
+
+    def test_chaining_preserves_original_error(self) -> None:
+        _AF, _NotReady, UpdateFailed, _setup, upd = self._imports()
+        original = RuntimeError("root cause")
+        try:
+            upd(original)
+        except UpdateFailed as wrapped:
+            self.assertIs(wrapped.__cause__, original)
+        else:
+            self.fail("expected UpdateFailed")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_flow_error_codes.py
+++ b/tests/test_config_flow_error_codes.py
@@ -1,0 +1,181 @@
+"""Tests for the error-code surfacing in the config flow (issue #30).
+
+A coded CannotConnect/InvalidAuth from validate_input must drive both the form
+error key and the shown ADDHON-NNN (via description_placeholders["error_code"]):
+- a UI code -> its precise slug key + label;
+- a non-UI (runtime-only) code -> the generic bucket + the bare label;
+- a legacy code-less exception -> the bucket with no code (back-compat).
+
+Reuses the HA-stub style of test_config_flow_reauth.py (no real HA needed).
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ha = _mod("homeassistant")
+    config_entries = _mod("homeassistant.config_entries")
+    config_entries.ConfigEntry = getattr(config_entries, "ConfigEntry", type("ConfigEntry", (), {}))
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+    config_entries.ConfigFlow = getattr(config_entries, "ConfigFlow", ConfigFlow)
+    config_entries.OptionsFlow = getattr(config_entries, "OptionsFlow", type("OptionsFlow", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    data_entry_flow = _mod("homeassistant.data_entry_flow")
+    data_entry_flow.FlowResult = getattr(data_entry_flow, "FlowResult", dict)
+    exceptions = _mod("homeassistant.exceptions")
+    base_err = getattr(exceptions, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exceptions.HomeAssistantError = base_err
+    exceptions.ConfigEntryNotReady = getattr(exceptions, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {}))
+    exceptions.ConfigEntryAuthFailed = getattr(exceptions, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {}))
+    helpers = _mod("homeassistant.helpers")
+    update_coordinator = _mod("homeassistant.helpers.update_coordinator")
+    update_coordinator.DataUpdateCoordinator = getattr(update_coordinator, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    update_coordinator.UpdateFailed = getattr(update_coordinator, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    ha.config_entries, ha.core, ha.exceptions, ha.helpers = config_entries, core, exceptions, helpers
+    helpers.update_coordinator = update_coordinator
+    if "voluptuous" not in sys.modules:
+        vol = _mod("voluptuous")
+        vol.Schema = lambda schema=None, **kwargs: schema
+
+        class Required:
+            def __init__(self, key, *args, **kwargs):
+                self.key = key
+
+        vol.Required = Required
+
+
+_install_stubs()
+
+from custom_components.addhon import config_flow as cf  # noqa: E402
+from custom_components.addhon import error_codes as ec  # noqa: E402
+
+
+class _FakeEntry:
+    def __init__(self):
+        self.entry_id = "entry-1"
+        self.data = {"email": "person@example.com", "password": "old"}
+        self.unique_id = "person@example.com"
+
+
+def _user_flow():
+    flow = cf.ConfigFlow()
+    flow.hass = object()
+    flow.context = {"source": "user"}
+    flow.unique_id = None
+
+    async def _set_unique_id(unique_id):
+        flow.unique_id = unique_id
+
+    flow.async_set_unique_id = _set_unique_id
+    flow._abort_if_unique_id_configured = lambda: None
+    flow.async_show_form = lambda **kw: {"type": "form", **kw}
+    flow.async_create_entry = lambda *, title, data: {"type": "create_entry", "title": title}
+    return flow
+
+
+def _reauth_flow():
+    entry = _FakeEntry()
+    flow = cf.ConfigFlow()
+
+    class _CE:
+        def async_get_entry(self, _id):
+            return entry
+
+    flow.hass = types.SimpleNamespace(config_entries=_CE())
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+    flow.unique_id = None
+    flow.async_show_form = lambda **kw: {"type": "form", **kw}
+    return flow
+
+
+def _patch_validate(test, fn) -> None:
+    original = cf.validate_input
+    cf.validate_input = fn
+    test.addCleanup(setattr, cf, "validate_input", original)
+
+
+class UserStepErrorCodeTest(unittest.IsolatedAsyncioTestCase):
+    async def _run_user(self, raiser):
+        async def _v(hass, data):
+            raise raiser
+
+        _patch_validate(self, _v)
+        flow = _user_flow()
+        return await flow.async_step_user({"email": "p@example.com", "password": "x"})
+
+    async def test_ui_code_drives_slug_and_label(self) -> None:
+        res = await self._run_user(cf.CannotConnect(ec.NETWORK_TIMEOUT))
+        self.assertEqual(res["errors"]["base"], "network_timeout")
+        self.assertEqual(res["description_placeholders"]["error_code"], "ADDHON-400")
+
+    async def test_invalid_auth_code(self) -> None:
+        res = await self._run_user(cf.InvalidAuth(ec.INVALID_CREDENTIALS))
+        self.assertEqual(res["errors"]["base"], "invalid_credentials")
+        self.assertEqual(res["description_placeholders"]["error_code"], "ADDHON-100")
+
+    async def test_non_ui_code_falls_back_to_bucket_but_keeps_label(self) -> None:
+        # MQTT_SUBSCRIBE_TIMEOUT is ui=False (runtime only); if it ever reaches the
+        # form it must degrade to the generic bucket while still showing the code.
+        res = await self._run_user(cf.CannotConnect(ec.MQTT_SUBSCRIBE_TIMEOUT))
+        self.assertEqual(res["errors"]["base"], "cannot_connect")
+        self.assertEqual(res["description_placeholders"]["error_code"], "ADDHON-320")
+
+    async def test_legacy_string_exception_has_no_code(self) -> None:
+        res = await self._run_user(cf.CannotConnect("offline"))
+        self.assertEqual(res["errors"]["base"], "cannot_connect")
+        self.assertEqual(res["description_placeholders"]["error_code"], "")
+
+    async def test_clean_form_has_empty_error_code(self) -> None:
+        flow = _user_flow()
+        res = await flow.async_step_user(None)
+        self.assertEqual(res["errors"], {})
+        self.assertEqual(res["description_placeholders"]["error_code"], "")
+
+    async def test_unexpected_error_maps_to_unknown_code(self) -> None:
+        async def _v(hass, data):
+            raise RuntimeError("weird")
+
+        _patch_validate(self, _v)
+        flow = _user_flow()
+        with self.assertLogs(cf._LOGGER.name, level="ERROR"):
+            res = await flow.async_step_user({"email": "p@example.com", "password": "x"})
+        self.assertEqual(res["errors"]["base"], "unknown")
+        self.assertEqual(res["description_placeholders"]["error_code"], ec.UNKNOWN.label)
+
+
+class ReauthStepErrorCodeTest(unittest.IsolatedAsyncioTestCase):
+    async def test_reauth_coded_error_surfaces(self) -> None:
+        async def _v(hass, data):
+            raise cf.CannotConnect(ec.LOOP_TIMEOUT)
+
+        _patch_validate(self, _v)
+        flow = _reauth_flow()
+        res = await flow.async_step_reauth_confirm({"password": "x"})
+        self.assertEqual(res["errors"]["base"], "loop_timeout")
+        self.assertEqual(res["description_placeholders"]["error_code"], "ADDHON-460")
+        self.assertEqual(res["description_placeholders"]["email"], "person@example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_flow_reauth.py
+++ b/tests/test_config_flow_reauth.py
@@ -41,6 +41,9 @@ def _install_stubs() -> None:
             super().__init_subclass__()
 
     config_entries.ConfigFlow = getattr(config_entries, "ConfigFlow", ConfigFlow)
+    config_entries.OptionsFlow = getattr(
+        config_entries, "OptionsFlow", type("OptionsFlow", (), {})
+    )
 
     core = _mod("homeassistant.core")
     core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
@@ -239,6 +242,84 @@ class ReauthFlowTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("abort", result["type"])
         self.assertEqual("reauth_account_mismatch", result["reason"])
         self.assertNotIn("update", flow.calls)
+
+
+class UserStepUniqueIdTest(unittest.IsolatedAsyncioTestCase):
+    """#18: async_step_user must set the unique_id and abort an already-configured
+    account BEFORE the costly network validate_input (login + appliance fetch)."""
+
+    def _patch_validate(self, fn) -> None:
+        from custom_components.addhon import config_flow
+
+        original = config_flow.validate_input
+        config_flow.validate_input = fn
+        self.addCleanup(setattr, config_flow, "validate_input", original)
+
+    def _make_user_flow(self):
+        from custom_components.addhon.config_flow import ConfigFlow
+
+        flow = ConfigFlow()
+        flow.hass = object()
+        flow.context = {"source": "user"}
+        flow.unique_id = None
+        flow.calls = {"abort_checked": False, "validated": False}
+
+        async def _set_unique_id(unique_id):
+            flow.unique_id = unique_id
+
+        flow.async_set_unique_id = _set_unique_id
+        flow.async_show_form = lambda **kw: {"type": "form", **kw}
+        flow.async_create_entry = lambda *, title, data: {
+            "type": "create_entry", "title": title, "data": data,
+        }
+        return flow
+
+    async def test_aborts_before_validate_when_already_configured(self) -> None:
+        class AbortFlow(Exception):
+            pass
+
+        flow = self._make_user_flow()
+
+        def _abort_if_configured():
+            flow.calls["abort_checked"] = True
+            raise AbortFlow("already_configured")
+
+        flow._abort_if_unique_id_configured = _abort_if_configured
+
+        async def _validate(hass, data):
+            flow.calls["validated"] = True
+            return {"title": "x", "appliance_count": 1}
+
+        self._patch_validate(_validate)
+
+        with self.assertRaises(AbortFlow):
+            await flow.async_step_user({"email": "Person@Example.com", "password": "p"})
+
+        self.assertTrue(flow.calls["abort_checked"])
+        self.assertFalse(flow.calls["validated"])  # NO network round-trip on re-add
+        self.assertEqual(flow.unique_id, "person@example.com")  # set (lowercased) first
+
+    async def test_creates_entry_when_not_configured(self) -> None:
+        flow = self._make_user_flow()
+        flow._abort_if_unique_id_configured = lambda: flow.calls.__setitem__(
+            "abort_checked", True
+        )
+
+        async def _validate(hass, data):
+            flow.calls["validated"] = True
+            return {"title": "My hOn", "appliance_count": 2}
+
+        self._patch_validate(_validate)
+
+        result = await flow.async_step_user(
+            {"email": "Person@Example.com", "password": "p"}
+        )
+
+        self.assertTrue(flow.calls["abort_checked"])
+        self.assertTrue(flow.calls["validated"])
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["title"], "My hOn")
+        self.assertEqual(flow.unique_id, "person@example.com")
 
 
 if __name__ == "__main__":

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -11,6 +11,7 @@ source/manifest-level guards that catch accidental regressions.
 """
 from __future__ import annotations
 
+import ast
 import json
 import unittest
 from pathlib import Path
@@ -38,6 +39,63 @@ class CoordinatorConfigEntryTest(unittest.TestCase):
             "DataUpdateCoordinator must receive config_entry=entry "
             "(HA 2024.11+; omitting it breaks on newer HA)",
         )
+
+    def test_coordinator_summary_redacts_mac(self) -> None:
+        # #24: the per-device debug summary must not log the raw MAC (a behavioral
+        # test is infeasible: async_update_data is a closure inside async_setup_entry).
+        source = INIT.read_text(encoding="utf-8")
+        self.assertIn(
+            '"mac": redact_mac(',
+            source,
+            "the coordinator debug summary must redact the MAC",
+        )
+        self.assertNotIn(
+            '"mac": appliance_data.get("mac")',
+            source,
+            "raw MAC must not be put in the coordinator debug summary",
+        )
+        # The summary 'id' is the appliance_id = unique_id = MAC (or serial): it must
+        # be redacted too (GAP found by the refuter pool), not just 'mac'.
+        self.assertIn(
+            '"id": redact_mac(appliance_id)',
+            source,
+            "the coordinator debug summary 'id' (= MAC/serial) must be redacted",
+        )
+        self.assertNotIn('"id": appliance_id,', source)
+        self.assertIn("from .debug_utils import redact_mac", source)
+
+    def test_coordinator_summary_redacts_mac_ast(self) -> None:
+        # Robust (decoy/whitespace-proof) version of the guard above: AST-parse the
+        # summary dict literal and require its 'id' and 'mac' values to be a
+        # redact_mac(...) call. A substring guard is fooled by a comment + a space
+        # before the comma; this is not.
+        def _is_redact_mac(call: ast.AST) -> bool:
+            if not isinstance(call, ast.Call):
+                return False
+            func = call.func
+            return (isinstance(func, ast.Name) and func.id == "redact_mac") or (
+                isinstance(func, ast.Attribute) and func.attr == "redact_mac"
+            )
+
+        tree = ast.parse(INIT.read_text(encoding="utf-8"))
+        summaries = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Dict):
+                keys = [k.value for k in node.keys if isinstance(k, ast.Constant)]
+                if {"id", "name", "type", "mac"} <= set(keys):
+                    summaries.append(node)
+        self.assertTrue(summaries, "coordinator summary dict literal not found")
+        for node in summaries:
+            kv = {
+                k.value: v
+                for k, v in zip(node.keys, node.values)
+                if isinstance(k, ast.Constant)
+            }
+            for field in ("id", "mac"):
+                self.assertTrue(
+                    _is_redact_mac(kv[field]),
+                    f"summary '{field}' must be a redact_mac(...) call",
+                )
 
     def test_manifest_has_no_invalid_homeassistant_key(self) -> None:
         manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))

--- a/tests/test_coordinator_resilience.py
+++ b/tests/test_coordinator_resilience.py
@@ -1,0 +1,158 @@
+"""Per-appliance resilience of the coordinator poll (async_get_appliances_data).
+
+A non-auth failure on ONE appliance (a transient cloud 5xx that outlived the
+retries, a malformed payload, ...) must NOT blank EVERY device: the failed
+appliance is simply absent from the snapshot while the others stay live. Only a
+TOTAL failure (every appliance errored) re-raises so the coordinator marks the
+cycle failed instead of publishing an empty snapshot.
+
+Uses the same HA-stub harness as test_hon_client_realtime.py (the real
+homeassistant package is not importable in the unit env).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = sys.modules.get(name)
+    if m is None:
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+    return m
+
+
+def _install_stubs() -> None:
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    exc = _mod("homeassistant.exceptions")
+    base = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base,), {}))
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    ha = _mod("homeassistant")
+    ha.config_entries, ha.core, ha.exceptions = ce, core, exc
+    ha.helpers = _mod("homeassistant.helpers")
+    ha.helpers.update_coordinator = uc
+
+
+_install_stubs()
+
+from custom_components.addhon.hon_client import HonClient  # noqa: E402
+
+
+class FakeApi:
+    def __init__(self, appliances) -> None:
+        self.appliances = appliances
+
+
+class FakeAppliance:
+    def __init__(self, uid: str) -> None:
+        self.unique_id = uid
+        self.attributes = {"parameters": {}, "available": True}
+        self.settings = {"s": 1}
+        self.statistics = {}
+        self.nick_name = uid
+
+
+def _client(appliances):
+    c = HonClient(email="e@x", password="p")
+    c._api = FakeApi(appliances)
+    return c
+
+
+class CoordinatorResilienceTest(unittest.TestCase):
+    def test_first_poll_is_strict_one_failure_raises(self) -> None:
+        # On the FIRST poll, a per-appliance failure must re-raise (NOT skip): platform
+        # setup iterates the first snapshot once with no dynamic discovery, so a skipped
+        # appliance would get zero entities until a reload. Raising -> ConfigEntryNotReady
+        # -> HA retries setup until the full inventory loads.
+        good, bad = FakeAppliance("g1"), FakeAppliance("bad")
+        c = _client([good, bad])  # fresh client: _first_poll_done is False
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError("boom")  # non-auth, non-retryable
+
+        c._update_appliance_sync = _update
+        with self.assertRaises(RuntimeError):
+            asyncio.run(c.async_get_appliances_data())
+        self.assertFalse(c._first_poll_done)  # never completed -> still strict
+
+    def test_first_poll_full_success_flips_flag(self) -> None:
+        c = _client([FakeAppliance("g1"), FakeAppliance("g2")])
+        c._update_appliance_sync = lambda appliance: None
+        data = asyncio.run(c.async_get_appliances_data())
+        self.assertEqual(set(data), {"g1", "g2"})
+        self.assertTrue(c._first_poll_done)  # steady-state resilience now armed
+
+    def test_steady_state_partial_update_keeps_the_others(self) -> None:
+        good1, bad, good2 = FakeAppliance("g1"), FakeAppliance("bad"), FakeAppliance("g2")
+        c = _client([good1, bad, good2])
+        c._first_poll_done = True  # simulate a healthy first poll already happened
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError("boom")  # non-auth, non-retryable
+
+        c._update_appliance_sync = _update
+        data = asyncio.run(c.async_get_appliances_data())
+
+        self.assertIn("g1", data)
+        self.assertIn("g2", data)
+        self.assertNotIn("bad", data)  # the failed appliance is skipped, not fatal
+
+    def test_steady_state_total_failure_raises(self) -> None:
+        bad1, bad2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([bad1, bad2])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(RuntimeError("boom"))
+        # Every appliance failed -> surface a failed update (do NOT publish empty data)
+        with self.assertRaises(RuntimeError):
+            asyncio.run(c.async_get_appliances_data())
+
+    def test_zero_appliances_returns_empty_without_raising(self) -> None:
+        c = _client([])
+        c._update_appliance_sync = lambda appliance: None
+        self.assertEqual(asyncio.run(c.async_get_appliances_data()), {})
+
+    def test_reauth_error_still_triggers_reauth(self) -> None:
+        # Regression: an auth/"session unavailable" error must NOT be silently
+        # skipped like a generic one -> it still drives re-authentication and a retry.
+        app = FakeAppliance("ac")
+        c = _client([app])
+        calls = {"update": 0, "reauth": 0}
+
+        def _update(appliance):
+            calls["update"] += 1
+            if calls["update"] == 1:
+                raise RuntimeError("hOn session unavailable")  # _requires_reauth -> True
+
+        async def _reauth():
+            calls["reauth"] += 1
+            return True
+
+        c._update_appliance_sync = _update
+        c._async_reauth = _reauth
+        data = asyncio.run(c.async_get_appliances_data())
+
+        self.assertEqual(calls["reauth"], 1)       # reauth was attempted
+        self.assertGreaterEqual(calls["update"], 2)  # and the poll retried
+        self.assertIn("ac", data)                  # recovered after reauth
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_coordinator_resilience.py
+++ b/tests/test_coordinator_resilience.py
@@ -51,7 +51,19 @@ def _install_stubs() -> None:
 
 _install_stubs()
 
-from custom_components.addhon.hon_client import HonClient  # noqa: E402
+from custom_components.addhon.hon_client import (  # noqa: E402
+    HonClient,
+    _representative_failure,
+    _requires_reauth,
+)
+from custom_components.addhon.error_codes import (  # noqa: E402
+    APPLIANCE_LOAD_FAILED,
+    AUTH_REFRESH,
+    DECODE_ERROR,
+    UNKNOWN,
+    HonCodedError,
+    classify,
+)
 
 
 class FakeApi:
@@ -88,8 +100,13 @@ class CoordinatorResilienceTest(unittest.TestCase):
                 raise RuntimeError("boom")  # non-auth, non-retryable
 
         c._update_appliance_sync = _update
-        with self.assertRaises(RuntimeError):
+        # CR#6: it now raises a coded error preserving the real cause (boom is opaque ->
+        # APPLIANCE_LOAD_FAILED) and stays NON-auth, so routing is UpdateFailed ->
+        # ConfigEntryNotReady (HA retries setup), not a reauth.
+        with self.assertRaises(HonCodedError) as ctx:
             asyncio.run(c.async_get_appliances_data())
+        self.assertIs(classify(ctx.exception), APPLIANCE_LOAD_FAILED)
+        self.assertFalse(ctx.exception.error_code.requires_reauth)
         self.assertFalse(c._first_poll_done)  # never completed -> still strict
 
     def test_first_poll_full_success_flips_flag(self) -> None:
@@ -120,9 +137,95 @@ class CoordinatorResilienceTest(unittest.TestCase):
         c = _client([bad1, bad2])
         c._first_poll_done = True
         c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(RuntimeError("boom"))
-        # Every appliance failed -> surface a failed update (do NOT publish empty data)
-        with self.assertRaises(RuntimeError):
+        # Every appliance failed -> surface a failed update (do NOT publish empty data).
+        # CR#6: a coded error carrying a meaningful NON-auth code (boom is opaque ->
+        # APPLIANCE_LOAD_FAILED), never the old UNKNOWN.
+        with self.assertRaises(HonCodedError) as ctx:
             asyncio.run(c.async_get_appliances_data())
+        self.assertIs(classify(ctx.exception), APPLIANCE_LOAD_FAILED)
+        self.assertIsNot(classify(ctx.exception), UNKNOWN)
+        self.assertFalse(ctx.exception.error_code.requires_reauth)
+
+    def test_total_failure_preserves_meaningful_code(self) -> None:
+        # CR#6: a real per-appliance cause must reach the catalog, not UNKNOWN.
+        bad1, bad2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([bad1, bad2])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(
+            RuntimeError("decode error")  # non-retryable -> classify DECODE_ERROR
+        )
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIs(classify(ctx.exception), DECODE_ERROR)
+
+    def test_total_failure_carried_coded_error_surfaced(self) -> None:
+        bad1, bad2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([bad1, bad2])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(
+            HonCodedError(DECODE_ERROR)
+        )
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIs(ctx.exception.error_code, DECODE_ERROR)
+
+    def test_total_failure_mixed_picks_first_meaningful(self) -> None:
+        # First failure opaque (UNKNOWN), second meaningful -> the meaningful one wins.
+        b1, b2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([b1, b2])
+        c._first_poll_done = True
+
+        def _update(appliance):
+            if appliance is b1:
+                raise RuntimeError("boom")        # UNKNOWN -> skipped by the picker
+            raise RuntimeError("decode error")    # DECODE_ERROR -> chosen
+
+        c._update_appliance_sync = _update
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIs(classify(ctx.exception), DECODE_ERROR)
+
+    def test_total_failure_all_unknown_falls_back_to_load_failed(self) -> None:
+        b1, b2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([b1, b2])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(RuntimeError("boom"))
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIs(ctx.exception.error_code, APPLIANCE_LOAD_FAILED)
+
+    def test_total_failure_routing_stays_non_auth(self) -> None:
+        b1 = FakeAppliance("b1")
+        c = _client([b1])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(RuntimeError("boom"))
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        # the consumer routes a non-reauth code as a transient UpdateFailed, not a reauth
+        self.assertFalse(_requires_reauth(ctx.exception))
+
+    def test_representative_failure_rejects_reauth_code(self) -> None:
+        # The picker must NOT surface a reauth code (it would flip the transient
+        # UpdateFailed into a ConfigEntryAuthFailed). classify() is substring-based and
+        # could name an auth code for an error the non-auth gate already let through, so
+        # a reauth-classified failure falls back to the non-auth APPLIANCE_LOAD_FAILED.
+        code, _cause = _representative_failure([("n", HonCodedError(AUTH_REFRESH))])
+        self.assertIs(code, APPLIANCE_LOAD_FAILED)
+        self.assertFalse(code.requires_reauth)
+
+    def test_first_poll_failure_preserves_meaningful_code(self) -> None:
+        good, bad = FakeAppliance("g1"), FakeAppliance("bad")
+        c = _client([good, bad])  # _first_poll_done False
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError("decode error")  # DECODE_ERROR, non-retryable
+
+        c._update_appliance_sync = _update
+        with self.assertRaises(HonCodedError) as ctx:
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIs(classify(ctx.exception), DECODE_ERROR)
+        self.assertFalse(c._first_poll_done)
 
     def test_zero_appliances_returns_empty_without_raising(self) -> None:
         c = _client([])

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -59,5 +59,83 @@ class RedactEmailTest(unittest.TestCase):
         self.assertIn("redact_email", debug_utils.__all__)
 
 
+redact_identity = debug_utils.redact_identity
+redact_mac = debug_utils.redact_mac
+
+
+class RedactIdentityTest(unittest.TestCase):
+    def test_masks_known_identity_keys(self) -> None:
+        out = redact_identity({"macAddress": "AA:BB", "serialNumber": "X", "code": "C"})
+        self.assertEqual(out, {"macAddress": "***", "serialNumber": "***", "code": "***"})
+
+    def test_case_insensitive_key_match(self) -> None:
+        self.assertEqual(redact_identity({"MAC": "z"}), {"MAC": "***"})
+
+    def test_non_identity_values_pass_through(self) -> None:
+        self.assertEqual(
+            redact_identity({"modelName": "HDPW", "temp": 4}),
+            {"modelName": "HDPW", "temp": 4},
+        )
+
+    def test_recurses_into_nested_dicts_and_lists(self) -> None:
+        src = {"outer": {"transactionId": "AA_123"}, "items": [{"mobileId": "m"}]}
+        self.assertEqual(
+            redact_identity(src),
+            {"outer": {"transactionId": "***"}, "items": [{"mobileId": "***"}]},
+        )
+
+    def test_does_not_mutate_input(self) -> None:
+        src = {"mac": "secret", "nested": {"token": "t"}}
+        redact_identity(src)
+        self.assertEqual(src, {"mac": "secret", "nested": {"token": "t"}})
+
+    def test_scalar_input_returned_unchanged(self) -> None:
+        self.assertEqual(redact_identity("plain"), "plain")
+        self.assertEqual(redact_identity(7), 7)
+        self.assertIsNone(redact_identity(None))
+
+    def test_exported_in_all(self) -> None:
+        self.assertIn("redact_identity", debug_utils.__all__)
+
+
+class RedactMacTest(unittest.TestCase):
+    def test_none_returns_none(self) -> None:
+        self.assertIsNone(redact_mac(None))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(redact_mac(""))
+
+    def test_full_mac_is_masked(self) -> None:
+        self.assertEqual(redact_mac("AA:BB:CC:DD:EE:FF"), "***")
+
+    def test_raw_mac_never_leaks(self) -> None:
+        out = redact_mac("AA:BB:CC:DD:EE:FF")
+        self.assertNotIn("AA", out)
+        self.assertNotIn(":", out)
+
+    def test_exported_in_all(self) -> None:
+        self.assertIn("redact_mac", debug_utils.__all__)
+
+
+class IdentityKeysPinTest(unittest.TestCase):
+    """Pin the EXACT _IDENTITY_KEYS set: iterating the set in a test would silently
+    stop checking a removed key, so dropping one (e.g. the snake-case transaction_id
+    not covered by the diagnostics drift-guard) must fail here."""
+
+    _EXPECTED = frozenset(
+        {
+            "serial", "serialnumber", "serial_number",
+            "mac", "macaddress", "mac_address",
+            "code", "nickname", "nick_name", "email",
+            "password", "token", "access_token", "refresh_token",
+            "authorization", "secret",
+            "transactionid", "transaction_id", "mobileid", "mobile_id",
+        }
+    )
+
+    def test_identity_keys_exact(self) -> None:
+        self.assertEqual(set(debug_utils._IDENTITY_KEYS), set(self._EXPECTED))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -209,5 +209,58 @@ class IdentityKeysPinTest(unittest.TestCase):
         self.assertEqual(set(debug_utils._IDENTITY_KEYS), set(self._EXPECTED))
 
 
+redact_store = debug_utils.redact_store
+
+
+class RedactStoreTest(unittest.TestCase):
+    """CR#1: a coordinator store dumped to a debug log must mask its KEYS (MAC-derived
+    appliance ids) while keeping the non-identity VALUES (program codes)."""
+
+    def test_masks_mac_keyed_keys(self) -> None:
+        out = redact_store({"AA:BB:CC:DD:EE:FF": "iot_auto"})
+        self.assertEqual(out, {"***": "iot_auto"})
+
+    def test_raw_mac_key_never_leaks(self) -> None:
+        out = redact_store({"AA:BB:CC:DD:EE:FF": "iot_auto"})
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", str(out))
+        self.assertNotIn("AA:BB", str(out))
+
+    def test_values_pass_through(self) -> None:
+        # program codes are the diagnostic signal and carry no identity
+        self.assertEqual(redact_store({"mac": "super_cool"}), {"***": "super_cool"})
+
+    def test_multiple_appliances_keep_all_values_no_collapse(self) -> None:
+        # distinct keys all mask to '***'; without disambiguation they would collapse
+        # to one entry and drop a value -> the ordinal preserves count + every value.
+        out = redact_store({"AA:BB:CC:DD:EE:01": "a", "AA:BB:CC:DD:EE:02": "b"})
+        self.assertEqual(set(out), {"***", "***#2"})
+        self.assertEqual(sorted(out.values()), ["a", "b"])
+
+    def test_three_way_collision_keeps_all(self) -> None:
+        # exercises the ordinal loop beyond the 2-way case
+        out = redact_store({"AA:11": "a", "BB:22": "b", "CC:33": "c"})
+        self.assertEqual(set(out), {"***", "***#2", "***#3"})
+        self.assertEqual(sorted(out.values()), ["a", "b", "c"])
+
+    def test_int_id_fallback_key_is_masked(self) -> None:
+        # _appliance_id can fall back to id(obj); even a non-string key must mask.
+        self.assertEqual(redact_store({140234567890: "iot_auto"}), {"***": "iot_auto"})
+
+    def test_empty_store(self) -> None:
+        self.assertEqual(redact_store({}), {})
+
+    def test_does_not_mutate_input(self) -> None:
+        src = {"AA:BB:CC:DD:EE:FF": "iot_auto"}
+        redact_store(src)
+        self.assertEqual(src, {"AA:BB:CC:DD:EE:FF": "iot_auto"})
+
+    def test_non_mapping_returned_unchanged(self) -> None:
+        self.assertEqual(redact_store("not-a-dict"), "not-a-dict")
+        self.assertIsNone(redact_store(None))
+
+    def test_exported_in_all(self) -> None:
+        self.assertIn("redact_store", debug_utils.__all__)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -86,6 +86,45 @@ class RedactIdentityTest(unittest.TestCase):
             {"outer": {"transactionId": "***"}, "items": [{"mobileId": "***"}]},
         )
 
+    def test_masks_mac_shaped_string_leaf(self) -> None:
+        # CR#4: identity that arrives where key-name redaction can't reach -- a bare
+        # list element or a value under a benign key -- is masked via the MAC pattern.
+        self.assertEqual(redact_identity("AA:BB:CC:DD:EE:FF"), "***")
+        self.assertEqual(
+            redact_identity({"parameters": ["AA:BB:CC:DD:EE:FF", "ok"]}),
+            {"parameters": ["***", "ok"]},
+        )
+        self.assertEqual(
+            redact_identity({"benign": "AA:BB:CC:DD:EE:FF"}), {"benign": "***"}
+        )
+
+    def test_mac_with_dash_separators_masked(self) -> None:
+        self.assertEqual(redact_identity("aa-bb-cc-dd-ee-ff"), "***")
+
+    def test_non_mac_string_leaf_passes_through(self) -> None:
+        # no over-redaction of legitimate non-MAC values
+        self.assertEqual(redact_identity("iot_auto"), "iot_auto")
+        self.assertEqual(
+            redact_identity({"benign": "HDPW5620CNPK"}), {"benign": "HDPW5620CNPK"}
+        )
+
+    def test_embedded_mac_in_string_leaf_masked(self) -> None:
+        # a MAC embedded mid-string (not an exact match) is still masked
+        self.assertEqual(
+            redact_identity("device AA:BB:CC:DD:EE:FF online"), "device *** online"
+        )
+
+    def test_serial_leaf_passes_through_documented_residual(self) -> None:
+        # DOCUMENTED RESIDUAL: a serial/mobile-id has no safe pattern, so a BARE serial
+        # scalar (e.g. a malformed parameters element, or a value under a benign key) is
+        # NOT masked by redact_identity -- only the MAC class is. A serial under a real
+        # `serialNumber` KEY is still masked (key-based). This pins the deliberate CR#2
+        # residual: if a future change starts masking bare serials, update this test.
+        self.assertEqual(redact_identity("SN0123456789ABC"), "SN0123456789ABC")
+        self.assertEqual(redact_identity(["SN0123456789ABC"]), ["SN0123456789ABC"])
+        self.assertEqual(redact_identity({"serialNumber": "SN0123456789ABC"}),
+                         {"serialNumber": "***"})  # key-based still masks it
+
     def test_does_not_mutate_input(self) -> None:
         src = {"mac": "secret", "nested": {"token": "t"}}
         redact_identity(src)

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -61,6 +61,8 @@ class RedactEmailTest(unittest.TestCase):
 
 redact_identity = debug_utils.redact_identity
 redact_mac = debug_utils.redact_mac
+redact_id = debug_utils.redact_id
+redact_topic = debug_utils.redact_topic
 
 
 class RedactIdentityTest(unittest.TestCase):
@@ -115,6 +117,76 @@ class RedactMacTest(unittest.TestCase):
 
     def test_exported_in_all(self) -> None:
         self.assertIn("redact_mac", debug_utils.__all__)
+
+
+class RedactIdTest(unittest.TestCase):
+    def test_bare_id_is_fully_masked(self) -> None:
+        self.assertEqual(redact_id("AA:BB:CC:DD:EE:FF"), "***")
+        self.assertEqual(redact_id("SERIAL123"), "***")
+
+    def test_falsy_passthrough(self) -> None:
+        # Falsy returned unchanged so an `or <fallback>` at the call site still works.
+        self.assertIsNone(redact_id(None))
+        self.assertEqual(redact_id(""), "")
+
+    def test_raw_id_never_leaks(self) -> None:
+        out = redact_id("AA:BB:CC:DD:EE:FF")
+        self.assertNotIn("AA", out)
+        self.assertNotIn(":", out)
+
+    def test_unique_id_keeps_suffix_masks_prefix(self) -> None:
+        # f"{appliance_id}_{suffix}" -> the MAC prefix is masked, the suffix kept.
+        self.assertEqual(redact_id("AA:BB:CC_program", "AA:BB:CC"), "***_program")
+        self.assertEqual(
+            redact_id("SERIAL123_target_temp_zone3", "SERIAL123"),
+            "***_target_temp_zone3",
+        )
+
+    def test_prefix_absent_falls_back_to_full_mask(self) -> None:
+        # parent_id not a prefix (defensive) -> mask the whole thing, never leak.
+        self.assertEqual(redact_id("HonNumberXYZ", "AA:BB:CC"), "***")
+
+    def test_no_parent_id_full_mask(self) -> None:
+        self.assertEqual(redact_id("AA:BB:CC_program"), "***")
+
+    def test_non_string_value_coerced(self) -> None:
+        self.assertEqual(redact_id(12345), "***")
+
+    def test_exported_in_all(self) -> None:
+        self.assertIn("redact_id", debug_utils.__all__)
+
+
+class RedactTopicTest(unittest.TestCase):
+    def test_masks_dash_mac_in_topic(self) -> None:
+        self.assertEqual(
+            redact_topic("haier/things/3c-71-bf-bd-32-2c/event/appliancestatus/update"),
+            "haier/things/***/event/appliancestatus/update",
+        )
+
+    def test_masks_colon_mac_in_topic(self) -> None:
+        self.assertEqual(
+            redact_topic("haier/things/AA:BB:CC:DD:EE:FF/event/connected"),
+            "haier/things/***/event/connected",
+        )
+
+    def test_keeps_event_path(self) -> None:
+        out = redact_topic("x/3c-71-bf-bd-32-2c/event/disconnected")
+        self.assertIn("event/disconnected", out)
+        self.assertNotIn("3c-71-bf-bd-32-2c", out)
+
+    def test_no_mac_unchanged(self) -> None:
+        self.assertEqual(redact_topic("haier/things/foo/event"), "haier/things/foo/event")
+
+    def test_raw_mac_never_leaks(self) -> None:
+        mac = "3c-71-bf-bd-32-2c"
+        self.assertNotIn(mac, redact_topic(f"haier/things/{mac}/event/x"))
+
+    def test_falsy_passthrough(self) -> None:
+        self.assertIsNone(redact_topic(None))
+        self.assertEqual(redact_topic(""), "")
+
+    def test_exported_in_all(self) -> None:
+        self.assertIn("redact_topic", debug_utils.__all__)
 
 
 class IdentityKeysPinTest(unittest.TestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -169,6 +169,7 @@ def _install_stubs() -> None:
 _install_stubs()
 
 from custom_components.addhon import diagnostics  # noqa: E402
+from custom_components.addhon import debug_utils  # noqa: E402
 from custom_components.addhon.const import DOMAIN  # noqa: E402
 
 
@@ -615,6 +616,20 @@ class DiagnosticsCoverageMetaTest(unittest.TestCase):
         cov = self._coverage_ac()
         self.assertEqual(cov["command_params_total"], 1)
         self.assertEqual(len(cov["command_params_unmapped"]), cov["command_params_total"])
+
+
+class IdentityKeysDriftGuardTest(unittest.TestCase):
+    """The shared log redactor (debug_utils._IDENTITY_KEYS) must redact at least
+    everything the Download-Diagnostics path (diagnostics._TO_REDACT) does, so a
+    new secret key added to one is not left in cleartext in the other."""
+
+    def test_to_redact_is_subset_of_identity_keys(self) -> None:
+        missing = set(diagnostics._TO_REDACT) - set(debug_utils._IDENTITY_KEYS)
+        self.assertEqual(
+            missing,
+            set(),
+            f"keys redacted by diagnostics but NOT by the log redactor: {missing}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -632,5 +632,26 @@ class IdentityKeysDriftGuardTest(unittest.TestCase):
         )
 
 
+class LastErrorDiagnosticsTest(unittest.TestCase):
+    """#30: the config-entry diagnostics expose the last classified error code."""
+
+    def test_last_error_none_without_client(self) -> None:
+        # FakeHass stores only the coordinator -> no recorded error.
+        result = _run(diagnostics.async_get_config_entry_diagnostics(FakeHass(_build_coordinator()), FakeEntry()))
+        self.assertIn("last_error", result)
+        self.assertIsNone(result["last_error"])
+
+    def test_last_error_reports_code_and_reason(self) -> None:
+        from custom_components.addhon import error_codes as ec
+
+        class _Client:
+            last_error_code = ec.NETWORK_TIMEOUT
+
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"]["client"] = _Client()
+        result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        self.assertEqual(result["last_error"], {"code": "ADDHON-400", "reason": ec.NETWORK_TIMEOUT.reason_en})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -425,6 +425,27 @@ class ClusterBehaviorTest(unittest.TestCase):
         c.parameters["mode"].value = "hot"
         self.assertEqual(c.parameters["temp"].value, 22.5)
 
+    def test_sync_params_to_command_preserves_half_degree(self) -> None:
+        # ORACLE (Bug3 at its call-site): a half-degree setpoint (22.5) coming from the
+        # attributes must survive sync_params_to_command into the command settings, not
+        # be truncated to 22. The old code assigned float(new.value) to the range setter,
+        # and str_to_float(22.5)=int(22.5)=22 truncates silently (step 0.5 makes the
+        # truncated 22 pass the off-step check, so no ValueError surfaced). The fix
+        # assigns str(new.value). Without this test a regression to float() would still
+        # leave all other tests green.
+        from custom_components.addhon.client.engine.attributes import HonAttribute
+
+        command = NaCommand(
+            "settings",
+            {"parameters": {"temp": _range(default="20", lo="16", hi="30", inc="0.5")}},
+            FakeAppliance(),
+        )
+        app = NaAppliance(FakeApi(), dict(_INFO), zone=0)
+        app._commands = {"settings": command}
+        app._attributes = {"parameters": {"temp": HonAttribute({"parNewVal": "22.5"})}}
+        app.sync_params_to_command("settings")
+        self.assertEqual(command.settings["temp"].value, 22.5)
+
     def test_ac_eco_nested_rule_fires(self) -> None:
         # REAL AC structure (apk/dump/ac_live): ecoMode=1 with machMode fixed=1
         # must constrain tempSel to 26 and the wind-direction (nested extra-condition).

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -158,5 +158,42 @@ class NativeEnumEdgeBehaviorTest(unittest.TestCase):
             na.value = "A|B|C"
 
 
+class RangeSetterHardeningTest(unittest.TestCase):
+    """ITEM A: a fractional float assigned DIRECTLY to the range setter must not be
+    truncated. The setter delegated to str_to_float, whose int()-first quirk turned a
+    raw 22.5 into 22 silently (the golden never hit this: range.values yields strings).
+    Integer-valued inputs must stay int so intern_value is clean ("24", never "24.0")."""
+
+    def _range(self, lo="20", hi="25", step="0.5"):
+        return NaRange("temp", {"category": "command", "typology": "range",
+                                "mandatory": 0, "minimumValue": lo, "maximumValue": hi,
+                                "incrementValue": step, "defaultValue": lo}, "grp")
+
+    def test_fractional_float_not_truncated(self) -> None:
+        p = self._range()
+        p.value = 22.5  # FLOAT passed directly, not the documented string
+        self.assertEqual(p.value, 22.5)
+        self.assertEqual(p.intern_value, "22.5")
+
+    def test_integer_valued_inputs_stay_int_and_clean(self) -> None:
+        # str "24", int 24 and float 24.0 must all store int 24 -> intern "24", no "24.0".
+        for v in ("24", 24, 24.0):
+            p = self._range()
+            p.value = v
+            self.assertEqual(p.value, 24)
+            self.assertEqual(p.intern_value, "24")
+
+    def test_off_grid_float_raises_instead_of_truncating(self) -> None:
+        # 22.3 is off the 0.5 grid: it must raise, not be truncated to 22 and accepted.
+        p = self._range()
+        with self.assertRaises(ValueError):
+            p.value = 22.3
+
+    def test_decimal_comma_string_still_preserved(self) -> None:
+        p = self._range()
+        p.value = "22,5"  # cloud decimal comma -> 22.5 (string path unchanged)
+        self.assertEqual(p.value, 22.5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -1,0 +1,230 @@
+"""Tests for the stable error-code catalog (issue #30).
+
+Covers catalog integrity (unique codes/slugs, label format), the classify()
+mapping for the representative failures, the HonCodedError carrier (and that it
+never leaks identity), the phase->timeout mapping, the _requires_reauth coupling,
+and the catalog<->translations contract (every UI code has en+it strings with the
+{error_code} placeholder, and no orphan error keys).
+
+Pure stdlib unittest. HA is stubbed only because importing the package runs its
+__init__.py; classify() lazily imports hon_client which is HA-free at module top.
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+COMPONENT = REPO / "custom_components" / "addhon"
+TRANSLATIONS = COMPONENT / "translations"
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = sys.modules.get(name)
+    if m is None:
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+    return m
+
+
+def _install_ha_stubs() -> None:
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    exc = _mod("homeassistant.exceptions")
+    base = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base,), {}))
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    ha = _mod("homeassistant")
+    ha.config_entries, ha.core, ha.exceptions = ce, core, exc
+    ha.helpers = _mod("homeassistant.helpers")
+    ha.helpers.update_coordinator = uc
+
+
+_install_ha_stubs()
+
+from custom_components.addhon import error_codes as ec  # noqa: E402
+from custom_components.addhon import hon_client as hc  # noqa: E402
+
+
+# Class named like the real one (classify keys off the class NAME for auth).
+class NativeAuthError(Exception):
+    pass
+
+
+class CatalogIntegrityTest(unittest.TestCase):
+    def test_codes_and_slugs_unique(self) -> None:
+        codes = [c.code for c in ec.all_codes()]
+        slugs = [c.slug for c in ec.all_codes()]
+        self.assertEqual(len(codes), len(set(codes)), "duplicate numeric code")
+        self.assertEqual(len(slugs), len(set(slugs)), "duplicate slug")
+
+    def test_label_format(self) -> None:
+        for c in ec.all_codes():
+            self.assertEqual(c.label, f"ADDHON-{c.code}")
+            self.assertTrue(c.reason_en.isascii(), f"{c.slug} reason must be ASCII")
+
+    def test_known_code_number(self) -> None:
+        # The MQTT subscribe timeout is the user's illustrative example.
+        self.assertEqual(ec.MQTT_SUBSCRIBE_TIMEOUT.label, "ADDHON-320")
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_coded_error_returns_its_code(self) -> None:
+        err = ec.HonCodedError(ec.MQTT_CONNECT_TIMEOUT)
+        self.assertIs(ec.classify(err), ec.MQTT_CONNECT_TIMEOUT)
+
+    def test_timeout_uses_phase(self) -> None:
+        self.assertIs(ec.classify(asyncio.TimeoutError()), ec.LOOP_TIMEOUT)
+        self.assertIs(
+            ec.classify(concurrent.futures.TimeoutError(), phase="connect"),
+            ec.NETWORK_TIMEOUT,
+        )
+        self.assertIs(
+            ec.classify(asyncio.TimeoutError(), phase="mqtt_subscribe"),
+            ec.MQTT_SUBSCRIBE_TIMEOUT,
+        )
+        self.assertIs(
+            ec.classify(asyncio.TimeoutError(), phase="load_appliance"),
+            ec.NETWORK_TIMEOUT,
+        )
+
+    def test_auth_step_messages(self) -> None:
+        self.assertIs(ec.classify(NativeAuthError("login: failed (status 200)")), ec.AUTH_LOGIN)
+        self.assertIs(ec.classify(NativeAuthError("api_auth: no cognito token")), ec.AUTH_API_AUTH)
+        self.assertIs(ec.classify(NativeAuthError("get_token: status 404")), ec.AUTH_GET_TOKEN)
+        self.assertIs(ec.classify(NativeAuthError("introduce: no login url")), ec.AUTH_INTRODUCE)
+        self.assertIs(ec.classify(NativeAuthError("Decode Error")), ec.DECODE_ERROR)
+
+    def test_server_and_rate_limit_win_over_auth_name(self) -> None:
+        # Retryable 5xx / 429 must beat the auth-named class (existing routing rule).
+        self.assertIs(ec.classify(NativeAuthError("boom status 500")), ec.SERVER_ERROR)
+        self.assertIs(ec.classify(NativeAuthError("429 too many requests")), ec.RATE_LIMITED)
+
+    def test_network_classes(self) -> None:
+        self.assertIs(ec.classify(RuntimeError("certificate verify failed")), ec.TLS_FAILURE)
+        self.assertIs(ec.classify(RuntimeError("getaddrinfo failed")), ec.DNS_FAILURE)
+        self.assertIs(ec.classify(RuntimeError("Connection refused")), ec.CONNECTION_REFUSED)
+
+    def test_aiohttp_connect_failure_is_not_tls(self) -> None:
+        # aiohttp's ClientConnectorError __str__ ALWAYS carries "ssl:default" for any
+        # HTTPS connect failure; that is a plain outage, NOT a TLS problem (refuter F1).
+        class ClientConnectorError(Exception):
+            pass
+
+        err = ClientConnectorError(
+            "Cannot connect to host api-iot.he.services:443 ssl:default [Connect call failed]"
+        )
+        self.assertIs(ec.classify(err), ec.CONNECTION_REFUSED)
+
+    def test_aiohttp_dns_failure_via_connector(self) -> None:
+        class ClientConnectorError(Exception):
+            pass
+
+        err = ClientConnectorError(
+            "Cannot connect to host api-iot.he.services:443 ssl:default "
+            "[Errno -2] Name or service not known"
+        )
+        self.assertIs(ec.classify(err), ec.DNS_FAILURE)
+
+    def test_real_cert_error_is_tls_by_class_name(self) -> None:
+        # A genuine TLS failure: aiohttp raises ClientConnectorCertificateError; the
+        # class NAME carries "certificate" even though the message also says
+        # "cannot connect to host".
+        class ClientConnectorCertificateError(Exception):
+            pass
+
+        err = ClientConnectorCertificateError(
+            "Cannot connect to host api-iot.he.services:443 ssl:default "
+            "[SSLCertVerificationError: certificate has expired]"
+        )
+        self.assertIs(ec.classify(err), ec.TLS_FAILURE)
+
+    def test_fallback_unknown(self) -> None:
+        self.assertIs(ec.classify(RuntimeError("something odd happened")), ec.UNKNOWN)
+
+    def test_generic_auth_keyword_fallback(self) -> None:
+        self.assertIs(ec.classify(RuntimeError("HTTP 401 unauthorized")), ec.INVALID_CREDENTIALS)
+
+
+class CodedErrorTest(unittest.TestCase):
+    def test_str_has_label_and_reason_no_identity(self) -> None:
+        err = ec.HonCodedError(ec.INVALID_CREDENTIALS, phase="connect")
+        text = str(err)
+        self.assertIn("ADDHON-100", text)
+        self.assertIn("Invalid email or password", text)
+        self.assertNotIn("@", text)  # no email/identity ever in the message
+        self.assertEqual(err.phase, "connect")
+        self.assertIs(err.error_code, ec.INVALID_CREDENTIALS)
+
+    def test_phase_timeout_code(self) -> None:
+        self.assertIs(ec.phase_timeout_code(""), ec.LOOP_TIMEOUT)
+        self.assertIs(ec.phase_timeout_code(None), ec.LOOP_TIMEOUT)
+        self.assertIs(ec.phase_timeout_code("mqtt_connect"), ec.MQTT_CONNECT_TIMEOUT)
+        self.assertIs(ec.phase_timeout_code("aws_token"), ec.MQTT_CONNECT_TIMEOUT)
+        # Every phase-timeout code must read as retryable (so the failure is retried,
+        # never mistaken for a reauth) -> its message must trip _is_retryable_server_error.
+        for slug in ("loop_timeout", "network_timeout", "mqtt_connect_timeout", "mqtt_subscribe_timeout"):
+            self.assertTrue(
+                hc._is_retryable_server_error(ec.HonCodedError(ec.by_slug(slug))),
+                f"{slug} should be retryable",
+            )
+
+
+class RequiresReauthCouplingTest(unittest.TestCase):
+    def test_coded_error_routes_by_its_flag(self) -> None:
+        self.assertTrue(hc._requires_reauth(ec.HonCodedError(ec.AUTH_LOGIN)))
+        self.assertTrue(hc._requires_reauth(ec.HonCodedError(ec.INVALID_CREDENTIALS)))
+        self.assertFalse(hc._requires_reauth(ec.HonCodedError(ec.NETWORK_TIMEOUT)))
+        self.assertFalse(hc._requires_reauth(ec.HonCodedError(ec.LOOP_TIMEOUT)))
+        self.assertFalse(hc._requires_reauth(ec.HonCodedError(ec.MQTT_SUBSCRIBE_TIMEOUT)))
+
+    def test_plain_errors_unchanged(self) -> None:
+        # The legacy path (no error_code attr) keeps its behaviour.
+        self.assertTrue(hc._requires_reauth(NativeAuthError("login failed")))
+        self.assertFalse(hc._requires_reauth(NativeAuthError("boom status 500")))
+        self.assertFalse(hc._requires_reauth(RuntimeError("network down")))
+
+
+class CatalogTranslationsContractTest(unittest.TestCase):
+    """Every UI code must have an en+it string with the {error_code} placeholder,
+    and the config.error key set is exactly the buckets + the UI slugs."""
+
+    def setUp(self) -> None:
+        self.errors = {
+            lang: json.loads((TRANSLATIONS / f"{lang}.json").read_text("utf-8"))["config"]["error"]
+            for lang in ("en", "it")
+        }
+
+    def test_ui_codes_have_localized_strings_with_placeholder(self) -> None:
+        for code in ec.all_codes():
+            if not code.ui:
+                continue
+            for lang in ("en", "it"):
+                self.assertIn(code.slug, self.errors[lang], f"{lang}: missing error.{code.slug}")
+                self.assertIn(
+                    "{error_code}",
+                    self.errors[lang][code.slug],
+                    f"{lang}: error.{code.slug} must carry the {{error_code}} placeholder",
+                )
+
+    def test_no_orphan_error_keys(self) -> None:
+        expected = {"cannot_connect", "invalid_auth"} | {c.slug for c in ec.all_codes() if c.ui}
+        for lang in ("en", "it"):
+            self.assertEqual(set(self.errors[lang]), expected, f"{lang}: error key drift")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -50,6 +50,7 @@ def _install_stubs() -> None:
 _install_stubs()
 
 from custom_components.addhon.hon_client import HonClient  # noqa: E402
+from custom_components.addhon.error_codes import HonCodedError  # noqa: E402
 
 
 class FakeSession:
@@ -272,8 +273,9 @@ class DiscoveryLogRedactionTest(unittest.TestCase):
         self.assertEqual(data[mac]["name"], nick)
 
     def test_update_error_warning_redacts_nick_name(self) -> None:
-        # The per-appliance error path logs a WARNING with the nick_name and re-raises
-        # a RuntimeError carrying it (first poll). Neither must leak the nick.
+        # The per-appliance error path logs a WARNING with the nick_name and (first
+        # poll) re-raises a coded error (CR#6: HonCodedError preserving the cause).
+        # Neither the WARNING nor the raised error must leak the nick.
         nick = "NickSecret42"
         app = types.SimpleNamespace(
             mac_address="AA:BB:CC:DD:EE:FF",
@@ -297,12 +299,12 @@ class DiscoveryLogRedactionTest(unittest.TestCase):
 
         logger = "custom_components.addhon.hon_client"
         with self.assertLogs(logger, level="WARNING") as cm:
-            with self.assertRaises(RuntimeError) as ctx:
+            with self.assertRaises(HonCodedError) as ctx:
                 asyncio.run(c.async_get_appliances_data())
         blob = "\n".join(cm.output)
         self.assertTrue(any("Error updating" in line for line in cm.output))
         self.assertNotIn(nick, blob)  # WARNING must not leak the nick
-        self.assertNotIn(nick, str(ctx.exception))  # nor the re-raised RuntimeError
+        self.assertNotIn(nick, str(ctx.exception))  # nor the raised coded error
 
     def test_steady_state_partial_failure_warning_redacts_nick(self) -> None:
         # Steady state (resilient): one appliance fails, the other succeeds. The
@@ -338,6 +340,41 @@ class DiscoveryLogRedactionTest(unittest.TestCase):
         self.assertTrue(any("Partial update" in line for line in cm.output))
         self.assertNotIn(nick_bad, blob)  # neither the per-appliance nor the joined list
         self.assertIn(app_ok.unique_id, data)  # the healthy appliance survives
+
+    def test_steady_state_total_failure_warning_redacts_nick(self) -> None:
+        # Steady state, EVERY appliance fails (CR#6): the all-failed summary WARNING
+        # joins the failed names (must redact) and the raised coded error carries no
+        # identity in its message.
+        nick1, nick2 = "SecretNickA1", "SecretNickB2"
+        app1 = types.SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:11", unique_id="AA:BB:CC:DD:EE:11",
+            appliance_type="REF", nick_name=nick1,
+            attributes={}, settings={}, statistics={},
+        )
+        app2 = types.SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:12", unique_id="AA:BB:CC:DD:EE:12",
+            appliance_type="REF", nick_name=nick2,
+            attributes={}, settings={}, statistics={},
+        )
+        c = HonClient(email="e@x", password="p")
+        c._first_poll_done = True  # steady state -> all fail -> all-failed branch
+
+        async def fake_get_appliances():
+            return [app1, app2]
+
+        c.async_get_appliances = fake_get_appliances  # type: ignore[assignment]
+        c._update_appliance_sync = lambda a: (_ for _ in ()).throw(ValueError("update boom"))
+
+        logger = "custom_components.addhon.hon_client"
+        with self.assertLogs(logger, level="WARNING") as cm:
+            with self.assertRaises(HonCodedError) as ctx:
+                asyncio.run(c.async_get_appliances_data())
+        blob = "\n".join(cm.output)
+        self.assertTrue(any("Update failed for all" in line for line in cm.output))
+        self.assertNotIn(nick1, blob)  # summary WARNING must redact the joined names
+        self.assertNotIn(nick2, blob)
+        self.assertNotIn(nick1, str(ctx.exception))  # nor the raised coded error
+        self.assertNotIn(nick2, str(ctx.exception))
 
 
 class RealtimeWiringSourceGuard(unittest.TestCase):

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -110,6 +110,34 @@ class HonClientRealtimeTest(unittest.TestCase):
         c = HonClient(email="e@x", password="p")  # _hon_instance is None
         self.assertEqual(c.build_realtime_snapshot(), {})
 
+    def test_build_realtime_snapshot_skips_raising_appliance(self) -> None:
+        # Runs on the awscrt thread: one appliance raising must be skipped, never
+        # take down the whole snapshot.
+        class BadAppliance:
+            unique_id = "bad"
+            nick_name = "x"
+            statistics = {}
+
+            @property
+            def attributes(self):
+                raise RuntimeError("boom")
+
+        good = FakeAppliance("good")
+        c = _client([BadAppliance(), good])
+        snap = c.build_realtime_snapshot()
+        self.assertIn("good", snap)
+        self.assertNotIn("bad", snap)
+
+    def test_build_appliance_entry_has_all_keys(self) -> None:
+        # Pin the shared shape so the realtime snapshot and the HTTP poll never
+        # diverge (the reason _build_appliance_entry was extracted).
+        entry = HonClient._build_appliance_entry(FakeAppliance("x"))
+        self.assertEqual(
+            set(entry),
+            {"appliance", "type", "name", "model", "serial", "mac",
+             "attributes", "statistics", "settings"},
+        )
+
     def test_notify_roundtrip_invokes_callback(self) -> None:
         # subscribe_updates registers on the session; session.notify() (called by the
         # MQTT push) must invoke the callback.

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -9,6 +9,7 @@ test_coordinator_config_entry.py).
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 import types
 import unittest
@@ -232,6 +233,40 @@ class HonClientRealtimeTest(unittest.TestCase):
         c.subscribe_updates(lambda _arg: calls.append(True))
         c._hon_instance.notify()
         self.assertEqual(calls, [True])
+
+
+class DiscoveryLogRedactionTest(unittest.TestCase):
+    """The poll/discovery DEBUG logs (incl. the 'Updated' line) must redact the
+    MAC and the appliance_id (= MAC/serial), never log them raw."""
+
+    def test_discovery_and_updated_logs_redact_identity(self) -> None:
+        mac = "AA:BB:CC:DD:EE:FF"
+        app = types.SimpleNamespace(
+            mac_address=mac,
+            unique_id=mac,
+            appliance_type="REF",
+            nick_name="Fridge",
+            attributes={},
+            settings={},
+            statistics={},
+        )
+        c = HonClient(email="e@x", password="p")
+
+        async def fake_get_appliances():
+            return [app]
+
+        c.async_get_appliances = fake_get_appliances  # type: ignore[assignment]
+        c._update_appliance_sync = lambda a: None  # type: ignore[assignment]
+
+        logger = "custom_components.addhon.hon_client"
+        with self.assertLogs(logger, level="DEBUG") as cm:
+            data = asyncio.run(c.async_get_appliances_data())
+        blob = "\n".join(cm.output)
+        self.assertNotIn(mac, blob)  # neither mac= nor id= leak the MAC
+        self.assertIn("***", blob)
+        self.assertTrue(any("Updated" in line for line in cm.output))
+        # the coordinator DATA still carries the real MAC (data, not a log)
+        self.assertIn(mac, data)
 
 
 class RealtimeWiringSourceGuard(unittest.TestCase):

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -237,15 +237,16 @@ class HonClientRealtimeTest(unittest.TestCase):
 
 class DiscoveryLogRedactionTest(unittest.TestCase):
     """The poll/discovery DEBUG logs (incl. the 'Updated' line) must redact the
-    MAC and the appliance_id (= MAC/serial), never log them raw."""
+    MAC, the appliance_id (= MAC/serial) and the nick_name, never log them raw."""
 
     def test_discovery_and_updated_logs_redact_identity(self) -> None:
         mac = "AA:BB:CC:DD:EE:FF"
+        nick = "NickSecret42"
         app = types.SimpleNamespace(
             mac_address=mac,
             unique_id=mac,
             appliance_type="REF",
-            nick_name="Fridge",
+            nick_name=nick,
             attributes={},
             settings={},
             statistics={},
@@ -263,10 +264,80 @@ class DiscoveryLogRedactionTest(unittest.TestCase):
             data = asyncio.run(c.async_get_appliances_data())
         blob = "\n".join(cm.output)
         self.assertNotIn(mac, blob)  # neither mac= nor id= leak the MAC
+        self.assertNotIn(nick, blob)  # nick_name (= identity) must not leak either
         self.assertIn("***", blob)
         self.assertTrue(any("Updated" in line for line in cm.output))
-        # the coordinator DATA still carries the real MAC (data, not a log)
+        # the coordinator DATA still carries the real MAC + nick (data, not a log)
         self.assertIn(mac, data)
+        self.assertEqual(data[mac]["name"], nick)
+
+    def test_update_error_warning_redacts_nick_name(self) -> None:
+        # The per-appliance error path logs a WARNING with the nick_name and re-raises
+        # a RuntimeError carrying it (first poll). Neither must leak the nick.
+        nick = "NickSecret42"
+        app = types.SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:FF",
+            unique_id="AA:BB:CC:DD:EE:FF",
+            appliance_type="REF",
+            nick_name=nick,
+            attributes={},
+            settings={},
+            statistics={},
+        )
+        c = HonClient(email="e@x", password="p")
+
+        async def fake_get_appliances():
+            return [app]
+
+        def boom(_a):
+            raise ValueError("update boom")
+
+        c.async_get_appliances = fake_get_appliances  # type: ignore[assignment]
+        c._update_appliance_sync = boom  # type: ignore[assignment]
+
+        logger = "custom_components.addhon.hon_client"
+        with self.assertLogs(logger, level="WARNING") as cm:
+            with self.assertRaises(RuntimeError) as ctx:
+                asyncio.run(c.async_get_appliances_data())
+        blob = "\n".join(cm.output)
+        self.assertTrue(any("Error updating" in line for line in cm.output))
+        self.assertNotIn(nick, blob)  # WARNING must not leak the nick
+        self.assertNotIn(nick, str(ctx.exception))  # nor the re-raised RuntimeError
+
+    def test_steady_state_partial_failure_warning_redacts_nick(self) -> None:
+        # Steady state (resilient): one appliance fails, the other succeeds. The
+        # 'Partial update' WARNING joins the failed appliances' names -> must redact.
+        nick_ok, nick_bad = "OkNick", "BadSecretNick99"
+        app_ok = types.SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:01", unique_id="AA:BB:CC:DD:EE:01",
+            appliance_type="REF", nick_name=nick_ok,
+            attributes={}, settings={}, statistics={},
+        )
+        app_bad = types.SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:02", unique_id="AA:BB:CC:DD:EE:02",
+            appliance_type="REF", nick_name=nick_bad,
+            attributes={}, settings={}, statistics={},
+        )
+        c = HonClient(email="e@x", password="p")
+        c._first_poll_done = True  # steady state -> skip a failed appliance, keep the rest
+
+        async def fake_get_appliances():
+            return [app_ok, app_bad]
+
+        def update(a):
+            if a is app_bad:
+                raise ValueError("update boom")
+
+        c.async_get_appliances = fake_get_appliances  # type: ignore[assignment]
+        c._update_appliance_sync = update  # type: ignore[assignment]
+
+        logger = "custom_components.addhon.hon_client"
+        with self.assertLogs(logger, level="WARNING") as cm:
+            data = asyncio.run(c.async_get_appliances_data())
+        blob = "\n".join(cm.output)
+        self.assertTrue(any("Partial update" in line for line in cm.output))
+        self.assertNotIn(nick_bad, blob)  # neither the per-appliance nor the joined list
+        self.assertIn(app_ok.unique_id, data)  # the healthy appliance survives
 
 
 class RealtimeWiringSourceGuard(unittest.TestCase):

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -125,7 +125,7 @@ class HonClientRealtimeTest(unittest.TestCase):
         import custom_components.addhon.client.factory as factory
         new_session = FakeSession([])
         orig_create = getattr(factory, "create_session", None)
-        factory.create_session = lambda email, password: new_session
+        factory.create_session = lambda email, password, **kw: new_session
         try:
             c = HonClient(email="e@x", password="p")
             cb = lambda _a: None  # noqa: E731
@@ -147,7 +147,7 @@ class HonClientRealtimeTest(unittest.TestCase):
         import custom_components.addhon.client.factory as factory
         new_session = FakeSession([])
         orig_create = getattr(factory, "create_session", None)
-        factory.create_session = lambda email, password: new_session
+        factory.create_session = lambda email, password, **kw: new_session
         try:
             c = HonClient(email="e@x", password="p")  # never subscribed
             c._start_hon_loop = lambda: None  # type: ignore[assignment]
@@ -170,7 +170,7 @@ class HonClientRealtimeTest(unittest.TestCase):
 
         boom = BoomSession([])
         orig_create = getattr(factory, "create_session", None)
-        factory.create_session = lambda email, password: boom
+        factory.create_session = lambda email, password, **kw: boom
         try:
             c = HonClient(email="e@x", password="p")
             cb = lambda _a: None  # noqa: E731

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -178,7 +178,7 @@ class HonClientRealtimeTest(unittest.TestCase):
             c.subscribe_updates(cb)
             c._start_hon_loop = lambda: None  # type: ignore[assignment]
             c._run_on_hon_loop = lambda coro: asyncio.run(coro)  # type: ignore[assignment]
-            with self.assertRaises(Exception):
+            with self.assertRaises(RuntimeError):
                 c.setup_sync()
             self.assertIsNone(c._hon_instance)  # _close_sync ran on failure
             self.assertIs(c._notify_function, cb)  # callback survives for next setup

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -1,0 +1,154 @@
+"""Tests for the MQTT realtime wiring (#4): HonClient.subscribe_updates /
+build_realtime_snapshot, plus source-guards for the async_setup_entry wiring.
+
+A full async_setup_entry behavioural test is infeasible with the stub harness
+(it runs the executor login, first refresh and platform forwarding), so the
+cross-thread wiring in __init__.py is covered by source-guards (same approach as
+test_coordinator_config_entry.py).
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = sys.modules.get(name)
+    if m is None:
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+    return m
+
+
+def _install_stubs() -> None:
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    exc = _mod("homeassistant.exceptions")
+    base = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base,), {}))
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    ha = _mod("homeassistant")
+    ha.config_entries, ha.core, ha.exceptions = ce, core, exc
+    ha.helpers = _mod("homeassistant.helpers")
+    ha.helpers.update_coordinator = uc
+
+
+_install_stubs()
+
+from custom_components.addhon.hon_client import HonClient  # noqa: E402
+
+
+class FakeSession:
+    """Stands in for the NativeHon session held as HonClient._hon_instance."""
+
+    def __init__(self, appliances) -> None:
+        self.appliances = appliances
+        self._notify_function = None
+
+    def subscribe_updates(self, fn) -> None:
+        self._notify_function = fn
+
+    def notify(self) -> None:
+        if self._notify_function:
+            self._notify_function(None)
+
+
+class FakeAppliance:
+    def __init__(self, uid: str) -> None:
+        self.unique_id = uid
+        self.attributes = {"parameters": {}}
+        self.settings = {"s": 1}
+        self.statistics = {}
+        self.nick_name = "Nick"
+
+
+def _client(appliances=None):
+    c = HonClient(email="e@x", password="p")
+    c._hon_instance = FakeSession(appliances or [])
+    return c
+
+
+class HonClientRealtimeTest(unittest.TestCase):
+    def test_subscribe_updates_forwarded(self) -> None:
+        c = _client()
+        cb = lambda _arg: None  # noqa: E731
+        c.subscribe_updates(cb)
+        self.assertIs(c._hon_instance._notify_function, cb)
+
+    def test_subscribe_updates_before_setup_raises(self) -> None:
+        c = HonClient(email="e@x", password="p")  # no _hon_instance yet
+        with self.assertRaises(RuntimeError):
+            c.subscribe_updates(lambda _a: None)
+
+    def test_subscribe_updates_detach_with_none(self) -> None:
+        c = _client()
+        c.subscribe_updates(lambda _a: None)
+        c.subscribe_updates(None)
+        self.assertIsNone(c._hon_instance._notify_function)
+
+    def test_build_realtime_snapshot_from_memory(self) -> None:
+        app = FakeAppliance("ac-1")
+        c = _client([app])
+        snap = c.build_realtime_snapshot()
+        self.assertIn("ac-1", snap)
+        self.assertIs(snap["ac-1"]["appliance"], app)
+        self.assertEqual(snap["ac-1"]["settings"], {"s": 1})
+
+    def test_build_realtime_snapshot_empty_without_session(self) -> None:
+        c = HonClient(email="e@x", password="p")  # _hon_instance is None
+        self.assertEqual(c.build_realtime_snapshot(), {})
+
+    def test_notify_roundtrip_invokes_callback(self) -> None:
+        # subscribe_updates registers on the session; session.notify() (called by the
+        # MQTT push) must invoke the callback.
+        c = _client()
+        calls = []
+        c.subscribe_updates(lambda _arg: calls.append(True))
+        c._hon_instance.notify()
+        self.assertEqual(calls, [True])
+
+
+class RealtimeWiringSourceGuard(unittest.TestCase):
+    """The cross-thread wiring in async_setup_entry can't be exercised by the stub
+    harness; guard its essential pieces at the source level."""
+
+    _COMPONENT = REPO / "custom_components" / "addhon"
+
+    def test_init_wires_push_via_call_soon_threadsafe(self) -> None:
+        src = (self._COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        # push wired to the client...
+        self.assertIn("subscribe_updates(", src)
+        # ...and marshalled onto the HA loop (NOT a direct coordinator call from the
+        # awscrt thread, which would be unsafe).
+        self.assertIn("call_soon_threadsafe", src)
+        self.assertIn("async_set_updated_data", src)
+        # detached on unload
+        self.assertIn("subscribe_updates(None)", src)
+
+    def test_init_does_not_repoll_on_push(self) -> None:
+        src = (self._COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        # The realtime publish must use the snapshot, not async_request_refresh
+        # (which would re-trigger the slow HTTP poll on every push).
+        self.assertIn("build_realtime_snapshot", src)
+        self.assertNotIn("async_request_refresh", src)
+
+    def test_hon_client_exposes_realtime_api(self) -> None:
+        src = (self._COMPONENT / "hon_client.py").read_text(encoding="utf-8")
+        self.assertIn("def subscribe_updates", src)
+        self.assertIn("def build_realtime_snapshot", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -8,6 +8,7 @@ test_coordinator_config_entry.py).
 """
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 import unittest
@@ -64,6 +65,12 @@ class FakeSession:
         if self._notify_function:
             self._notify_function(None)
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
 
 class FakeAppliance:
     def __init__(self, uid: str) -> None:
@@ -86,17 +93,96 @@ class HonClientRealtimeTest(unittest.TestCase):
         cb = lambda _arg: None  # noqa: E731
         c.subscribe_updates(cb)
         self.assertIs(c._hon_instance._notify_function, cb)
+        self.assertIs(c._notify_function, cb)  # also stored on the client
 
-    def test_subscribe_updates_before_setup_raises(self) -> None:
+    def test_subscribe_updates_before_setup_is_stored_not_raised(self) -> None:
+        # #28: no raise when there is no session yet; the callback is remembered and
+        # applied by setup_sync. (Old contract raised RuntimeError here.)
         c = HonClient(email="e@x", password="p")  # no _hon_instance yet
-        with self.assertRaises(RuntimeError):
-            c.subscribe_updates(lambda _a: None)
+        cb = lambda _a: None  # noqa: E731
+        c.subscribe_updates(cb)  # must NOT raise
+        self.assertIs(c._notify_function, cb)
+
+    def test_subscribe_none_after_close_is_noop(self) -> None:
+        # #28: the on-unload detach runs subscribe_updates(None) AFTER the client is
+        # closed (_hon_instance None) -> must be a clean no-op, not RuntimeError.
+        c = HonClient(email="e@x", password="p")  # post-close state
+        c.subscribe_updates(None)  # must NOT raise
+        self.assertIsNone(c._notify_function)
 
     def test_subscribe_updates_detach_with_none(self) -> None:
         c = _client()
         c.subscribe_updates(lambda _a: None)
         c.subscribe_updates(None)
         self.assertIsNone(c._hon_instance._notify_function)
+        self.assertIsNone(c._notify_function)
+
+    def test_callback_rewired_after_reauth(self) -> None:
+        # #20: setup_sync (run at initial setup AND on re-auth, which rebuilds the
+        # session) must re-apply the stored notify callback to the NEW session, else
+        # the MQTT push dies permanently after a re-auth.
+        import custom_components.addhon.client.factory as factory
+        new_session = FakeSession([])
+        orig_create = getattr(factory, "create_session", None)
+        factory.create_session = lambda email, password: new_session
+        try:
+            c = HonClient(email="e@x", password="p")
+            cb = lambda _a: None  # noqa: E731
+            c.subscribe_updates(cb)  # stored on the client (no session yet)
+            # run setup_sync offline: stub the dedicated-loop machinery
+            c._start_hon_loop = lambda: None  # type: ignore[assignment]
+            c._run_on_hon_loop = lambda coro: coro.close()  # type: ignore[assignment]
+            c.setup_sync()
+            self.assertIs(c._hon_instance, new_session)
+            self.assertIs(new_session._notify_function, cb)  # re-applied to new session
+        finally:
+            if orig_create is not None:
+                factory.create_session = orig_create
+
+    def test_setup_sync_without_subscribe_does_not_crash(self) -> None:
+        # The constructor MUST init _notify_function: setup_sync runs at initial
+        # setup BEFORE subscribe_updates is ever called, and reads it for the
+        # re-apply. Without the init this raises AttributeError.
+        import custom_components.addhon.client.factory as factory
+        new_session = FakeSession([])
+        orig_create = getattr(factory, "create_session", None)
+        factory.create_session = lambda email, password: new_session
+        try:
+            c = HonClient(email="e@x", password="p")  # never subscribed
+            c._start_hon_loop = lambda: None  # type: ignore[assignment]
+            c._run_on_hon_loop = lambda coro: coro.close()  # type: ignore[assignment]
+            c.setup_sync()  # must NOT raise
+            self.assertIs(c._hon_instance, new_session)
+            self.assertIsNone(new_session._notify_function)  # nothing to apply
+        finally:
+            if orig_create is not None:
+                factory.create_session = orig_create
+
+    def test_setup_sync_failure_closes_and_keeps_callback(self) -> None:
+        # On a failed (re)setup the session is closed (_hon_instance cleared) but the
+        # stored callback PERSISTS on the client, ready for the next setup (#20).
+        import custom_components.addhon.client.factory as factory
+
+        class BoomSession(FakeSession):
+            async def __aenter__(self):
+                raise RuntimeError("login boom")
+
+        boom = BoomSession([])
+        orig_create = getattr(factory, "create_session", None)
+        factory.create_session = lambda email, password: boom
+        try:
+            c = HonClient(email="e@x", password="p")
+            cb = lambda _a: None  # noqa: E731
+            c.subscribe_updates(cb)
+            c._start_hon_loop = lambda: None  # type: ignore[assignment]
+            c._run_on_hon_loop = lambda coro: asyncio.run(coro)  # type: ignore[assignment]
+            with self.assertRaises(Exception):
+                c.setup_sync()
+            self.assertIsNone(c._hon_instance)  # _close_sync ran on failure
+            self.assertIs(c._notify_function, cb)  # callback survives for next setup
+        finally:
+            if orig_create is not None:
+                factory.create_session = orig_create
 
     def test_build_realtime_snapshot_from_memory(self) -> None:
         app = FakeAppliance("ac-1")

--- a/tests/test_legacy_cleanup.py
+++ b/tests/test_legacy_cleanup.py
@@ -1,0 +1,133 @@
+"""Tests for _remove_legacy_entities (#22): the legacy 'power' cleanup must be
+scoped to the switch domain, so the legitimate WH `power` and KT `current_power`
+SENSORS (which also end in '_power') are not purged on every setup.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = sys.modules.get(name)
+    if m is None:
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+    return m
+
+
+def _install_stubs() -> None:
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    if not hasattr(core, "callback"):
+        core.callback = lambda f: f
+    if not hasattr(core, "ServiceCall"):
+        core.ServiceCall = object
+    exc = _mod("homeassistant.exceptions")
+    base = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base,), {}))
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    _mod("homeassistant.helpers.entity_registry")  # functions set per-test
+    ha = _mod("homeassistant")
+    ha.config_entries, ha.core, ha.exceptions = ce, core, exc
+    ha.helpers = _mod("homeassistant.helpers")
+    ha.helpers.update_coordinator = uc
+    ha.helpers.entity_registry = sys.modules["homeassistant.helpers.entity_registry"]
+
+
+_install_stubs()
+
+import homeassistant.helpers.entity_registry as er  # noqa: E402
+from custom_components.addhon import _remove_legacy_entities, DOMAIN  # noqa: E402
+
+
+class FakeRegEntry:
+    def __init__(self, entity_id: str, unique_id: str) -> None:
+        self.entity_id = entity_id
+        self.unique_id = unique_id
+
+    @property
+    def domain(self) -> str:
+        return self.entity_id.split(".", 1)[0]
+
+
+class FakeRegistry:
+    def __init__(self, entries) -> None:
+        self._entries = list(entries)
+        self.removed: list = []
+
+    def async_remove(self, entity_id: str) -> None:
+        self.removed.append(entity_id)
+        self._entries = [e for e in self._entries if e.entity_id != entity_id]
+
+
+class FakeEntry:
+    def __init__(self, entry_id: str = "entry-1") -> None:
+        self.entry_id = entry_id
+
+
+def _run(entries, coord_data=None):
+    reg = FakeRegistry(entries)
+    er.async_get = lambda hass: reg
+    er.async_entries_for_config_entry = lambda registry, entry_id: list(registry._entries)
+    entry = FakeEntry()
+    coordinator = types.SimpleNamespace(data=coord_data or {})
+    hass = types.SimpleNamespace(data={DOMAIN: {entry.entry_id: {"coordinator": coordinator}}})
+    _remove_legacy_entities(hass, entry)
+    return reg.removed
+
+
+class LegacyCleanupTest(unittest.TestCase):
+    def test_legacy_power_switch_removed(self) -> None:
+        removed = _run([FakeRegEntry("switch.foo_power", "ID_power")])
+        self.assertEqual(removed, ["switch.foo_power"])
+
+    def test_wh_power_sensor_kept(self) -> None:
+        # #22: a sensor with unique_id '<id>_power' must NOT be deleted.
+        removed = _run([FakeRegEntry("sensor.foo_power", "ID_power")])
+        self.assertEqual(removed, [])
+
+    def test_kt_current_power_sensor_kept(self) -> None:
+        removed = _run([FakeRegEntry("sensor.foo_current_power", "ID_current_power")])
+        self.assertEqual(removed, [])
+
+    def test_mixed_only_switch_power_removed(self) -> None:
+        entries = [
+            FakeRegEntry("switch.foo_power", "ID_power"),         # legacy -> remove
+            FakeRegEntry("sensor.foo_power", "ID_power"),         # WH power -> keep
+            FakeRegEntry("sensor.foo_current_power", "ID_current_power"),  # KT -> keep
+            FakeRegEntry("sensor.foo_temperature", "ID_temperature"),     # unrelated -> keep
+        ]
+        removed = _run(entries)
+        self.assertEqual(removed, ["switch.foo_power"])
+
+    def test_td_orphan_consumption_removed(self) -> None:
+        # Existing behavior preserved: washer-only consumption sensors on a TD device.
+        removed = _run(
+            [FakeRegEntry("sensor.td_total_water", "tdid_total_water")],
+            coord_data={"tdid": {"type": "TD"}},
+        )
+        self.assertEqual(removed, ["sensor.td_total_water"])
+
+    def test_td_orphan_not_removed_on_non_td(self) -> None:
+        removed = _run(
+            [FakeRegEntry("sensor.wm_total_water", "wmid_total_water")],
+            coord_data={"wmid": {"type": "WM"}},
+        )
+        self.assertEqual(removed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -56,7 +56,7 @@ _FILES = {
     # MQTT handler: the whole parsed payload dict, the topic (embeds the MAC) and
     # the appliance nick_name.
     "client/transport/mqtt.py": (
-        frozenset({"payload", "topic"}),
+        frozenset({"payload", "topic", "parameter"}),
         frozenset({"nick_name"}),
     ),
 }

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -85,6 +85,27 @@ def _bare_offender(arg: ast.AST, names: frozenset, attrs: frozenset) -> str | No
     return None
 
 
+def _dict_dump_offender(arg: ast.AST) -> str | None:
+    """Label the arg if it is `dict(<name>)` -- a raw mapping dumped to a log.
+
+    `_bare_offender` only inspects top-level Name/Attribute nodes, so a `dict(store)`
+    (an ast.Call) slips through while still dumping the mapping's raw KEYS (e.g. the
+    MAC-derived appliance ids keying PROGRAM_PENDING_STORE -- CR#1). Any
+    `dict(<single bare Name>)` with no kwargs passed to _LOGGER must instead go through
+    a redactor (debug_utils.redact_store), so flag it. A dict LITERAL `{...}` or a
+    `redact_store(store)` call is a different node and is not flagged."""
+    if (
+        isinstance(arg, ast.Call)
+        and isinstance(arg.func, ast.Name)
+        and arg.func.id == "dict"
+        and not arg.keywords
+        and len(arg.args) == 1
+        and isinstance(arg.args[0], ast.Name)
+    ):
+        return f"dict({arg.args[0].id})"
+    return None
+
+
 class LogIdentityRedactionTest(unittest.TestCase):
     def test_no_raw_identity_in_logger_calls(self) -> None:
         offenders: list[str] = []
@@ -96,7 +117,7 @@ class LogIdentityRedactionTest(unittest.TestCase):
                 if not _is_logger_call(node):
                     continue
                 for arg in node.args:
-                    label = _bare_offender(arg, names, attrs)
+                    label = _bare_offender(arg, names, attrs) or _dict_dump_offender(arg)
                     if label:
                         offenders.append(f"{rel}:{node.lineno}: raw {label}")
         self.assertEqual(
@@ -117,6 +138,16 @@ class LogIdentityRedactionTest(unittest.TestCase):
         self.assertIsNone(
             _bare_offender(safe.args[1], _ENTITY_NAMES, _ENTITY_ATTRS)
         )
+
+    def test_guard_detects_dict_dump_leak(self) -> None:
+        # Meta: the CR#1 class -- `dict(store)` dumped to a log -- is caught, while a
+        # redacted dump or a dict literal is not.
+        leak = ast.parse('_LOGGER.debug("x %s", dict(store))').body[0].value
+        self.assertEqual(_dict_dump_offender(leak.args[1]), "dict(store)")
+        safe = ast.parse('_LOGGER.debug("x %s", redact_store(store))').body[0].value
+        self.assertIsNone(_dict_dump_offender(safe.args[1]))
+        literal = ast.parse('_LOGGER.debug("x %s", {"k": v})').body[0].value
+        self.assertIsNone(_dict_dump_offender(literal.args[1]))
 
 
 if __name__ == "__main__":

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -48,6 +48,11 @@ _FILES = {
     "binary_sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "climate.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "diagnostics.py": (frozenset({"appliance_id"}), frozenset()),
+    # Setup orchestration: the raw cloud appliance dict (CR#2 malformed-appliance
+    # log). It must never be passed bare to _LOGGER -- key-name redaction cannot mask
+    # nested identity (attributes[].parValue), so the malformed path logs structure
+    # only (field names + error type). This guards against a future bare-dict log.
+    "client/session.py": (frozenset({"appliance", "appliance_data"}), frozenset()),
     # MQTT handler: the whole parsed payload dict, the topic (embeds the MAC) and
     # the appliance nick_name.
     "client/transport/mqtt.py": (

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -1,0 +1,118 @@
+"""Static guard for the #32/#34/#35 cluster: device identity must never reach the
+logs raw.
+
+Redacting a value wraps it in a `redact_*(...)` call, which turns the argument node
+into an `ast.Call`; a *bare* identity reference (a `Name`/`Attribute`) passed straight
+to `_LOGGER.*` is the leak. This AST guard fails on any such bare argument, so it both
+proves the cluster fix and catches future regressions (a new log line that forgets to
+redact). Pure AST, no Home Assistant import required.
+
+Scope/limitation: this checks the TOP-LEVEL argument node only, which fits the
+entity-layer + diagnostics + mqtt logs (all simple `%s, <ref>` forms). It deliberately
+does NOT cover hon_client.py, whose identity passes through helper calls and f-strings
+(`_get_name(a)`, `f"name={...}"`) that a top-level check can't reason about; those are
+covered behaviorally by test_hon_client_realtime.DiscoveryLogRedactionTest.
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "addhon"
+
+_LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical", "log"}
+
+# Entity layer: the appliance id (MAC/serial/code), the entity unique_id, and the
+# raw device-identity attributes a future log line might reach for directly.
+_ENTITY_NAMES = frozenset({"appliance_id", "aid"})
+_ENTITY_ATTRS = frozenset(
+    {
+        "_appliance_id",
+        "_attr_unique_id",
+        "mac_address",
+        "serial_number",
+        "_serial",
+        "nick_name",
+    }
+)
+
+# rel path -> (forbidden bare Name ids, forbidden bare Attribute attrs)
+_FILES = {
+    "base_entity.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "select.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "switch.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "button.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "number.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "binary_sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "climate.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "diagnostics.py": (frozenset({"appliance_id"}), frozenset()),
+    # MQTT handler: the whole parsed payload dict, the topic (embeds the MAC) and
+    # the appliance nick_name.
+    "client/transport/mqtt.py": (
+        frozenset({"payload", "topic"}),
+        frozenset({"nick_name"}),
+    ),
+}
+
+
+def _is_logger_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _LOG_METHODS
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "_LOGGER"
+    )
+
+
+def _bare_offender(arg: ast.AST, names: frozenset, attrs: frozenset) -> str | None:
+    """Label the arg if it is a BARE identity reference, else None.
+
+    Only the top-level arg node is inspected: a redacted value is an `ast.Call`
+    (`redact_id(appliance_id)`, `payload.get(...)`), so it is never flagged; a bare
+    `appliance_id` / `self._appliance_id` / `appliance.nick_name` / `payload` is."""
+    if isinstance(arg, ast.Name) and arg.id in names:
+        return arg.id
+    if isinstance(arg, ast.Attribute) and arg.attr in attrs:
+        return f".{arg.attr}"
+    return None
+
+
+class LogIdentityRedactionTest(unittest.TestCase):
+    def test_no_raw_identity_in_logger_calls(self) -> None:
+        offenders: list[str] = []
+        for rel, (names, attrs) in _FILES.items():
+            path = COMPONENT / rel
+            self.assertTrue(path.is_file(), f"missing source file: {rel}")
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not _is_logger_call(node):
+                    continue
+                for arg in node.args:
+                    label = _bare_offender(arg, names, attrs)
+                    if label:
+                        offenders.append(f"{rel}:{node.lineno}: raw {label}")
+        self.assertEqual(
+            [],
+            offenders,
+            "raw device identity passed to _LOGGER (wrap it in redact_id/"
+            "redact_identity):\n" + "\n".join(offenders),
+        )
+
+    def test_guard_actually_detects_a_leak(self) -> None:
+        # Meta: prove the guard is not vacuous (would catch a regression).
+        leak = ast.parse('_LOGGER.debug("x %s", appliance_id)').body[0].value
+        self.assertTrue(_is_logger_call(leak))
+        self.assertEqual(
+            _bare_offender(leak.args[1], _ENTITY_NAMES, _ENTITY_ATTRS), "appliance_id"
+        )
+        safe = ast.parse('_LOGGER.debug("x %s", redact_id(appliance_id))').body[0].value
+        self.assertIsNone(
+            _bare_offender(safe.args[1], _ENTITY_NAMES, _ENTITY_ATTRS)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -262,9 +262,11 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual([a.mac_address for a in nh.appliances], ["A"])
 
     def test_appliance_load_error_redacts_identity_in_log(self) -> None:
-        # #19: the except path logs the RAW appliance dict at ERROR (never gated by
-        # the debug toggles). MAC/serial must NOT reach the log; non-identity fields
-        # (modelName) still do, so the message stays useful for the maintainer.
+        # #19/CR#2: the malformed-appliance path logs at ERROR (never gated by the
+        # debug toggles). It logs STRUCTURE ONLY -- the exception type + the top-level
+        # field NAMES -- never a VALUE, so no macAddress/serialNumber/modelName value
+        # (nor anything else) can reach home-assistant.log. The full redacted dict is
+        # in Download Diagnostics (redacted at a different layer).
         data = [{
             "macAddress": "AA:BB:CC:DD:EE:FF",
             "serialNumber": "SN-SECRET-123",
@@ -277,11 +279,225 @@ class NativeSessionSetupTest(unittest.TestCase):
         with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
             _run(nh.setup())
         blob = "\n".join(cm.output)
+        # NO value leaks (identity or otherwise)
         self.assertNotIn("AA:BB:CC:DD:EE:FF", blob)
         self.assertNotIn("SN-SECRET-123", blob)
-        self.assertIn("***", blob)
-        self.assertIn("HDPW5620CNPK", blob)  # non-identity survives
+        self.assertNotIn("HDPW5620CNPK", blob)
+        # structure IS present: field NAMES (not values) + the error type + the code
+        self.assertIn("macAddress", blob)   # the field NAME, not its value
+        self.assertIn("KeyError", blob)     # the exception TYPE name
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, blob)
         self.assertEqual([a.mac_address for a in nh.appliances], ["AA:BB:CC:DD:EE:FF"])
+
+    def test_malformed_log_does_not_leak_nested_identity(self) -> None:
+        # CR#2 / Refuter-2: redact_identity masks by TOP-LEVEL key name only, so a
+        # serial/MAC hidden in a nested attributes[].parValue (the real hOn shape) or
+        # under a benign key would survive it. The malformed-appliance log therefore
+        # logs STRUCTURE only (field names + error type), never values -- so nested
+        # identity cannot leak even though redact_identity would have passed it.
+        # zone is valid (numeric) so the LOAD path runs (fail_macs -> KeyError),
+        # carrying the raw appliance_data (with nested + benign-key identity) into
+        # _log_malformed -- the exact pre-existing path Refuter-2 flagged.
+        data = [{
+            "macAddress": "AA:BB:CC:DD:EE:FF",
+            "applianceTypeName": "REF",
+            "zone": "0",
+            "attributes": [
+                {"parName": "serialNumber", "parValue": "SN-NESTED-SECRET"},
+            ],
+            "modelName": "IDENTITY-UNDER-BENIGN-KEY",
+        }]
+        h = _Harness(self, data, fail_macs={"AA:BB:CC:DD:EE:FF"})
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        blob = "\n".join(cm.output)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", blob)          # top-level identity value
+        self.assertNotIn("SN-NESTED-SECRET", blob)           # nested attributes[].parValue
+        self.assertNotIn("IDENTITY-UNDER-BENIGN-KEY", blob)  # value under a benign key
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, blob)
+
+    # --- CR#2: setup-path per-appliance isolation -----------------------------
+    # A single malformed appliance must be logged-and-skipped (redacted) without
+    # aborting setup of the OTHER appliances. The fault boundary now spans the WHOLE
+    # per-appliance build: non-dict element + zone parse + constructor + load_* trio.
+
+    def test_non_dict_element_skipped_others_load(self) -> None:
+        # parse_appliance_list gives no per-element dict guarantee. A bare-string
+        # element (here MAC-shaped) must be logged-and-skipped -- it would otherwise
+        # raise AttributeError on appliance.get(...) and abort the whole loop -- and
+        # ONLY its type is logged, never the raw value (redact_identity passes a bare
+        # scalar through, so a MAC-string element would leak if echoed).
+        good = {"macAddress": "B", "applianceTypeName": "WM"}
+        h = _Harness(self, [good])
+        h.install()
+
+        async def mixed_load_appliances():
+            h.events.append("load_appliances")
+            return ["AA:BB:CC:DD:EE:FF", dict(good)]
+
+        h.api.load_appliances = mixed_load_appliances
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        self.assertEqual([a.mac_address for a in nh.appliances], ["B"])
+        self.assertEqual(h.events[-1], "mqtt")
+        blob = "\n".join(cm.output)
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, blob)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", blob)  # raw scalar never echoed
+        self.assertIn("type=str", blob)  # only its type is logged
+
+    def test_unparseable_zone_skips_only_that_appliance(self) -> None:
+        # int(appliance.get("zone","0")) raises ValueError on a non-numeric zone;
+        # only THAT appliance is skipped, the next one loads and setup completes.
+        data = [
+            {"macAddress": "BAD", "applianceTypeName": "AC", "zone": "not-a-number"},
+            {"macAddress": "OK", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        self.assertEqual([a.mac_address for a in nh.appliances], ["OK"])
+        self.assertNotIn("cmd:BAD:0", h.events)
+        self.assertIn("cmd:OK:0", h.events)
+        self.assertEqual(h.events[-1], "mqtt")
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, "\n".join(cm.output))
+
+    def test_constructor_failure_skips_only_that_appliance(self) -> None:
+        # factory.create_appliance (HonAppliance.__init__) raises TypeError on a
+        # malformed info["attributes"] -- this ran BEFORE the per-device try and
+        # aborted ALL. Now the bad device is skipped (no usable object) and the good
+        # one loads.
+        bad = {"macAddress": "BAD", "applianceTypeName": "REF"}
+        good = {"macAddress": "OK", "applianceTypeName": "WM"}
+        h = _Harness(self, [bad, good])
+
+        def fake_create_appliance(api, data, zone=0):
+            if data.get("macAddress") == "BAD":
+                raise TypeError("malformed attributes in constructor")
+            return FakeAppliance(api, data, zone, h.events)
+
+        async def fake_make_mqtt(hon):
+            h.events.append("mqtt")
+            m = FakeMqtt(h)
+            h.mqtt_calls.append((hon, hon._mobile_id))
+            return m
+
+        self._patch(factory, "create_appliance", fake_create_appliance)
+        self._patch(NativeHon, "_make_mqtt", fake_make_mqtt)
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        self.assertEqual([a.mac_address for a in nh.appliances], ["OK"])
+        self.assertEqual(h.events[-1], "mqtt")
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, "\n".join(cm.output))
+
+    def test_load_attributes_attributeerror_keeps_partial_others_load(self) -> None:
+        # load_attributes() raises AttributeError (a non-dict "shadow") -- previously
+        # OUTSIDE the (KeyError, ValueError, IndexError) catch, so it aborted the loop.
+        # Now caught: the failing appliance is kept (partial state) AND the next one
+        # still loads fully.
+        class AttrFailAppliance(FakeAppliance):
+            async def load_attributes(self) -> None:
+                self.events.append(f"attr:{self.mac_address}:{self.zone}")
+                raise AttributeError("'list' object has no attribute 'get'")
+
+        bad = {"macAddress": "BAD", "applianceTypeName": "REF"}
+        good = {"macAddress": "OK", "applianceTypeName": "WM"}
+        h = _Harness(self, [bad, good])
+
+        def fake_create_appliance(api, data, zone=0):
+            cls = AttrFailAppliance if data.get("macAddress") == "BAD" else FakeAppliance
+            return cls(api, data, zone, h.events)
+
+        async def fake_make_mqtt(hon):
+            h.events.append("mqtt")
+            return FakeMqtt(h)
+
+        self._patch(factory, "create_appliance", fake_create_appliance)
+        self._patch(NativeHon, "_make_mqtt", fake_make_mqtt)
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        self.assertEqual([a.mac_address for a in nh.appliances], ["BAD", "OK"])
+        self.assertIn("cmd:OK:0", h.events)
+        self.assertEqual(h.events[-1], "mqtt")
+        self.assertIn(session_mod.APPLIANCE_DATA_MALFORMED.label, "\n".join(cm.output))
+
+    def test_setup_does_not_swallow_cancelled_error(self) -> None:
+        # The broadened catch is (KeyError, ValueError, IndexError, TypeError,
+        # AttributeError) -- NOT BaseException -- so an asyncio.CancelledError raised
+        # during a per-appliance load must PROPAGATE (cooperative cancellation), not
+        # be mistaken for malformed data and swallowed.
+        class CancelAppliance(FakeAppliance):
+            async def load_commands(self) -> None:
+                raise asyncio.CancelledError()
+
+        data = [{"macAddress": "A", "applianceTypeName": "REF"}]
+        h = _Harness(self, data)
+
+        def fake_create_appliance(api, data, zone=0):
+            return CancelAppliance(api, data, zone, h.events)
+
+        async def fake_make_mqtt(hon):
+            h.events.append("mqtt")
+            return FakeMqtt(h)
+
+        self._patch(factory, "create_appliance", fake_create_appliance)
+        self._patch(NativeHon, "_make_mqtt", fake_make_mqtt)
+        nh = self._nh_with_api(h)
+        with self.assertRaises(asyncio.CancelledError):
+            _run(nh.setup())
+
+    def test_log_malformed_tolerates_unorderable_keys(self) -> None:
+        # _log_malformed runs INSIDE the except handlers, so it must NEVER raise: a
+        # raise there would escape and abort the whole setup loop -- the very failure
+        # CR#2 fixes. sorted() on a dict with mixed-type top-level keys raises
+        # TypeError, so the helper str()s the keys first. (Not reachable from JSON
+        # cloud data -- keys are always str -- but the fault boundary must hold by
+        # construction.) Drive a malformed appliance whose dict has an int key.
+        good = {"macAddress": "OK", "applianceTypeName": "WM"}
+        bad = {"macAddress": "BAD", 1: "x", "applianceTypeName": "REF"}
+        h = _Harness(self, [bad, good], fail_macs={"BAD"})
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())  # must NOT raise TypeError from sorted()
+        # the helper did not abort the loop -> the good appliance still loaded + mqtt
+        self.assertIn("OK", [a.mac_address for a in nh.appliances])
+        self.assertEqual(h.events[-1], "mqtt")
+
+    def test_multizone_one_zone_failure_isolated(self) -> None:
+        # A multi-zone appliance whose ONE zone fails to BUILD must lose only that
+        # zone, not its sibling zones or the next appliance (each per-zone
+        # _create_appliance is independently isolated).
+        zoned = {"macAddress": "Z", "applianceTypeName": "AC", "zone": "2"}
+        nxt = {"macAddress": "N", "applianceTypeName": "WM"}
+        h = _Harness(self, [zoned, nxt])
+
+        def fake_create_appliance(api, data, zone=0):
+            if data.get("macAddress") == "Z" and zone == 1:
+                raise TypeError("zone-1 constructor boom")
+            return FakeAppliance(api, data, zone, h.events)
+
+        async def fake_make_mqtt(hon):
+            h.events.append("mqtt")
+            return FakeMqtt(h)
+
+        self._patch(factory, "create_appliance", fake_create_appliance)
+        self._patch(NativeHon, "_make_mqtt", fake_make_mqtt)
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        # zone1 dropped (constructor failed, no object); zone2 + base Z(0) + N survive
+        self.assertEqual(
+            [(a.mac_address, a.zone) for a in nh.appliances],
+            [("Z", 2), ("Z", 0), ("N", 0)],
+        )
+        self.assertEqual(h.events[-1], "mqtt")
 
     def test_mqtt_disabled(self) -> None:
         data = [{"macAddress": "A", "applianceTypeName": "REF"}]

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -290,11 +290,14 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual([a.mac_address for a in nh.appliances], ["AA:BB:CC:DD:EE:FF"])
 
     def test_malformed_log_does_not_leak_nested_identity(self) -> None:
-        # CR#2 / Refuter-2: redact_identity masks by TOP-LEVEL key name only, so a
-        # serial/MAC hidden in a nested attributes[].parValue (the real hOn shape) or
-        # under a benign key would survive it. The malformed-appliance log therefore
-        # logs STRUCTURE only (field names + error type), never values -- so nested
-        # identity cannot leak even though redact_identity would have passed it.
+        # CR#2 / Refuter-2: redact_identity is recursive and masks two ways -- a VALUE
+        # whose KEY name is identity-shaped (at any depth), AND any MAC embedded in a
+        # string leaf (regex, even under a benign key). The residual gap is a NON-MAC
+        # identity (e.g. a serial) carried as a VALUE under a non-identity key: a nested
+        # attributes[].parValue (the real hOn shape) or a benign top-level key like
+        # modelName -- no identity key name, no MAC pattern -> it survives redaction.
+        # The malformed-appliance log therefore logs STRUCTURE only (field names + error
+        # type), never values, so even that residual cannot leak.
         # zone is valid (numeric) so the LOAD path runs (fail_macs -> KeyError),
         # carrying the raw appliance_data (with nested + benign-key identity) into
         # _log_malformed -- the exact pre-existing path Refuter-2 flagged.

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -261,6 +261,28 @@ class NativeSessionSetupTest(unittest.TestCase):
         # load_commands raises KeyError but the appliance stays (partial state, like pyhOn)
         self.assertEqual([a.mac_address for a in nh.appliances], ["A"])
 
+    def test_appliance_load_error_redacts_identity_in_log(self) -> None:
+        # #19: the except path logs the RAW appliance dict at ERROR (never gated by
+        # the debug toggles). MAC/serial must NOT reach the log; non-identity fields
+        # (modelName) still do, so the message stays useful for the maintainer.
+        data = [{
+            "macAddress": "AA:BB:CC:DD:EE:FF",
+            "serialNumber": "SN-SECRET-123",
+            "applianceTypeName": "REF",
+            "modelName": "HDPW5620CNPK",
+        }]
+        h = _Harness(self, data, fail_macs={"AA:BB:CC:DD:EE:FF"})
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR") as cm:
+            _run(nh.setup())
+        blob = "\n".join(cm.output)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", blob)
+        self.assertNotIn("SN-SECRET-123", blob)
+        self.assertIn("***", blob)
+        self.assertIn("HDPW5620CNPK", blob)  # non-identity survives
+        self.assertEqual([a.mac_address for a in nh.appliances], ["AA:BB:CC:DD:EE:FF"])
+
     def test_mqtt_disabled(self) -> None:
         data = [{"macAddress": "A", "applianceTypeName": "REF"}]
         h = _Harness(self, data)

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -324,6 +324,171 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertTrue(created["conn_created"])
         self.assertIsInstance(created["api_conn"], FakeConn)
         self.assertEqual([a.mac_address for a in nh.appliances], ["A"])
+        self.assertFalse(h.api.closed)  # success path must NOT close
+
+    def _patch_conn_api_with_failing_setup(self, h):
+        # HonConnection.create() succeeds, HonApi is the harness api, but setup()
+        # fails (load_appliances raises) so create() must self-clean.
+        class FakeConn:
+            async def create(self):
+                return self
+
+            async def close(self):
+                pass
+
+        async def boom():
+            raise RuntimeError("setup boom")
+
+        h.api.load_appliances = boom
+        self._patch(session_mod, "HonConnection", lambda *a, **k: FakeConn())
+        self._patch(session_mod, "HonApi", lambda conn: h.api)
+
+    def test_create_failure_closes_session_no_leak(self) -> None:
+        # #31: if setup() raises, create() must close() so the owned ClientSession
+        # (via api.close() -> connection.close()) is released, not leaked.
+        h = _Harness(self, [])
+        h.install()
+        self._patch_conn_api_with_failing_setup(h)
+        nh = NativeHon("u@x", "p", enable_mqtt=False)
+        with self.assertRaises(RuntimeError):
+            _run(nh.create())
+        self.assertTrue(h.api.closed)  # close() ran on the failed create()
+
+    def test_async_with_create_failure_still_closes(self) -> None:
+        # The documented hazard: `async with NativeHon(...)` does NOT run __aexit__
+        # when __aenter__/create() raises, so create() itself must clean up.
+        h = _Harness(self, [])
+        h.install()
+        self._patch_conn_api_with_failing_setup(h)
+
+        async def body():
+            async with NativeHon("u@x", "p", enable_mqtt=False):
+                pass
+
+        with self.assertRaises(RuntimeError):
+            _run(body())
+        self.assertTrue(h.api.closed)
+
+    def test_create_baseexception_in_setup_still_closes(self) -> None:
+        # #31: the guard is `except BaseException` ON PURPOSE so a CANCELLED setup
+        # (asyncio.CancelledError is a BaseException, NOT an Exception) also tears
+        # down the owned session. `except Exception` would let it leak -> kill that
+        # mutant. setup() raises CancelledError here (via load_appliances).
+        h = _Harness(self, [])
+        h.install()
+
+        class FakeConn:
+            async def create(self):
+                return self
+
+            async def close(self):
+                pass
+
+        async def cancel_boom():
+            raise asyncio.CancelledError()
+
+        h.api.load_appliances = cancel_boom
+        self._patch(session_mod, "HonConnection", lambda *a, **k: FakeConn())
+        self._patch(session_mod, "HonApi", lambda conn: h.api)
+
+        nh = NativeHon("u@x", "p", enable_mqtt=False)
+        with self.assertRaises(asyncio.CancelledError):
+            _run(nh.create())
+        self.assertTrue(h.api.closed)  # close() ran even on a BaseException
+
+    def test_create_failure_in_connection_create_closes_with_no_api(self) -> None:
+        # #31: failure point BEFORE _api is set (HonConnection.create() raises).
+        # create()'s except still runs close(), which must tolerate _api is None
+        # (no AttributeError) AND must close the partially-built connection so its
+        # owned ClientSession is not leaked. Exercises the `_api is None` guard in
+        # close() on the create() error path + connection cleanup.
+        class FakeConn:
+            async def create(self):
+                raise RuntimeError("connection create boom")
+
+            async def close(self):
+                pass
+
+        api_built = {"n": 0}
+
+        def fake_honapi(conn):
+            api_built["n"] += 1
+            return object()
+
+        self._patch(session_mod, "HonConnection", lambda *a, **k: FakeConn())
+        self._patch(session_mod, "HonApi", fake_honapi)
+
+        nh = NativeHon("u@x", "p", enable_mqtt=False)
+        with self.assertRaises(RuntimeError):
+            _run(nh.create())  # must NOT raise AttributeError from close()
+        self.assertEqual(api_built["n"], 0)  # failed before _api was built
+        self.assertIsNone(nh._api)
+
+    def test_create_failure_after_mqtt_started_stops_mqtt_and_closes_api(self) -> None:
+        # #31: deeper failure point. load_appliances succeeds, MQTT is built, then
+        # something AFTER that raises. close() must stop the started MQTT (no leak)
+        # AND close the api. Tests the cleanup path with a live _mqtt_client.
+        data = [{"macAddress": "A", "applianceTypeName": "REF"}]
+        h = _Harness(self, data)
+        h.install()
+
+        class FakeConn:
+            async def create(self):
+                return self
+
+            async def close(self):
+                pass
+
+        self._patch(session_mod, "HonConnection", lambda *a, **k: FakeConn())
+        self._patch(session_mod, "HonApi", lambda conn: h.api)
+
+        nh = NativeHon("u@x", "p", enable_mqtt=True)
+
+        real_setup = nh.setup
+
+        async def setup_then_boom():
+            await real_setup()  # builds appliances + starts MQTT
+            assert nh._mqtt_client is h.mqtt_instance
+            raise RuntimeError("post-mqtt boom")
+
+        nh.setup = setup_then_boom  # type: ignore[assignment]
+
+        with self.assertRaises(RuntimeError):
+            _run(nh.create())
+        self.assertTrue(h.mqtt_instance.stopped)  # started MQTT was stopped
+        self.assertIsNone(nh._mqtt_client)
+        self.assertTrue(h.api.closed)  # api closed too
+
+    def test_create_failure_cleanup_error_does_not_mask_original(self) -> None:
+        # #31 (refuter): if close()'s teardown itself raises, it must NOT mask the
+        # ORIGINAL setup exception (the config-entry classifier keys off it, e.g. an
+        # auth error must surface as ConfigEntryAuthFailed, not be hidden by a
+        # cleanup ConnectionResetError). close() is exception-guarded -> original wins.
+        h = _Harness(self, [])
+        h.install()
+
+        class FakeConn:
+            async def create(self):
+                return self
+
+            async def close(self):
+                pass
+
+        async def setup_boom():
+            raise ValueError("ORIGINAL setup error")
+
+        async def close_boom():
+            raise RuntimeError("cleanup boom")
+
+        h.api.load_appliances = setup_boom
+        h.api.close = close_boom
+        self._patch(session_mod, "HonConnection", lambda *a, **k: FakeConn())
+        self._patch(session_mod, "HonApi", lambda conn: h.api)
+
+        nh = NativeHon("u@x", "p", enable_mqtt=False)
+        with self.assertRaises(ValueError) as ctx:
+            _run(nh.create())
+        self.assertIn("ORIGINAL", str(ctx.exception))  # cleanup error did not mask it
 
     def test_close_closes_api(self) -> None:
         h = _Harness(self, [])

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -293,6 +293,36 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.mqtt_calls, [])
         self.assertIsNone(nh._mqtt_client)
 
+    def test_minimal_skips_per_appliance_loads_and_mqtt(self) -> None:
+        # #30: config-flow validation builds + counts the appliances but does NOT run
+        # the per-appliance load_commands/attributes/statistics, and never starts MQTT.
+        data = [
+            {"macAddress": "A", "applianceTypeName": "REF"},
+            {"macAddress": "B", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h, enable_mqtt=False, minimal=True)
+        _run(nh.setup())
+        # appliances are built (so the flow can count + type them) ...
+        self.assertEqual([a.mac_address for a in nh.appliances], ["A", "B"])
+        # ... but only load_appliances ran: no per-appliance cmd/attr/stat, no mqtt.
+        self.assertEqual(h.events, ["load_appliances"])
+        self.assertEqual(h.mqtt_calls, [])
+        self.assertIsNone(nh._mqtt_client)
+        self.assertEqual(nh._setup_phase, "")  # cleared after a clean setup
+
+    def test_minimal_empty_mac_still_skipped(self) -> None:
+        data = [
+            {"macAddress": "", "applianceTypeName": "GHOST"},
+            {"macAddress": "B", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h, enable_mqtt=False, minimal=True)
+        _run(nh.setup())
+        self.assertEqual([a.mac_address for a in nh.appliances], ["B"])
+
     def test_create_builds_connection_api_then_setup(self) -> None:
         data = [{"macAddress": "A", "applianceTypeName": "REF"}]
         h = _Harness(self, data)

--- a/tests/test_number_setpoints.py
+++ b/tests/test_number_setpoints.py
@@ -165,6 +165,35 @@ class RangeParam:
         self._v = fv
 
 
+class EnumParam:
+    """Mimics HonParameterEnum: a discrete set of allowed (string) values and NO
+    min/max/step attribute. The value setter raises ValueError for anything outside
+    the set, exactly like enum.py. Used to test the enum-setpoint handling (#26)."""
+
+    def __init__(self, values) -> None:
+        self._values = [str(v) for v in values]
+        self._value = self._values[0] if self._values else ""
+
+    @staticmethod
+    def _clean(v):
+        return str(v).strip("[]").replace("|", "_").lower()
+
+    @property
+    def values(self):
+        return [self._clean(v) for v in self._values]
+
+    @property
+    def value(self):
+        return self._clean(self._value)
+
+    @value.setter
+    def value(self, v):
+        if self._clean(v) in self.values:
+            self._value = v
+        else:
+            raise ValueError(f"Allowed values: {self._values} But was: {v}")
+
+
 class RecordingCommand:
     def __init__(self, parameters) -> None:
         self.parameters = parameters
@@ -375,6 +404,228 @@ class NumberSetpointTest(unittest.TestCase):
         added = asyncio.run(_build("OV", app, {"tempSel": "180"}))
         self.assertEqual([e.entity_description.key for e in added], ["target_temp"])
         self.assertEqual(added[0].native_step, 5.0)
+
+    # --- #26: enum-typed temperature setpoints (e.g. tempSelZ3 = ['0','2','5'] on
+    # some multidoor models) must NOT get fabricated 0..100 bounds nor reject valid
+    # writes. They get a discrete numeric range + membership validation before send.
+    def test_enum_setpoint_uses_discrete_bounds_not_0_100(self) -> None:
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "5"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        self.assertEqual(z3.native_min_value, 0.0)
+        self.assertEqual(z3.native_max_value, 5.0)  # NOT the fabricated 100
+        # gcd of the gaps {2,3} = 1 -> every member (0,2,5) is reachable from min.
+        self.assertEqual(z3.native_step, 1.0)
+
+    def test_enum_setpoint_uniform_set_tiles_exactly(self) -> None:
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "4"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        self.assertEqual((z3.native_min_value, z3.native_max_value, z3.native_step), (0.0, 4.0, 2.0))
+
+    def test_enum_setpoint_rejects_out_of_set_before_send(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "5"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("REF", app, {}, client=client))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        with self.assertRaises(HomeAssistantError) as ctx:
+            asyncio.run(z3.async_set_native_value(3.0))  # in 0..5 range but not in {0,2,5}
+        # Distinct, actionable error (not the generic command_error), and NO cloud call.
+        self.assertEqual(getattr(ctx.exception, "translation_key", None), "invalid_setpoint")
+        self.assertEqual(commands["settings"].send_calls, 0)
+
+    def test_enum_setpoint_in_set_value_sends(self) -> None:
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "5"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("REF", app, {}, client=client))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        asyncio.run(z3.async_set_native_value(2.0))
+        self.assertEqual(commands["settings"].send_calls, 1)
+        self.assertEqual(commands["settings"].parameters["tempSelZ3"].value, "2")
+
+    def test_non_numeric_enum_setpoint_is_gated_off(self) -> None:
+        # A mode-style enum (['low','high']) is not a sensible number control -> no
+        # entity (rather than a fabricated 0..100 number).
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["low", "high"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        keys = [e.entity_description.key for e in added]
+        self.assertNotIn("target_temp_zone3", keys)
+
+    # --- #26 CONFUTATORE: numeric/edge attacks on the new helpers (_enum_step,
+    # _numeric_enum_set, _value_in_set) + the enum bounds derivation. Each test
+    # kills a targeted mutant.
+
+    def test_enum_step_uniform_gap_three(self) -> None:
+        # {0,3,6,9} -> all gaps are 3 -> gcd = 3 (kills a gcd->1 mutant).
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._enum_step([0.0, 3.0, 6.0, 9.0]), 3.0)
+
+    def test_enum_step_single_value_is_one_and_min_eq_max(self) -> None:
+        # A 1-value enum (len<2) -> step 1.0; the entity has min==max (kills a
+        # mutant that drops the len<2 guard and would index diffs[] of an empty list).
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._enum_step([4.0]), 1.0)
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["4"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        self.assertEqual(
+            (z3.native_min_value, z3.native_max_value, z3.native_step), (4.0, 4.0, 1.0)
+        )
+
+    def test_enum_step_empty_is_one(self) -> None:
+        # Defensive: an empty list (len<2) -> 1.0, never an IndexError on diffs.
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._enum_step([]), 1.0)
+
+    def test_enum_step_single_float_value_does_not_crash(self) -> None:
+        # KILLS the `len(values) < 2`->`< 1` mutant: a single NON-integer value
+        # ['4.5'] falls through to the float branch, where min(diffs) on an EMPTY
+        # diffs list would raise ValueError. The len<2 guard must short-circuit
+        # to 1.0 (a single-int value takes the gcd branch and would NOT expose this).
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._enum_step([4.5]), 1.0)
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["4.5"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        self.assertEqual(
+            (z3.native_min_value, z3.native_max_value, z3.native_step), (4.5, 4.5, 1.0)
+        )
+
+    def test_enum_float_set_step_is_smallest_gap(self) -> None:
+        # Fractional set -> float branch -> SMALLEST adjacent diff. Use a set where
+        # the smallest gap is NOT first: [10,12,12.5] -> gaps [2.0, 0.5]. min=0.5.
+        # This single assert kills BOTH mutants: `min(diffs)`->`max(diffs)` (=2.0)
+        # AND `min(diffs)`->`diffs[0]` (=2.0).
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._enum_step([10.0, 12.0, 12.5]), 0.5)  # not 2.0
+        # And the simple ascending case still holds.
+        self.assertEqual(N._enum_step([10.0, 10.5, 12.0]), 0.5)
+
+    def test_enum_float_setpoint_full_roundtrip_bounds_and_send(self) -> None:
+        # ['10','10.5','11'] -> bounds (10,11,0.5); 10.5 passes membership and is
+        # sent as "10.5" (NOT truncated to "10"); membership and the sent string
+        # must agree with EnumParam's clean_value.
+        commands = {"settings": RecordingCommand({"tempSel": EnumParam(["10", "10.5", "11"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("WC", app, {}, client=client))
+        ent = next(e for e in added if e.entity_description.key == "target_temp")
+        self.assertEqual(
+            (ent.native_min_value, ent.native_max_value, ent.native_step),
+            (10.0, 11.0, 0.5),
+        )
+        asyncio.run(ent.async_set_native_value(10.5))
+        self.assertEqual(commands["settings"].send_calls, 1)
+        # Sent as the fractional string and accepted by the enum setter.
+        self.assertEqual(commands["settings"].parameters["tempSel"].value, "10.5")
+
+    def test_negative_enum_setpoint_bounds_and_membership(self) -> None:
+        # Freezer-style negative enum tempSelZ2 = ['-24','-20','-18']:
+        # bounds (-24,-18, gcd of {4,2}=2); -20 sends, -19 rejected before send.
+        from homeassistant.exceptions import HomeAssistantError
+
+        commands = {"settings": RecordingCommand({"tempSelZ2": EnumParam(["-24", "-20", "-18"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("REF", app, {}, client=client))
+        z2 = next(e for e in added if e.entity_description.key == "target_temp_zone2")
+        self.assertEqual(z2.native_min_value, -24.0)
+        self.assertEqual(z2.native_max_value, -18.0)
+        self.assertEqual(z2.native_step, 2.0)
+        asyncio.run(z2.async_set_native_value(-20.0))
+        self.assertEqual(commands["settings"].send_calls, 1)
+        self.assertEqual(commands["settings"].parameters["tempSelZ2"].value, "-20")
+        with self.assertRaises(HomeAssistantError):
+            asyncio.run(z2.async_set_native_value(-19.0))  # in range, not in set
+        self.assertEqual(commands["settings"].send_calls, 1)  # no extra send
+
+    def test_value_in_set_tolerance_and_non_float(self) -> None:
+        # KILLS the 1e-6 tolerance->0 mutant (2.0000001 must pass) and proves a
+        # non-float (None) returns False instead of crashing.
+        from custom_components.addhon import number as N
+
+        s = [0.0, 2.0, 5.0]
+        self.assertTrue(N._value_in_set(2.0, s))
+        self.assertTrue(N._value_in_set(2.0000001, s))  # within tolerance
+        self.assertFalse(N._value_in_set(2.1, s))
+        self.assertFalse(N._value_in_set(None, s))  # non-float -> False, no crash
+
+    def test_value_in_set_tolerance_passes_guard_via_set_native_value(self) -> None:
+        # A value with sub-tolerance drift from a set member must NOT be rejected by
+        # the up-front membership guard (kills tolerance 1e-6 -> strict equality:
+        # under strict-eq this would raise invalid_setpoint). We assert the guard
+        # specifically does not raise invalid_setpoint; the downstream enum setter
+        # may still reject the drifted string, but that is a different code path.
+        from homeassistant.exceptions import HomeAssistantError
+
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "5"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("REF", app, {}, client=client))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        try:
+            asyncio.run(z3.async_set_native_value(2.0000001))  # within 1e-6 of 2
+        except HomeAssistantError as err:
+            # Must NOT be the membership rejection; if it is, the tolerance is gone.
+            self.assertNotEqual(
+                getattr(err, "translation_key", None),
+                "invalid_setpoint",
+                "membership guard rejected a within-tolerance value (tolerance lost)",
+            )
+
+    def test_numeric_enum_set_skips_when_any_value_non_numeric(self) -> None:
+        # KILLS the `return None`->`continue` mutant in _numeric_enum_set: a single
+        # non-numeric member among numbers (['0','low','2']) must gate the WHOLE
+        # entity off (return None), not silently drop the bad value and keep [0,2].
+        from custom_components.addhon import number as N
+
+        self.assertIsNone(N._numeric_enum_set(EnumParam(["0", "low", "2"])))
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "low", "2"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        self.assertNotIn(
+            "target_temp_zone3", [e.entity_description.key for e in added]
+        )
+
+    def test_disordered_enum_set_is_sorted_for_bounds(self) -> None:
+        # KILLS the `sorted(set(out))`->`out` mutant: an enum given out of order
+        # ['5','0','2'] must still yield min=0, max=5 (NOT min=5).
+        from custom_components.addhon import number as N
+
+        self.assertEqual(N._numeric_enum_set(EnumParam(["5", "0", "2"])), [0.0, 2.0, 5.0])
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["5", "0", "2"])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
+        self.assertEqual(z3.native_min_value, 0.0)  # NOT 5.0
+        self.assertEqual(z3.native_max_value, 5.0)
+
+    def test_empty_enum_set_is_gated_off(self) -> None:
+        # An enum with no values -> _numeric_enum_set returns None -> no entity
+        # (covers the `if not out: return None` line).
+        from custom_components.addhon import number as N
+
+        self.assertIsNone(N._numeric_enum_set(EnumParam([])))
+        commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam([])})}
+        app = FakeAppliance(commands)
+        added = asyncio.run(_build("REF", app, {}))
+        self.assertNotIn(
+            "target_temp_zone3", [e.entity_description.key for e in added]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_number_setpoints.py
+++ b/tests/test_number_setpoints.py
@@ -564,28 +564,41 @@ class NumberSetpointTest(unittest.TestCase):
         self.assertFalse(N._value_in_set(2.1, s))
         self.assertFalse(N._value_in_set(None, s))  # non-float -> False, no crash
 
-    def test_value_in_set_tolerance_passes_guard_via_set_native_value(self) -> None:
-        # A value with sub-tolerance drift from a set member must NOT be rejected by
-        # the up-front membership guard (kills tolerance 1e-6 -> strict equality:
-        # under strict-eq this would raise invalid_setpoint). We assert the guard
-        # specifically does not raise invalid_setpoint; the downstream enum setter
-        # may still reject the drifted string, but that is a different code path.
-        from homeassistant.exceptions import HomeAssistantError
-
+    def test_within_tolerance_drift_snapped_to_canonical_int_sends(self) -> None:
+        # CR#7: a sub-tolerance drift (2.0000001) must be SNAPPED to the canonical
+        # member and SENT as "2" -- NOT serialized raw as "2.0000001", which the cloud
+        # enum setter rejects, surfacing as a generic command_error instead of applying.
         commands = {"settings": RecordingCommand({"tempSelZ3": EnumParam(["0", "2", "5"])})}
         app = FakeAppliance(commands)
         client = FakeClient()
         added = asyncio.run(_build("REF", app, {}, client=client))
         z3 = next(e for e in added if e.entity_description.key == "target_temp_zone3")
-        try:
-            asyncio.run(z3.async_set_native_value(2.0000001))  # within 1e-6 of 2
-        except HomeAssistantError as err:
-            # Must NOT be the membership rejection; if it is, the tolerance is gone.
-            self.assertNotEqual(
-                getattr(err, "translation_key", None),
-                "invalid_setpoint",
-                "membership guard rejected a within-tolerance value (tolerance lost)",
-            )
+        asyncio.run(z3.async_set_native_value(2.0000001))  # within 1e-6 of 2
+        self.assertEqual(commands["settings"].send_calls, 1)
+        self.assertEqual(commands["settings"].parameters["tempSelZ3"].value, "2")
+
+    def test_within_tolerance_drift_snapped_to_canonical_fraction_sends(self) -> None:
+        # Fractional set (where min+n*step float drift actually bites): 10.5000001 must
+        # be sent as "10.5", not "10.5000001".
+        commands = {"settings": RecordingCommand({"tempSel": EnumParam(["10", "10.5", "11"])})}
+        app = FakeAppliance(commands)
+        client = FakeClient()
+        added = asyncio.run(_build("WC", app, {}, client=client))
+        ent = next(e for e in added if e.entity_description.key == "target_temp")
+        asyncio.run(ent.async_set_native_value(10.5000001))  # within 1e-6 of 10.5
+        self.assertEqual(commands["settings"].send_calls, 1)
+        self.assertEqual(commands["settings"].parameters["tempSel"].value, "10.5")
+
+    def test_snap_to_set_returns_canonical_member_or_none(self) -> None:
+        # Unit: snap returns the CANONICAL member (not the drifted input) or None.
+        from custom_components.addhon import number as N
+
+        s = [0.0, 2.0, 5.0]
+        self.assertEqual(N._snap_to_set(2.0000001, s), 2.0)  # canonical, not the input
+        self.assertEqual(N._snap_to_set(2.0, s), 2.0)
+        self.assertIsNone(N._snap_to_set(2.0 + 5e-6, s))     # just beyond tolerance (1e-6)
+        self.assertIsNone(N._snap_to_set(2.1, s))            # well beyond tolerance
+        self.assertIsNone(N._snap_to_set(None, s))           # non-float, no crash
 
     def test_numeric_enum_set_skips_when_any_value_non_numeric(self) -> None:
         # KILLS the `return None`->`continue` mutant in _numeric_enum_set: a single

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -339,6 +339,58 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({}, coordinator.pending_programs)
         self.assertEqual(1, coordinator.refreshes)
 
+    async def test_start_button_sends_command_swapped_by_program_apply(self) -> None:
+        # #6: on a washer/dryer whose 'program' is a HonParameterProgram, setting its
+        # value SWAPS the active startProgram command in the appliance dict
+        # (category setter). The button must send the NEW (selected) command, not the
+        # stale pre-swap object.
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        appliance = types.SimpleNamespace(commands={})
+        new_cmd = RecordingCommand({"prStr": Param("X")})
+
+        class ProgramSwapParam:
+            """Mimics HonParameterProgram: .value setter replaces the active command
+            in appliance.commands[name] with the selected category's command."""
+
+            def __init__(self) -> None:
+                self._value = None
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd  # category swap
+
+        old_cmd = RecordingCommand({"program": ProgramSwapParam()})
+        appliance.commands["startProgram"] = old_cmd
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": "2"}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+            command_parameters={"prStr": "Y"},  # fixed params must land on the NEW command
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        # The selected (swapped) command was sent; the stale pre-swap one was NOT.
+        self.assertEqual(1, new_cmd.send_calls)
+        self.assertEqual(0, old_cmd.send_calls)
+        self.assertEqual("2", old_cmd.parameters["program"].value)  # program applied
+        # The fixed parameters were applied to the NEW (swapped) command, not the stale one.
+        self.assertEqual("Y", new_cmd.parameters["prStr"].value)
+
     async def test_stop_button_ignores_pending_program(self) -> None:
         from custom_components.addhon.button import HonProgramCommandButton
 

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -339,6 +339,73 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({}, coordinator.pending_programs)
         self.assertEqual(1, coordinator.refreshes)
 
+    async def test_button_debug_log_redacts_store_keys(self) -> None:
+        # CR#1: the press + "consumed and removed" DEBUG logs dump the pending-program
+        # store, whose KEYS are the MAC-derived appliance id. The raw MAC must NOT reach
+        # the log (the AST guard can't catch the old dict(store)); behaviour unchanged.
+        from custom_components.addhon.select import HonProgramSelect
+        from custom_components.addhon.button import HonProgramCommandButton
+        from custom_components.addhon import button as button_mod
+
+        mac = "AA:BB:CC:DD:EE:FF"
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        # appliance keyed under the MAC so the entity's _appliance_id (and thus the
+        # store key) is the MAC -- the exact identity that must not reach the log.
+        coordinator = FakeCoordinator({mac: {
+            "type": "WM", "name": "Washer",
+            "appliance": types.SimpleNamespace(commands={"startProgram": start}),
+            "attributes": {}, "settings": {},
+        }})
+
+        select_entity = HonProgramSelect(coordinator, mac, FakeClient())
+        self._attach(select_entity)
+        button = HonProgramCommandButton(
+            coordinator, mac, FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        await select_entity.async_select_option("Sintetici")
+        with self.assertLogs(button_mod._LOGGER.name, level="DEBUG") as logs:
+            await button.async_press()
+        blob = "\n".join(logs.output)
+        # behaviour unchanged: program applied + started, pending cleared
+        self.assertEqual("2", start.parameters["program"].value)
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual({}, coordinator.pending_programs)
+        # both store-dump debug lines fired, with the MAC key masked
+        self.assertTrue(any("press" in ln and "store=" in ln for ln in logs.output))
+        self.assertTrue(any("consumed and removed" in ln for ln in logs.output))
+        self.assertNotIn(mac, blob)        # raw MAC key never logged
+        self.assertNotIn("AA:BB", blob)
+        self.assertIn("'***': '2'", blob)  # masked key, program-code value preserved
+
+    async def test_select_debug_log_redacts_store_keys(self) -> None:
+        # CR#1 (sibling site): the select before/after-selection DEBUG logs dump the
+        # same store -> the MAC key must be masked while the selection still stores
+        # under the real id (redaction is log-only, behaviour unchanged).
+        from custom_components.addhon.select import HonProgramSelect
+        from custom_components.addhon import select as select_mod
+
+        mac = "AA:BB:CC:DD:EE:FF"
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator({mac: {
+            "type": "WM", "name": "Washer",
+            "appliance": types.SimpleNamespace(commands={"startProgram": start}),
+            "attributes": {}, "settings": {},
+        }})
+        select_entity = HonProgramSelect(coordinator, mac, FakeClient())
+        self._attach(select_entity)
+
+        with self.assertLogs(select_mod._LOGGER.name, level="DEBUG") as logs:
+            await select_entity.async_select_option("Sintetici")
+        blob = "\n".join(logs.output)
+        self.assertEqual("2", coordinator.pending_programs.get(mac))  # stored under real id
+        self.assertTrue(any("selection" in ln and "store=" in ln for ln in logs.output))
+        self.assertNotIn(mac, blob)
+        self.assertIn("'***': '2'", blob)  # the "after selection" dump masks the key
+
     async def test_start_button_sends_command_swapped_by_program_apply(self) -> None:
         # #6: on a washer/dryer whose 'program' is a HonParameterProgram, setting its
         # value SWAPS the active startProgram command in the appliance dict

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -561,5 +561,53 @@ class LoadingPercentageBuildTest(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class ZeroPlaceholderFallbackTest(unittest.IsolatedAsyncioTestCase):
+    """#10: a zero/empty primary value is a placeholder MISS, so the attr_fallbacks
+    chain keeps looking (actualWeight=0 -> weight; temp=0 -> temperature)."""
+
+    async def _value(self, app_type: str, key: str, attributes: dict) -> object:
+        from custom_components.addhon import sensor
+        from custom_components.addhon.const import DOMAIN
+
+        uid = f"{app_type.lower()}-1"
+        data = {uid: {"type": app_type, "name": app_type, "attributes": attributes, "settings": {}}}
+        coordinator = FakeCoordinator(data)
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator}}})
+        added: list = []
+        await sensor.async_setup_entry(hass, FakeEntry(), added.extend)
+        entity = next(e for e in added if e._attr_unique_id == f"{uid}_{key}")
+        return entity.native_value
+
+    async def test_zero_actual_weight_falls_back_to_weight(self) -> None:
+        # device-WM.json shape: actualWeight=0, weight=3 -> must read 3, not 0.
+        value = await self._value("WM", "estimated_weight", {"actualWeight": 0, "weight": 3})
+        self.assertEqual(value, 3.0)
+
+    async def test_zero_actual_weight_as_string_falls_back(self) -> None:
+        value = await self._value("WM", "estimated_weight", {"actualWeight": "0", "weight": "3"})
+        self.assertEqual(value, 3.0)
+
+    async def test_real_actual_weight_wins(self) -> None:
+        value = await self._value("WM", "estimated_weight", {"actualWeight": 5, "weight": 3})
+        self.assertEqual(value, 5.0)
+
+    async def test_both_zero_stays_zero(self) -> None:
+        # Genuinely zero (no better source) -> 0.0, not None.
+        value = await self._value("WM", "estimated_weight", {"actualWeight": 0, "weight": 0})
+        self.assertEqual(value, 0.0)
+
+    async def test_only_fallback_present(self) -> None:
+        value = await self._value("WM", "estimated_weight", {"weight": 4})
+        self.assertEqual(value, 4.0)
+
+    async def test_dishwasher_zero_temp_falls_back_to_temperature(self) -> None:
+        value = await self._value("DW", "wash_temperature", {"temp": 0, "temperature": 55})
+        self.assertEqual(value, 55.0)
+
+    async def test_dishwasher_real_temp_wins(self) -> None:
+        value = await self._value("DW", "wash_temperature", {"temp": 40, "temperature": 55})
+        self.assertEqual(value, 40.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sensor_per_type.py
+++ b/tests/test_sensor_per_type.py
@@ -608,6 +608,52 @@ class ZeroPlaceholderFallbackTest(unittest.IsolatedAsyncioTestCase):
         value = await self._value("DW", "wash_temperature", {"temp": 40, "temperature": 55})
         self.assertEqual(value, 40.0)
 
+    async def test_float_zero_string_primary_falls_back(self) -> None:
+        # A "0.0" numeric STRING is also a placeholder zero -> fall back to weight.
+        value = await self._value("WM", "estimated_weight", {"actualWeight": "0.0", "weight": 3})
+        self.assertEqual(value, 3.0)
+
+    async def test_float_zero_primary_falls_back(self) -> None:
+        # A float 0.0 primary is a placeholder zero -> fall back to weight.
+        value = await self._value("WM", "estimated_weight", {"actualWeight": 0.0, "weight": 3})
+        self.assertEqual(value, 3.0)
+
+
+class IsZeroishTest(unittest.TestCase):
+    """#10 helper contract: _is_zeroish flags placeholder zero/empty values across
+    ints, floats, numeric strings and the empty string, but NOT real values, non-numeric
+    strings or None. Direct unit test: _get_attr collapses "" -> None before the entity
+    path, so the empty-string branch is otherwise unreachable from native_value."""
+
+    def test_empty_string_is_zeroish(self) -> None:
+        from custom_components.addhon.sensor import _is_zeroish
+
+        self.assertTrue(_is_zeroish(""))
+
+    def test_numeric_zero_values_are_zeroish(self) -> None:
+        from custom_components.addhon.sensor import _is_zeroish
+
+        for value in (0, 0.0, "0", "0.0", "00", " 0 "):
+            self.assertTrue(_is_zeroish(value), value)
+
+    def test_nonzero_values_are_not_zeroish(self) -> None:
+        from custom_components.addhon.sensor import _is_zeroish
+
+        for value in (1, 3.5, "3", "0.1", -0.0001):
+            self.assertFalse(_is_zeroish(value), value)
+
+    def test_negative_zero_is_zeroish(self) -> None:
+        from custom_components.addhon.sensor import _is_zeroish
+
+        self.assertTrue(_is_zeroish(-0.0))
+
+    def test_non_numeric_and_none_are_not_zeroish(self) -> None:
+        # Non-numeric / unconvertible inputs hit the except branch -> False (not a miss).
+        from custom_components.addhon.sensor import _is_zeroish
+
+        for value in ("abc", None, [], {}, object()):
+            self.assertFalse(_is_zeroish(value), value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_adapter.py
+++ b/tests/test_session_adapter.py
@@ -58,7 +58,11 @@ class TotalDetachGuardTest(unittest.TestCase):
     def test_hon_client_uses_native_factory(self) -> None:
         src = _HON_CLIENT.read_text(encoding="utf-8")
         self.assertIn("from .client.factory import create_session", src)
-        self.assertIn("create_session(self._email, self._password)", src)
+        # create_session is called with the credentials (now also with the
+        # enable_mqtt/minimal flags for the lightweight config-flow validation).
+        self.assertIn("create_session(", src)
+        self.assertIn("self._email", src)
+        self.assertIn("self._password", src)
         self.assertNotIn("ensure_enum_patch", src)
 
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -76,6 +76,18 @@ class TranslationsContentTest(unittest.TestCase):
             for key in ("cannot_connect", "invalid_auth", "unknown"):
                 self.assertIn(key, errors, f"{lang}: missing error.{key}")
 
+    def test_per_code_error_strings_carry_error_code_placeholder(self) -> None:
+        # #30: the precise ADDHON-NNN codes are injected via {error_code}. The two
+        # generic buckets (cannot_connect/invalid_auth) keep no placeholder.
+        for lang in LANGS:
+            errors = self.data[lang]["config"]["error"]
+            for key, text in errors.items():
+                if key in ("cannot_connect", "invalid_auth"):
+                    continue
+                self.assertIn(
+                    "{error_code}", text, f"{lang}: error.{key} must carry {{error_code}}"
+                )
+
     def test_abort_keys_present(self) -> None:
         for lang in LANGS:
             abort = self.data[lang]["config"]["abort"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -77,13 +77,15 @@ class TranslationsContentTest(unittest.TestCase):
                 self.assertIn(key, errors, f"{lang}: missing error.{key}")
 
     def test_per_code_error_strings_carry_error_code_placeholder(self) -> None:
-        # #30: the precise ADDHON-NNN codes are injected via {error_code}. The two
-        # generic buckets (cannot_connect/invalid_auth) keep no placeholder.
+        # #30: the precise ADDHON-NNN codes are injected via {error_code}. Every
+        # config.error string must carry the placeholder -- including the two
+        # generic buckets (cannot_connect/invalid_auth): a ui=False code routed
+        # there by config_flow._error_base_and_code still yields a non-empty
+        # code.label (e.g. ADDHON-150/210/320), so the buckets must surface it too
+        # (greptile P2: the label was computed and passed but never shown).
         for lang in LANGS:
             errors = self.data[lang]["config"]["error"]
             for key, text in errors.items():
-                if key in ("cannot_connect", "invalid_auth"):
-                    continue
                 self.assertIn(
                     "{error_code}", text, f"{lang}: error.{key} must carry {{error_code}}"
                 )

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -95,6 +95,25 @@ class TranslationsContentTest(unittest.TestCase):
     def test_en_it_have_identical_structure(self) -> None:
         self.assertEqual(_dotted_keys(self.data["en"]), _dotted_keys(self.data["it"]))
 
+    def test_no_dead_pyhon_references(self) -> None:
+        """#17 regression guard: the strangler fully removed pyhOn (native client in
+        hon_client.py), so no user-facing translation string may mention it again.
+        A case-insensitive scan of the raw files catches any re-introduction in any
+        key (service descriptions, labels, etc.), not only the ones #17 touched."""
+        for lang in LANGS:
+            offenders = [
+                line.strip()
+                for line in (TRANSLATIONS / f"{lang}.json")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if "pyhon" in line.lower()
+            ]
+            self.assertEqual(
+                [],
+                offenders,
+                f"{lang}.json must not reintroduce a dead pyhOn reference (#17): {offenders}",
+            )
+
 
 class TranslationsMatchConfigFlowTest(unittest.TestCase):
     """Strings must cover exactly the keys config_flow.py references."""

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -398,6 +398,27 @@ class ApiHardeningTest(unittest.TestCase):
                 )
                 self.assertEqual(got, {})
 
+    def test_load_commands_failure_redacts_identity_in_log(self) -> None:
+        # #33: both failure branches log the raw cloud response at ERROR (never
+        # gated); identity in the body must be redacted.
+        mac = "AA:BB:CC:DD:EE:FF"
+        logger = "custom_components.addhon.client.transport.api"
+        for body in (
+            {"macAddress": mac, "payload": {}},                   # invalid-payload branch
+            {"macAddress": mac, "payload": {"resultCode": "1"}},  # resultCode != 0 branch
+            {"meta": {"macAddress": mac}, "payload": {}},         # nested mac (recursion)
+            {"payload": {"resultCode": "1", "dev": {"macAddress": mac}}},  # nested mac
+        ):
+            with self.subTest(body=body):
+                with self.assertLogs(logger, level="ERROR") as cm:
+                    got = _run(
+                        _call(FakeConnection(copy.deepcopy(body))).load_commands(FakeAppliance())
+                    )
+                self.assertEqual(got, {})
+                blob = "\n".join(cm.output)
+                self.assertNotIn(mac, blob)
+                self.assertIn("***", blob)
+
     def test_commands_result_code_nonzero(self) -> None:
         body = {"payload": {"resultCode": "1", "settings": {}}}
         self.assertEqual(_oracle_commands(copy.deepcopy(body)), {})

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import logging
 import re
 import sys
 import types
@@ -523,6 +524,25 @@ class SendCommandTest(unittest.TestCase):
                 conn = FakeConnection(body)
                 ok = _run(_call(conn).send_command(FakeAppliance(), "x", {}, {}))
                 self.assertFalse(ok)
+
+    def test_send_command_failure_redacts_identity_in_logs(self) -> None:
+        # #23: on failure the request payload (macAddress, transactionId=MAC,
+        # device.mobileId) must NOT be logged in cleartext; only command+resultCode
+        # at ERROR, the redacted payload at DEBUG.
+        self._patch_clock("2026-06-18T12:34:56.789012")
+        conn = FakeConnection({"payload": {"resultCode": "7"}}, mobile_id="SECRET_MOBILE")
+        app = FakeAppliance()  # mac_address = "AA:BB:CC:DD:EE:FF"
+        logger = "custom_components.addhon.client.transport.api"
+        with self.assertLogs(logger, level="DEBUG") as cm:
+            ok = _run(_call(conn).send_command(app, "setParameters", {"tempSelZ1": 4}, {}))
+        self.assertFalse(ok)
+        blob = "\n".join(cm.output)
+        self.assertNotIn(app.mac_address, blob)   # mac (also covers transactionId=<mac>_<ts>)
+        self.assertNotIn("SECRET_MOBILE", blob)   # device.mobileId (nested)
+        errors = "\n".join(r.getMessage() for r in cm.records if r.levelno == logging.ERROR)
+        self.assertIn("setParameters", errors)    # command in the ERROR line
+        self.assertIn("7", errors)                # resultCode in the ERROR line
+        self.assertIn("***", blob)                # redaction marker
 
 
 class CommandTimestampTest(unittest.TestCase):

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -658,6 +658,17 @@ class ContentTypeTest(unittest.TestCase):
         app = FakeAppliance(eepromId="EE", fwVersion="1.2", series="S")
         _run(_call(_StrictConnection(body)).load_commands(app))
 
+    def test_send_command_passes_content_type_none(self) -> None:
+        # Write path: the cloud's non-JSON Content-Type response motivated #8.
+        conn = _StrictConnection({"payload": {"resultCode": "0"}})
+        _run(_call(conn).send_command(FakeAppliance(), "setParameters", {"x": 1}, {}))
+
+    def test_load_attributes_passes_content_type_none(self) -> None:
+        _run(_call(_StrictConnection({})).load_attributes(FakeAppliance()))
+
+    def test_load_statistics_passes_content_type_none(self) -> None:
+        _run(_call(_StrictConnection({})).load_statistics(FakeAppliance()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -626,5 +626,38 @@ class ApiIntentionalNarrowingTest(unittest.TestCase):
         self.assertEqual(got, "")
 
 
+_NO_CT = object()
+
+
+class _StrictResponse(FakeResponse):
+    """json() requires content_type=None to be passed explicitly; otherwise it
+    raises, simulating aiohttp's ContentTypeError on a wrong Content-Type."""
+
+    async def json(self, content_type=_NO_CT):
+        if content_type is _NO_CT:
+            raise AssertionError("response.json() called without content_type=None")
+        return self._body
+
+
+class _StrictConnection(FakeConnection):
+    def _ctx(self, method, url, kwargs):
+        return _ReqCtx(self, method, url, kwargs, _StrictResponse(self._body, self._text))
+
+
+class ContentTypeTest(unittest.TestCase):
+    """#8: every api.py call-site must pass content_type=None (the cloud sometimes
+    returns valid JSON with a non-JSON Content-Type)."""
+
+    def test_load_appliances_passes_content_type_none(self) -> None:
+        body = {"modules": {"applianceList": {"payload": {"appliances": [{"a": 1}]}}}}
+        # Would raise if load_appliances called .json() without content_type=None.
+        _run(_call(_StrictConnection(body)).load_appliances())
+
+    def test_load_commands_passes_content_type_none(self) -> None:
+        body = {"payload": {"resultCode": "0"}}
+        app = FakeAppliance(eepromId="EE", fwVersion="1.2", series="S")
+        _run(_call(_StrictConnection(body)).load_commands(app))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -184,5 +184,49 @@ class NativeAuthFlowTest(unittest.TestCase):
         self.assertEqual(methods, ["GET", "GET", "GET", "GET", "POST", "GET", "GET", "POST"])
 
 
+class RefreshTest(unittest.TestCase):
+    """refresh() token rotation (#15) and malformed-response handling (#7)."""
+
+    def _auth(self, responses, refresh_token="old"):
+        auth = HonAuth(FakeSession(responses), "user@x.it", "pw", HonDevice())
+        auth.refresh_token = refresh_token
+        return auth
+
+    def test_refresh_rotates_refresh_token(self) -> None:
+        # A new refresh_token in the response must be persisted (#15).
+        auth = self._auth([
+            FakeResp(json={"id_token": "I", "access_token": "A", "refresh_token": "NEWRT"}),
+            FakeResp(json={"cognitoUser": {"Token": "COG"}}),  # _api_auth
+        ])
+        ok = asyncio.run(auth.refresh())
+        self.assertTrue(ok)
+        self.assertEqual("NEWRT", auth.refresh_token)
+        self.assertEqual("I", auth.id_token)
+        self.assertEqual("A", auth.access_token)
+
+    def test_refresh_keeps_token_when_not_rotated(self) -> None:
+        auth = self._auth([
+            FakeResp(json={"id_token": "I", "access_token": "A"}),
+            FakeResp(json={"cognitoUser": {"Token": "COG"}}),
+        ])
+        ok = asyncio.run(auth.refresh())
+        self.assertTrue(ok)
+        self.assertEqual("old", auth.refresh_token)
+
+    def test_refresh_malformed_2xx_returns_false(self) -> None:
+        # 200 without id/access token -> False, no KeyError, _expires untouched,
+        # and _api_auth is NOT reached (only the token POST happens).
+        auth = self._auth([FakeResp(json={})])
+        before = auth._expires
+        ok = asyncio.run(auth.refresh())
+        self.assertFalse(ok)
+        self.assertEqual(before, auth._expires)
+        self.assertEqual(1, len(auth._session.calls))  # no _api_auth call
+
+    def test_refresh_4xx_returns_false(self) -> None:
+        auth = self._auth([FakeResp(status=400)])
+        self.assertFalse(asyncio.run(auth.refresh()))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -358,6 +358,190 @@ class ConnectionTest(unittest.TestCase):
             asyncio.run(run())
 
 
+class RetryRefreshSingleFlightTest(unittest.TestCase):
+    """CR#3: the 401/403 RETRY refresh (loop=0 in _intercept) must be single-flighted
+    under the same _refresh_lock as the pre-request path, must copy the rotated
+    refresh_token back, and must release the lock BEFORE the recursive _intercept
+    (asyncio.Lock is not reentrant -> would deadlock)."""
+
+    def test_concurrent_401s_single_retry_refresh(self) -> None:
+        # A burst of concurrent requests (the asyncio.gather in load_commands) that all
+        # 401 must collapse to ONE refresh on the shared rotating token -- not N. The
+        # refresh yields so the siblings interleave and block on the lock.
+        class SlowFakeAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                await asyncio.sleep(0)  # yield: siblings reach the lock before gen bumps
+                self.cognito_token, self.id_token, self.refresh_token = "C2", "I2", "RT2"
+                self.token_expires_soon = False
+                return True
+
+        auth = SlowFakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"  # authenticated, NOT expiring
+        conn = _conn(auth, FakeSession([401, 401, 401, 200, 200, 200]))
+        conn._refresh_token = "RT"
+
+        async def one():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        async def run():
+            return await asyncio.gather(one(), one(), one())
+
+        results = asyncio.run(run())
+        self.assertEqual(results, [200, 200, 200])
+        self.assertEqual(auth.refresh_calls, 1)        # single-flight (was N)
+        self.assertEqual(auth.authenticate_calls, 0)
+        self.assertEqual(conn._refresh_token, "RT2")   # rotated token copied back
+
+    def test_gen_snapshot_taken_before_send_skips_inflight_sibling_refresh(self) -> None:
+        # Pins the snapshot PLACEMENT: refresh_gen is captured BEFORE the request is
+        # sent, so a request whose token was minted at gen G and is rejected while a
+        # sibling refreshed WHILE IT WAS IN FLIGHT (gen -> G+1) correctly SKIPS its own
+        # refresh. If the snapshot were taken AFTER the send, the in-flight request would
+        # read the advanced gen and refresh redundantly (the herd survives). Coordinated
+        # with events for determinism (no reliance on sleep ordering).
+        b_sent = asyncio.Event()       # set when request B has sent (snapshotted gen=0)
+        a_refreshed = asyncio.Event()  # set when request A has finished refreshing
+
+        class GateAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                await b_sent.wait()  # hold the refresh until B has sent (and snapshotted)
+                self.cognito_token, self.id_token, self.refresh_token = "C2", "I2", "RT2"
+                self.token_expires_soon = False
+                a_refreshed.set()
+                return True
+
+        class GatedResp:
+            def __init__(self, status, on_enter=None, wait_for=None):
+                self.status = status
+                self._on_enter = on_enter
+                self._wait_for = wait_for
+
+            async def json(self, content_type=None):
+                return {"ok": True}
+
+            async def __aenter__(self):
+                if self._on_enter is not None:
+                    self._on_enter.set()
+                if self._wait_for is not None:
+                    await self._wait_for.wait()  # stay IN FLIGHT until the sibling refreshed
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        class GatedSession:
+            def __init__(self):
+                self.calls: list = []
+                self._n = 0
+
+            def _resp(self, url, **kw):
+                self.calls.append(kw.get("headers", {}))
+                self._n += 1
+                if self._n == 1:
+                    return GatedResp(401)                                  # A: 401 now
+                if self._n == 2:
+                    return GatedResp(401, on_enter=b_sent, wait_for=a_refreshed)  # B: 401, in-flight
+                return GatedResp(200)                                      # retries: 200
+
+            def get(self, url, **kw):
+                return self._resp(url, **kw)
+
+            def post(self, url, **kw):
+                return self._resp(url, **kw)
+
+        auth = GateAuth()
+        auth.cognito_token, auth.id_token = "C", "I"  # authenticated, not expiring
+        conn = _conn(auth, GatedSession())
+        conn._refresh_token = "RT"
+
+        async def one():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        async def run():
+            return await asyncio.gather(one(), one())
+
+        results = asyncio.run(asyncio.wait_for(run(), timeout=2.0))
+        self.assertEqual(results, [200, 200])
+        # B's token was minted at gen 0; A bumped to gen 1 while B was in flight, so B
+        # must SKIP -> exactly one refresh. (Snapshot-after-send would make this 2.)
+        self.assertEqual(auth.refresh_calls, 1)
+
+    def test_rotation_after_401_retry_propagates_to_connection(self) -> None:
+        # Sub-claim (b): the retry refresh rotates the refresh_token; it MUST be copied
+        # back to the connection (the loop=0 path used to skip this, leaving it stale).
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"  # authenticated, not expiring
+        conn = _conn(auth, FakeSession([401, 200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.post("https://x/api") as resp:
+                return resp.status
+
+        status = asyncio.run(run())
+        self.assertEqual(status, 200)
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(conn._refresh_token, "RT2")  # FakeAuth.refresh rotates to RT2
+
+    def test_single_401_retry_completes_no_deadlock(self) -> None:
+        # The retry lock must be released BEFORE the recursive _intercept (loop=1),
+        # which re-acquires it via _check_headers. With token_expires_soon left STICKY
+        # by refresh, the loop=1 _check_headers genuinely re-takes the lock -> if the
+        # retry held it across the recursion this would deadlock (caught by wait_for).
+        class StickyExpiryAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                self.cognito_token, self.id_token, self.refresh_token = "C2", "I2", "RT2"
+                self.token_expires_soon = True  # sticky -> loop=1 _check_headers re-locks
+                return True
+
+        auth = StickyExpiryAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = False
+        conn = _conn(auth, FakeSession([401, 200, 200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        # wait_for turns a deadlock into a TimeoutError instead of hanging the suite.
+        status = asyncio.run(asyncio.wait_for(run(), timeout=2.0))
+        self.assertEqual(status, 200)
+        self.assertGreaterEqual(auth.refresh_calls, 2)  # loop0 retry + loop1 pre-request
+
+    def test_double_check_skips_when_gen_advanced(self) -> None:
+        # Directly: if a sibling already refreshed since this request was sent (the
+        # generation advanced), _refresh_after_rejection must NOT refresh again.
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([]))
+        conn._refresh_token = "RT"
+        conn._refresh_gen = 5
+
+        asyncio.run(conn._refresh_after_rejection(3))  # snapshot (3) != current (5)
+        self.assertEqual(auth.refresh_calls, 0)
+        self.assertEqual(conn._refresh_token, "RT")    # untouched
+
+    def test_double_check_refreshes_when_gen_matches(self) -> None:
+        # If nobody refreshed since this request was sent, the retry refreshes once,
+        # copies the rotated token back, and bumps the generation.
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([]))
+        conn._refresh_token = "RT"
+        conn._refresh_gen = 5
+
+        asyncio.run(conn._refresh_after_rejection(5))  # snapshot matches current
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(conn._refresh_token, "RT2")   # rotated + copied back
+        self.assertEqual(conn._refresh_gen, 6)         # generation bumped
+
+
 class ConnectionCreateCleanupTest(unittest.TestCase):
     """#31: a failed create() must not leak the aiohttp.ClientSession it created,
     and must never close a caller-supplied session (which the caller owns)."""

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -189,6 +189,26 @@ class ConnectionTest(unittest.TestCase):
 
         asyncio.run(run())
         self.assertEqual(auth.refresh_calls, 1)
+        # The pre-refresh must happen BEFORE the first request, so the very first
+        # outgoing request already carries the refreshed token (isolates the
+        # pre-refresh from the post-response refresh branch in _intercept).
+        self.assertEqual(conn._session.calls[0]["cognito-token"], "COG2")
+
+    def test_refresh_rotation_propagates_to_connection(self) -> None:
+        # A rotated refresh_token from auth must be stored on the connection, so a
+        # later restart persists the new token (anti IdP-rotation invariant).
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = True
+        conn = _conn(auth, FakeSession([200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        asyncio.run(run())
+        self.assertEqual(conn._refresh_token, "RT2")  # FakeAuth.refresh rotates to RT2
 
     def test_single_401_triggers_one_refresh(self) -> None:
         # #14: a single 401 must refresh exactly once (was 3: pre + loop0 + recursion).

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -82,6 +82,10 @@ class FakeAuth:
         self.cognito_token = "COG2"
         self.id_token = "IDT2"
         self.refresh_token = "RT2"
+        # Faithful to the real refresh(): resetting _expires clears the expiry
+        # flags, so a guarded pre-refresh does not fire again right after.
+        self.token_expires_soon = False
+        self.token_is_expired = False
         return True
 
 
@@ -154,6 +158,96 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertGreaterEqual(auth.refresh_calls, 1)
         self.assertEqual(len(session.calls), 2)  # one retry
+
+    def test_no_pre_refresh_when_token_fresh(self) -> None:
+        # #1: a valid, non-expiring token with a refresh_token present must NOT
+        # trigger a pre-request refresh (the old code refreshed on every request).
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = False
+        conn = _conn(auth, FakeSession([200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        asyncio.run(run())
+        self.assertEqual(auth.refresh_calls, 0)
+        self.assertEqual(auth.authenticate_calls, 0)
+
+    def test_pre_refresh_when_expires_soon(self) -> None:
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = True
+        conn = _conn(auth, FakeSession([200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        asyncio.run(run())
+        self.assertEqual(auth.refresh_calls, 1)
+
+    def test_single_401_triggers_one_refresh(self) -> None:
+        # #14: a single 401 must refresh exactly once (was 3: pre + loop0 + recursion).
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = False
+        conn = _conn(auth, FakeSession([401, 200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.post("https://x/api") as resp:
+                return resp.status
+
+        status = asyncio.run(run())
+        self.assertEqual(status, 200)
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(len(conn._session.calls), 2)
+
+    def test_restart_with_refresh_token_refreshes_not_logins(self) -> None:
+        # State after restart: refresh_token persisted but in-RAM tokens empty and
+        # not yet near expiry -> use the persisted token (refresh) instead of a
+        # full re-login (authenticate).
+        auth = FakeAuth()  # cognito/id empty
+        auth.token_expires_soon = False
+        conn = _conn(auth, FakeSession([200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        asyncio.run(run())
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(auth.authenticate_calls, 0)
+
+    def test_concurrent_requests_single_refresh(self) -> None:
+        # The lock + double-check collapses a burst of concurrent requests (the
+        # asyncio.gather in load_commands) into ONE refresh on the shared token.
+        class SlowFakeAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                await asyncio.sleep(0)  # yield so the other coroutines interleave
+                self.cognito_token, self.id_token, self.refresh_token = "C2", "I2", "RT2"
+                return True
+
+        auth = SlowFakeAuth()  # tokens empty -> all 3 initially _need_refresh
+        conn = _conn(auth, FakeSession([200, 200, 200]))
+        conn._refresh_token = "RT"
+
+        async def one():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        async def run():
+            return await asyncio.gather(one(), one(), one())
+
+        asyncio.run(run())
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(auth.authenticate_calls, 0)
 
     def test_retry_on_403_refreshes(self) -> None:
         # Same branch as the 401 (the code treats them identically) but made explicit

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -53,6 +53,8 @@ def _install_stubs() -> None:
     aio.ClientSession = getattr(aio, "ClientSession", type("ClientSession", (), {}))
     aio.ClientResponse = getattr(aio, "ClientResponse", type("ClientResponse", (), {}))
     aio.ContentTypeError = getattr(aio, "ContentTypeError", type("ContentTypeError", (Exception,), {}))
+    # connection.create() now passes an explicit timeout; the stub just records kwargs.
+    aio.ClientTimeout = getattr(aio, "ClientTimeout", lambda **kw: kw)
 
 
 _install_stubs()
@@ -377,13 +379,36 @@ class ConnectionCreateCleanupTest(unittest.TestCase):
         def boom(*a, **k):
             raise RuntimeError("auth ctor boom")
 
-        self._patch(conn_mod.aiohttp, "ClientSession", lambda: FakeSess())
+        self._patch(conn_mod.aiohttp, "ClientSession", lambda *a, **k: FakeSess())
         self._patch(conn_mod, "HonAuth", boom)
 
         conn = HonConnection("u@x", "p")  # session=None -> connection owns it
         with self.assertRaises(RuntimeError):
             asyncio.run(conn.create())
         self.assertEqual(closed["n"], 1)  # owned session closed, not leaked
+
+    def test_owned_session_gets_explicit_timeout(self) -> None:
+        # #30: the session WE create must carry an explicit ClientTimeout (so a dead
+        # endpoint fails fast, not after aiohttp's 300s default).
+        import custom_components.addhon.client.transport.connection as conn_mod
+
+        captured = {}
+
+        class FakeSess:
+            async def close(self):
+                pass
+
+        def fake_client_session(*a, **k):
+            captured.update(k)
+            return FakeSess()
+
+        self._patch(conn_mod.aiohttp, "ClientSession", fake_client_session)
+        self._patch(conn_mod, "HonAuth", lambda *a, **k: object())
+
+        conn = HonConnection("u@x", "p")  # owns the session
+        asyncio.run(conn.create())
+        self.assertIn("timeout", captured)
+        self.assertIsNotNone(captured["timeout"])
 
     def test_create_failure_leaves_caller_session_open(self) -> None:
         import custom_components.addhon.client.transport.connection as conn_mod
@@ -420,7 +445,7 @@ class ConnectionCreateCleanupTest(unittest.TestCase):
         def cancel_boom(*a, **k):
             raise asyncio.CancelledError()
 
-        self._patch(conn_mod.aiohttp, "ClientSession", lambda: FakeSess())
+        self._patch(conn_mod.aiohttp, "ClientSession", lambda *a, **k: FakeSess())
         self._patch(conn_mod, "HonAuth", cancel_boom)
 
         conn = HonConnection("u@x", "p")  # owns the session

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -356,5 +356,78 @@ class ConnectionTest(unittest.TestCase):
             asyncio.run(run())
 
 
+class ConnectionCreateCleanupTest(unittest.TestCase):
+    """#31: a failed create() must not leak the aiohttp.ClientSession it created,
+    and must never close a caller-supplied session (which the caller owns)."""
+
+    def _patch(self, obj, name, value):
+        real = getattr(obj, name)
+        setattr(obj, name, value)
+        self.addCleanup(lambda: setattr(obj, name, real))
+
+    def test_create_failure_closes_owned_session(self) -> None:
+        import custom_components.addhon.client.transport.connection as conn_mod
+
+        closed = {"n": 0}
+
+        class FakeSess:
+            async def close(self):
+                closed["n"] += 1
+
+        def boom(*a, **k):
+            raise RuntimeError("auth ctor boom")
+
+        self._patch(conn_mod.aiohttp, "ClientSession", lambda: FakeSess())
+        self._patch(conn_mod, "HonAuth", boom)
+
+        conn = HonConnection("u@x", "p")  # session=None -> connection owns it
+        with self.assertRaises(RuntimeError):
+            asyncio.run(conn.create())
+        self.assertEqual(closed["n"], 1)  # owned session closed, not leaked
+
+    def test_create_failure_leaves_caller_session_open(self) -> None:
+        import custom_components.addhon.client.transport.connection as conn_mod
+
+        closed = {"n": 0}
+
+        class FakeSess:
+            async def close(self):
+                closed["n"] += 1
+
+        def boom(*a, **k):
+            raise RuntimeError("auth ctor boom")
+
+        self._patch(conn_mod, "HonAuth", boom)
+
+        passed = FakeSess()
+        conn = HonConnection("u@x", "p", session=passed)  # caller owns the session
+        with self.assertRaises(RuntimeError):
+            asyncio.run(conn.create())
+        self.assertEqual(closed["n"], 0)  # caller-supplied session must stay open
+
+    def test_create_baseexception_closes_owned_session(self) -> None:
+        # #31: the guard is `except BaseException` on purpose; a CANCELLED create()
+        # (CancelledError is a BaseException, NOT an Exception) must still release
+        # the owned session. `except Exception` would leak it -> kill that mutant.
+        import custom_components.addhon.client.transport.connection as conn_mod
+
+        closed = {"n": 0}
+
+        class FakeSess:
+            async def close(self):
+                closed["n"] += 1
+
+        def cancel_boom(*a, **k):
+            raise asyncio.CancelledError()
+
+        self._patch(conn_mod.aiohttp, "ClientSession", lambda: FakeSess())
+        self._patch(conn_mod, "HonAuth", cancel_boom)
+
+        conn = HonConnection("u@x", "p")  # owns the session
+        with self.assertRaises(asyncio.CancelledError):
+            asyncio.run(conn.create())
+        self.assertEqual(closed["n"], 1)  # owned session closed on BaseException too
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -260,6 +260,85 @@ class PublishReceivedTest(unittest.TestCase):
         m._on_publish_received(types.SimpleNamespace(publish_packet=None))
         self.assertEqual(hon.notified, 0)
 
+    def test_non_json_payload_skipped_no_crash(self) -> None:
+        # Undecodable / non-JSON bytes -> skipped, not raised (the callback runs on
+        # an awscrt thread, a raise there would silence every later push).
+        app = FakeAppliance("t/appliancestatus")
+        m, hon = self._client(app)
+        bad = types.SimpleNamespace(
+            publish_packet=types.SimpleNamespace(
+                topic="t/appliancestatus", payload=b"not json {"
+            )
+        )
+        m._on_publish_received(bad)  # must not raise
+        self.assertEqual(hon.notified, 0)
+
+    def test_valid_json_but_non_object_skipped_no_crash(self) -> None:
+        # Valid JSON that is NOT an object (a bare list): json.loads succeeds, but the
+        # later payload.get(...) would raise AttributeError -> must be skipped.
+        app = FakeAppliance("t/appliancestatus")
+        m, hon = self._client(app)
+        pkt = types.SimpleNamespace(
+            publish_packet=types.SimpleNamespace(
+                topic="t/appliancestatus", payload=json.dumps([1, 2, 3]).encode()
+            )
+        )
+        m._on_publish_received(pkt)  # must not raise
+        self.assertEqual(hon.notified, 0)
+
+
+class StartReconnectTest(unittest.TestCase):
+    """Covers the watchdog leak fix: a second _start() (reconnect) must stop the
+    previous awscrt client before building a new one, instead of leaking it."""
+
+    def test_start_stops_previous_client_before_rebuild(self) -> None:
+        import awscrt
+        import awsiot
+
+        built: list = []
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.started = False
+                self.stopped = False
+
+            def start(self) -> None:
+                self.started = True
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        def fake_builder(**kwargs):
+            client = FakeClient()
+            built.append(client)
+            return client
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = fake_builder
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+
+        async def body():
+            m = NativeMqttClient(hon, "MID")
+            await m._start()  # first client
+            await m._start()  # reconnect: must stop the first
+            return m
+
+        m = _run(body())
+        self.assertEqual(len(built), 2)
+        self.assertTrue(built[0].stopped)  # previous client stopped
+        self.assertFalse(built[1].stopped)  # current client still alive
+        self.assertIs(m._client, built[1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -652,6 +652,23 @@ class WatchdogResilienceTest(unittest.TestCase):
         self.assertIn(base * 3, intervals)   # grew again
         self.assertEqual(intervals[-1], base)  # reset after the recovery tick
 
+    def test_watchdog_backoff_resets_after_successful_rebuild(self) -> None:
+        # The backoff must reset when a rebuild SUCCEEDS (distinct from the
+        # connection-up branch): _start may return OK while self._connection is
+        # still False (the awscrt connection-success callback fires later).
+        from custom_components.addhon.client.transport.mqtt import _WATCHDOG_INTERVAL
+        calls = {"n": 0}
+
+        async def flaky_start():
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise RuntimeError("transient")
+
+        intervals = self._drive([False] * 14, flaky_start)  # connection never comes up
+        base = _WATCHDOG_INTERVAL
+        self.assertIn(base * 3, intervals)     # backoff grew during the failures
+        self.assertEqual(intervals[-1], base)  # ...and reset after the successful rebuild
+
     def test_watchdog_backoff_caps(self) -> None:
         from custom_components.addhon.client.transport.mqtt import (
             _WATCHDOG_INTERVAL,

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -447,6 +447,28 @@ class PublishReceivedTest(unittest.TestCase):
         with self.assertNoLogs(self._LOGGER_NAME, level="WARNING"):
             m._on_publish_received(_packet(topic, {"parameters": [None, "x"]}))
 
+    def test_non_dict_parameter_does_not_leak_mac_value(self) -> None:
+        # CR#4: a bare MAC-shaped element must NOT reach the log. The skip line logs
+        # only the element TYPE, and the INFO summary masks the MAC leaf inside the
+        # parameters list via redact_identity (key-based redaction can't reach a bare
+        # list scalar, so redact_identity now masks MAC-shaped string leaves too).
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m, hon = self._client(app)
+        mac = "AA:BB:CC:DD:EE:FF"
+        with self.assertLogs(self._LOGGER_NAME, level="DEBUG") as cm:
+            m._on_publish_received(_packet(topic, {"parameters": [
+                mac,
+                {"parName": "temp", "parValue": "5"},
+            ]}))
+        blob = "\n".join(cm.output)
+        self.assertNotIn(mac, blob)      # raw MAC never logged (skip line + INFO summary)
+        self.assertIn("type=str", blob)  # skip line logs the element TYPE, not the value
+        # behaviour unchanged: the valid param in the same batch is still applied
+        self.assertEqual(app.attributes["parameters"]["temp"].updated,
+                         {"parName": "temp", "parValue": "5"})
+        self.assertEqual(hon.notified, 1)
+
     def test_appliance_topics_null_does_not_block_others(self) -> None:
         # An appliance whose info["topics"] is null must not break the topic lookup
         # for the OTHER appliances.

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -1467,6 +1467,44 @@ class SubscribedFlagLifecycleTest(unittest.TestCase):
         _run(m._start())
         self.assertFalse(m._subscribed)  # fresh client -> no subscriptions
 
+    def test_start_resets_connection(self) -> None:
+        # CR#1: _start() must also reset _connection (symmetric with _subscribed): the
+        # new client is not up until ITS connection-success callback fires. An escalation
+        # rebuild (connected-but-unsubscribed) reaches _start() with _connection=True
+        # carried over from the just-stopped client; leaving it True would make a rebuild
+        # whose subscribe then fails look connected-but-unsubscribed on a client not
+        # actually up yet, sending the next watchdog tick down the in-place re-subscribe
+        # path against a dead client instead of rebuilding.
+        import awsiot
+
+        class FakeClient:
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = (
+            lambda **kw: FakeClient()
+        )
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        m = NativeMqttClient(hon, "MID")
+        m._connection = True  # pretend the just-stopped client was connected
+
+        _run(m._start())
+        self.assertFalse(m._connection)  # fresh client -> not up until its success cb
+
     def test_create_sets_subscribed_true_on_success(self) -> None:
         m = NativeMqttClient(FakeHon([]), "MID")
 

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -417,6 +417,46 @@ class StaleLifecycleCallbackTest(unittest.TestCase):
         self.assertFalse(m._connection)
 
 
+class PublishReceivedRobustnessTest(unittest.TestCase):
+    """ITEM B: a VALID dict payload that makes the engine raise (param.update,
+    sync_params_to_command, or notify) must NOT propagate out of _on_publish_received
+    (it runs on the awscrt callback thread, where a raise would silence every later
+    push), and the failure must be logged at WARNING so it stays diagnosable."""
+
+    _LOGGER_NAME = "custom_components.addhon.client.transport.mqtt"
+
+    def test_raising_param_update_is_swallowed_and_warned(self) -> None:
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+
+        def boom(_value) -> None:
+            raise RuntimeError("engine update failed")
+
+        app.attributes["parameters"]["temp"].update = boom
+        hon = FakeHon([app])
+        m = NativeMqttClient(hon, "MID")
+        with self.assertLogs(self._LOGGER_NAME, level="WARNING") as cm:
+            m._on_publish_received(_packet(topic, {"parameters": [
+                {"parName": "temp", "parValue": "5"},
+            ]}))  # must NOT raise
+        self.assertEqual(hon.notified, 0)  # raised before notify()
+        self.assertTrue(any("handler failed" in r.getMessage() for r in cm.records))
+
+    def test_raising_notify_is_swallowed_and_warned(self) -> None:
+        topic = "haier/things/MAC/event/connected"
+        app = FakeAppliance(topic)
+        hon = FakeHon([app])
+
+        def boom() -> None:
+            raise RuntimeError("notify failed")
+
+        hon.notify = boom
+        m = NativeMqttClient(hon, "MID")
+        with self.assertLogs(self._LOGGER_NAME, level="WARNING") as cm:
+            m._on_publish_received(_packet(topic, {}))  # must NOT raise
+        self.assertTrue(any("handler failed" in r.getMessage() for r in cm.records))
+
+
 class StartGenerationWiringTest(unittest.TestCase):
     """Covers the _start <-> guard wiring: _start must bind the state-mutating lifecycle
     callbacks to the CURRENT generation via functools.partial, so awscrt (which calls

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -518,6 +518,94 @@ class PublishReceivedTest(unittest.TestCase):
         self.assertEqual(hon.notified, 0)
 
 
+class PublishReceivedRedactionTest(unittest.TestCase):
+    """#32/#35: the MQTT handler must not log raw device identity (payload echoing
+    macAddress/serial, nick_name) even when the MQTT logger is raised to INFO/DEBUG
+    for troubleshooting."""
+
+    _LOGGER_NAME = "custom_components.addhon.client.transport.mqtt"
+
+    def _client(self, appliance):
+        return NativeMqttClient(FakeHon([appliance]), "MID")
+
+    def test_appliancestatus_payload_redacted_at_info(self) -> None:
+        # #32: the generic INFO line logs the whole payload; a macAddress echoed in it
+        # must be masked.
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m = self._client(app)
+        mac = "AA:BB:CC:DD:EE:FF"
+        with self.assertLogs(self._LOGGER_NAME, level="INFO") as cm:
+            m._on_publish_received(
+                _packet(
+                    topic,
+                    {
+                        "macAddress": mac,
+                        "parameters": [{"parName": "temp", "parValue": "5"}],
+                    },
+                )
+            )
+        blob = "\n".join(cm.output)
+        self.assertNotIn(mac, blob)
+        self.assertIn("***", blob)
+
+    def test_disconnected_nick_name_redacted_at_info(self) -> None:
+        # #35: lifecycle logs nick_name at INFO -> must be masked.
+        topic = "haier/things/MAC/event/disconnected"
+        app = FakeAppliance(topic)
+        app.nick_name = "MySecretNick"
+        m = self._client(app)
+        with self.assertLogs(self._LOGGER_NAME, level="INFO") as cm:
+            m._on_publish_received(_packet(topic, {"disconnectReason": "x"}))
+        blob = "\n".join(cm.output)
+        self.assertNotIn("MySecretNick", blob)
+        self.assertIn("Disconnected ***", blob)
+
+    def test_connected_nick_name_redacted_at_info(self) -> None:
+        topic = "haier/things/MAC/event/connected"
+        app = FakeAppliance(topic)
+        app.nick_name = "MySecretNick"
+        m = self._client(app)
+        with self.assertLogs(self._LOGGER_NAME, level="INFO") as cm:
+            m._on_publish_received(_packet(topic, {}))
+        blob = "\n".join(cm.output)
+        self.assertNotIn("MySecretNick", blob)
+        self.assertIn("Connected ***", blob)
+
+    def test_topic_mac_redacted_at_info(self) -> None:
+        # #32 (refuter gap): the Haier topic embeds the device MAC
+        # (haier/things/<MAC>/...) and is logged at INFO right next to the payload.
+        mac = "3c-71-bf-bd-32-2c"
+        topic = f"haier/things/{mac}/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m = self._client(app)
+        with self.assertLogs(self._LOGGER_NAME, level="INFO") as cm:
+            m._on_publish_received(
+                _packet(topic, {"parameters": [{"parName": "temp", "parValue": "5"}]})
+            )
+        blob = "\n".join(cm.output)
+        self.assertNotIn(mac, blob)
+        self.assertIn("haier/things/***/event/appliancestatus/update", blob)
+
+    def test_non_object_payload_logs_type_only(self) -> None:
+        # #35 (refuter gap): a bare scalar JSON payload (e.g. a string that is a MAC)
+        # must NOT be echoed; only its type is logged, and the topic MAC is masked.
+        mac = "AA:BB:CC:DD:EE:FF"
+        topic = f"haier/things/{mac}/event/appliancestatus"
+        app = FakeAppliance(topic)
+        m = self._client(app)
+        pkt = types.SimpleNamespace(
+            publish_packet=types.SimpleNamespace(
+                topic=topic, payload=json.dumps(mac).encode()  # bare JSON string
+            )
+        )
+        with self.assertLogs(self._LOGGER_NAME, level="DEBUG") as cm:
+            m._on_publish_received(pkt)
+        blob = "\n".join(cm.output)
+        self.assertNotIn(mac, blob)
+        self.assertIn("type=str", blob)
+
+
 class StartReconnectTest(unittest.TestCase):
     """Covers the watchdog leak fix: a second _start() (reconnect) must stop the
     previous awscrt client before building a new one, instead of leaking it."""

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -681,10 +681,18 @@ class WatchdogThresholdTest(unittest.TestCase):
         async def fake_sleep(_interval):
             if not seq:
                 raise asyncio.CancelledError
-            m._connection = seq.pop(0)
+            # A scripted state is "healthy" (connected + subscribed) or fully "down":
+            # the watchdog now requires BOTH flags to consider a tick healthy, so set
+            # them together to keep this test about the failed-tick/rebuild threshold.
+            state = seq.pop(0)
+            m._connection = state
+            m._subscribed = state
+
+        async def noop_sub():
+            return None
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = lambda: None  # type: ignore[assignment]
+        m._subscribe_appliances = noop_sub  # type: ignore[assignment]
         real_sleep = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -853,7 +861,12 @@ class WatchdogResilienceTest(unittest.TestCase):
             intervals.append(interval)
             if not seq:
                 raise asyncio.CancelledError
-            m._connection = seq.pop(0)
+            # Healthy = connected AND subscribed (the watchdog now requires both); a
+            # scripted state drives the pair together so this test stays focused on the
+            # rebuild backoff, not the re-subscribe recovery path.
+            state = seq.pop(0)
+            m._connection = state
+            m._subscribed = state
 
         async def noop_sub():
             return None
@@ -1024,6 +1037,462 @@ class SubscribeNonBlockingTest(unittest.TestCase):
             self.assertIsInstance(ctx.exception.__cause__, asyncio.TimeoutError)
         finally:
             mod._SUBSCRIBE_TIMEOUT = orig
+
+
+class WatchdogSubscribedRecoveryTest(unittest.TestCase):
+    """Greptile P1: a single `self._connection` flag conflated 'transport connected'
+    with 'appliance topics subscribed'. The connection-success callback sets
+    _connection=True WITHOUT subscribing, so a rebuild whose _subscribe_appliances()
+    times out (or awscrt's own auto-reconnect on a clean session) left the client
+    connected-but-unsubscribed; the watchdog's `if self._connection:` check then treated
+    it as healthy and never recovered -> realtime pushes silently dead. The fix adds a
+    separate self._subscribed flag and a re-subscribe recovery branch. These tests fail
+    against the pre-fix one-flag watchdog and pass with the fix."""
+
+    def _drive(self, scripts, sub_fn=None):
+        """Drive the REAL _watchdog over a scripted sequence. Each script entry is a
+        (connection, subscribed) pair applied to the instance at the START of a tick
+        (i.e. it is the state the awscrt callbacks would have produced before this
+        tick's health check). asyncio.sleep is stubbed to advance the script and end
+        the loop (CancelledError) when it runs out. Returns (resub_calls, rebuilds,
+        m), where `rebuilds` holds the 1-based tick index of each full _start()
+        rebuild (so a test can pin WHEN the rebuild fired, not just that it did)."""
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        seq = list(scripts)
+        rebuilds = []
+        resub_calls = []
+        tick = {"n": 0}
+
+        async def fake_start():
+            rebuilds.append(tick["n"])
+            # The real _start() clears _subscribed (fresh client). Mirror that so a
+            # rebuild that does not re-subscribe is correctly seen as unsubscribed.
+            m._subscribed = False
+
+        async def counted_sub():
+            resub_calls.append(True)
+            if sub_fn is not None:
+                await sub_fn()
+
+        async def fake_sleep(_interval):
+            if not seq:
+                raise asyncio.CancelledError
+            tick["n"] += 1
+            conn, sub = seq.pop(0)
+            m._connection = conn
+            m._subscribed = sub
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+        return resub_calls, rebuilds, m
+
+    def test_connected_but_unsubscribed_triggers_resubscribe_not_healthy(self) -> None:
+        # Connected but NOT subscribed for two ticks (the subscribe-timeout aftermath):
+        # the watchdog must re-subscribe each tick (recovery), NOT treat it as healthy.
+        # Pre-fix: `if self._connection:` -> healthy -> 0 re-subscribes (the bug).
+        resub, rebuilds, m = self._drive([(True, False), (True, False)])
+        self.assertEqual(len(resub), 2)        # re-subscribed on each tick
+        self.assertEqual(len(rebuilds), 0)     # no full rebuild: transport is up
+        self.assertTrue(m._subscribed)         # recovered to healthy
+
+    def test_resubscribe_failure_retries_next_tick_no_stuck_healthy(self) -> None:
+        # If the in-place re-subscribe RAISES (e.g. MQTT_SUBSCRIBE_TIMEOUT), the
+        # watchdog must NOT mark _subscribed True (no stuck "healthy") and must retry on
+        # the next tick. Pre-fix this scenario could never arise (it was always healthy).
+        from custom_components.addhon.error_codes import (
+            HonCodedError,
+            MQTT_SUBSCRIBE_TIMEOUT,
+        )
+
+        attempts = []
+
+        async def flaky_sub():
+            attempts.append(True)
+            if len(attempts) == 1:
+                raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, "stall")
+
+        # Tick 1: connected/unsubscribed -> re-subscribe raises -> backoff, stays
+        # unsubscribed. Tick 2: still connected/unsubscribed -> re-subscribe succeeds.
+        resub, rebuilds, m = self._drive(
+            [(True, False), (True, False)], sub_fn=flaky_sub
+        )
+        self.assertEqual(len(resub), 2)     # retried after the first failure
+        self.assertEqual(len(rebuilds), 0)  # never escalated to a full rebuild
+        self.assertTrue(m._subscribed)      # recovered on the 2nd attempt
+
+    def test_healthy_when_connected_and_subscribed(self) -> None:
+        # Both flags set -> healthy -> neither re-subscribe nor rebuild.
+        resub, rebuilds, _ = self._drive([(True, True), (True, True)])
+        self.assertEqual(len(resub), 0)
+        self.assertEqual(len(rebuilds), 0)
+
+    def test_not_connected_rebuilds_not_resubscribes(self) -> None:
+        # Sustained not-connected -> the rebuild path (NOT the in-place re-subscribe),
+        # preserving the _RECONNECT_AFTER_FAILED_TICKS threshold semantics.
+        from custom_components.addhon.client.transport.mqtt import (
+            _RECONNECT_AFTER_FAILED_TICKS,
+        )
+
+        resub, rebuilds, _ = self._drive(
+            [(False, False)] * _RECONNECT_AFTER_FAILED_TICKS
+        )
+        self.assertEqual(len(rebuilds), 1)   # one full rebuild after the threshold
+        # The rebuild path re-subscribes once as part of the rebuild.
+        self.assertEqual(len(resub), 1)
+
+    def test_perpetual_resubscribe_failure_escalates_to_rebuild(self) -> None:
+        # Issue 1: connected but _subscribe_appliances() ALWAYS raises (half-open socket
+        # / stale custom-authorizer session that awscrt still reports connected and that
+        # never fires a disconnection callback). The in-place re-subscribe branch must
+        # NOT loop forever: after _MAX_RESUBSCRIBE_FAILURES it must escalate to a full
+        # _start() rebuild (which is what refreshes the AWS token + tears down the dead
+        # client).
+        #
+        # This test PINS THE TICK the rebuild fires on -- that is what actually exercises
+        # the escalation branch. Two weaker designs would be vacuous: without the cap
+        # gate the in-place re-subscribe loops forever and never rebuilds; with the gate
+        # but without the prompt escalation-skip, the rebuild is merely DELAYED to the
+        # slower failed_ticks fallback (tick _MAX_RESUBSCRIBE_FAILURES +
+        # _RECONNECT_AFTER_FAILED_TICKS). Asserting `len(rebuilds) > 0` alone passes
+        # against BOTH (the fallback still rebuilds inside a generous budget), so we
+        # assert the FIRST rebuild lands on the very next tick after the cap is hit
+        # (tick _MAX_RESUBSCRIBE_FAILURES + 1) -- only the escalation produces that.
+        from custom_components.addhon.client.transport.mqtt import (
+            _MAX_RESUBSCRIBE_FAILURES,
+        )
+        from custom_components.addhon.error_codes import (
+            HonCodedError,
+            MQTT_SUBSCRIBE_TIMEOUT,
+        )
+
+        async def always_fail():
+            raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, "stall")
+
+        # Stay connected-but-unsubscribed for more than enough ticks to exceed the
+        # threshold AND to give a (mutated) failed_ticks fallback room to fire later.
+        ticks = _MAX_RESUBSCRIBE_FAILURES + 3
+        resub, rebuilds, _ = self._drive(
+            [(True, False)] * ticks, sub_fn=always_fail
+        )
+        # It only escalated AFTER exhausting the in-place re-subscribe attempts.
+        self.assertGreaterEqual(len(resub), _MAX_RESUBSCRIBE_FAILURES)
+        # Escalation fired (with escalation disabled, or the cap gate removed, this is 0).
+        self.assertGreaterEqual(len(rebuilds), 1)
+        # ...and PROMPTLY, on the first tick past the cap -- not via the slower
+        # failed_ticks fallback. (1-based tick index recorded by _drive.)
+        self.assertEqual(rebuilds[0], _MAX_RESUBSCRIBE_FAILURES + 1)
+
+    def test_resubscribe_failure_counter_resets_on_success(self) -> None:
+        # Issue 1 corollary: the escalation counter must reset on EVERY successful
+        # subscribe, so an INTERMITTENT (not perpetual) re-subscribe failure never
+        # accumulates to a needless rebuild. Drive an alternating fail/succeed pattern
+        # whose TOTAL failures exceed _MAX_RESUBSCRIBE_FAILURES but where each failure is
+        # followed by a success (which must reset the counter to 0). With the reset: 0
+        # rebuilds. WITHOUT the reset: the failures accumulate past the threshold and the
+        # watchdog wrongly escalates to a full rebuild.
+        from custom_components.addhon.client.transport.mqtt import (
+            _MAX_RESUBSCRIBE_FAILURES,
+        )
+        from custom_components.addhon.error_codes import (
+            HonCodedError,
+            MQTT_SUBSCRIBE_TIMEOUT,
+        )
+
+        attempts = {"n": 0}
+
+        async def alternating():
+            attempts["n"] += 1
+            # Odd attempts fail, even attempts succeed: a fail is always followed by a
+            # success that re-subscribes (and must reset the failure counter).
+            if attempts["n"] % 2 == 1:
+                raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, "stall")
+
+        # Enough fail/succeed pairs that the cumulative odd-attempt failures comfortably
+        # exceed _MAX_RESUBSCRIBE_FAILURES (without the reset, escalation would fire).
+        pairs = _MAX_RESUBSCRIBE_FAILURES + 2
+        script = [(True, False)] * (pairs * 2)
+        resub, rebuilds, _ = self._drive(script, sub_fn=alternating)
+        self.assertEqual(len(rebuilds), 0)  # reset prevents intermittent escalation
+
+    def test_failed_ticks_symmetry_resubscribe_recovery_resets_outage(self) -> None:
+        # Issue 2: a successful in-place re-subscribe must reset failed_ticks, exactly
+        # like the healthy branch. A flapping connection
+        #   [down, up-but-unsubscribed->resubscribe-OK, down, down]
+        # must NOT force a full rebuild, because the recovered tick resets the outage
+        # counter (only _RECONNECT_AFTER_FAILED_TICKS *consecutive* down ticks rebuild).
+        resub, rebuilds, _ = self._drive(
+            [(False, False), (True, False), (False, False), (False, False)]
+        )
+        self.assertEqual(len(rebuilds), 0)  # recovered tick reset the outage counter
+        self.assertEqual(len(resub), 1)     # the up-but-unsubscribed tick re-subscribed
+
+    def test_failed_ticks_symmetry_contrast_full_outage_rebuilds(self) -> None:
+        # Contrast to the symmetry test: an UNINTERRUPTED not-connected run of the same
+        # length (no recovery tick to reset failed_ticks) DOES rebuild at the threshold.
+        from custom_components.addhon.client.transport.mqtt import (
+            _RECONNECT_AFTER_FAILED_TICKS,
+        )
+
+        resub, rebuilds, _ = self._drive(
+            [(False, False)] * (_RECONNECT_AFTER_FAILED_TICKS + 1)
+        )
+        self.assertGreaterEqual(len(rebuilds), 1)  # no reset -> threshold reached
+
+    def test_lost_update_disconnect_mid_resubscribe_not_marked_healthy(self) -> None:
+        # Issue 3 at the re-subscribe site: a disconnection callback lands DURING the
+        # in-place re-subscribe await (flips _connection=False on the awscrt thread).
+        # The post-await assignment must re-check connection (and generation) instead of
+        # an unconditional True, so _subscribed ends up False (not clobbered) and the
+        # next tick is NOT treated as healthy.
+        def make_dropper(m):
+            async def dropping_sub():
+                # Simulate the awscrt disconnection callback landing mid-subscribe.
+                m._connection = False
+            return dropping_sub
+
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        # One tick: connected/unsubscribed -> re-subscribe runs, but the connection drops
+        # during the await. Then a second scripted tick is NOT applied (loop ends), so we
+        # observe the state the re-subscribe left.
+        seq = [(True, False)]
+        rebuilds = []
+        resub_calls = []
+
+        async def fake_start():
+            rebuilds.append(True)
+            m._subscribed = False
+
+        dropping = make_dropper(m)
+
+        async def counted_sub():
+            resub_calls.append(True)
+            await dropping()
+
+        async def fake_sleep(_interval):
+            if not seq:
+                raise asyncio.CancelledError
+            conn, sub = seq.pop(0)
+            m._connection = conn
+            m._subscribed = sub
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+
+        self.assertEqual(len(resub_calls), 1)   # re-subscribe attempted
+        self.assertFalse(m._subscribed)         # NOT clobbered back to True
+        self.assertFalse(m._connection)         # the disconnect stuck
+        self.assertEqual(len(rebuilds), 0)      # one tick only: no rebuild yet
+
+    def test_lost_update_disconnect_mid_rebuild_subscribe_not_marked_healthy(self) -> None:
+        # Issue 3 at the REBUILD site: after a full _start() (which models the awscrt
+        # connection-success flipping _connection=True), the rebuild's subscribe is
+        # interrupted by a disconnection callback (flips _connection=False mid-await).
+        # The post-await assignment must re-check connection (and generation), so the
+        # rebuild does NOT leave a stuck "healthy on a dropped session".
+        import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.client.transport.mqtt import (
+            _RECONNECT_AFTER_FAILED_TICKS,
+        )
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        # Sustained not-connected long enough to trip the rebuild threshold; the rebuild's
+        # _start() then brings the transport up, but the subscribe drops it again.
+        seq = [(False, False)] * _RECONNECT_AFTER_FAILED_TICKS
+        rebuilds = []
+        resub_calls = []
+
+        async def fake_start():
+            rebuilds.append(True)
+            m._subscribed = False
+            # _start() built a fresh client; model the awscrt success callback bringing
+            # the transport up before the subscribe runs.
+            m._connection = True
+
+        async def counted_sub():
+            resub_calls.append(True)
+            # The disconnection callback lands on the awscrt thread mid-subscribe.
+            m._connection = False
+
+        async def fake_sleep(_interval):
+            if not seq:
+                raise asyncio.CancelledError
+            conn, sub = seq.pop(0)
+            m._connection = conn
+            m._subscribed = sub
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+
+        self.assertEqual(len(rebuilds), 1)   # the rebuild ran
+        self.assertEqual(len(resub_calls), 1)
+        self.assertFalse(m._subscribed)      # NOT clobbered back to True
+        self.assertFalse(m._connection)      # the mid-subscribe disconnect stuck
+
+
+class SubscribedFlagLifecycleTest(unittest.TestCase):
+    """The companion of WatchdogSubscribedRecoveryTest at the flag level: _subscribed
+    must be reset by the disconnection/failure callbacks (respecting the generation
+    guard) and by _start(), and set only after _subscribe_appliances() succeeds."""
+
+    def test_disconnection_resets_subscribed(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 1
+        m._connection = True
+        m._subscribed = True
+        m._on_lifecycle_disconnection(None, generation=1)
+        self.assertFalse(m._connection)
+        self.assertFalse(m._subscribed)
+
+    def test_connection_failure_resets_subscribed(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 1
+        m._connection = True
+        m._subscribed = True
+        m._on_lifecycle_connection_failure(None, generation=1)
+        self.assertFalse(m._connection)
+        self.assertFalse(m._subscribed)
+
+    def test_connection_success_does_not_set_subscribed(self) -> None:
+        # The success callback only flips _connection: it does NOT subscribe, so
+        # _subscribed must stay False (this is exactly the connected-but-unsubscribed
+        # window the watchdog must recover, incl. awscrt's clean-session auto-reconnect).
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 1
+        m._on_lifecycle_connection_success(None, generation=1)
+        self.assertTrue(m._connection)
+        self.assertFalse(m._subscribed)
+
+    def test_stale_disconnection_does_not_reset_subscribed(self) -> None:
+        # A late event from an OLD generation must not clear _subscribed on the current
+        # healthy client (same guard that protects _connection).
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 2
+        m._connection = True
+        m._subscribed = True
+        m._on_lifecycle_disconnection(None, generation=1)  # stale
+        self.assertTrue(m._connection)
+        self.assertTrue(m._subscribed)
+
+    def test_start_resets_subscribed(self) -> None:
+        import awscrt
+        import awsiot
+
+        class FakeClient:
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = (
+            lambda **kw: FakeClient()
+        )
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        m = NativeMqttClient(hon, "MID")
+        m._subscribed = True  # pretend a previous client was subscribed
+
+        _run(m._start())
+        self.assertFalse(m._subscribed)  # fresh client -> no subscriptions
+
+    def test_create_sets_subscribed_true_on_success(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+
+        async def fake_start():
+            m._client = object()
+            # The real _start() builds the client; the awscrt connection-success
+            # callback then flips _connection=True before subscribe completes. create()'s
+            # lost-update guard (Issue 3) only marks _subscribed when _connection is up,
+            # so model the connected transport here.
+            m._connection = True
+
+        async def ok_sub():
+            return None
+
+        async def ok_watchdog():
+            return None
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = ok_sub  # type: ignore[assignment]
+        m._start_watchdog = ok_watchdog  # type: ignore[assignment]
+        _run(m.create())
+        self.assertTrue(m._subscribed)
+
+    def test_create_does_not_clobber_subscribed_when_disconnect_lands_mid_subscribe(
+        self,
+    ) -> None:
+        # Issue 3 at the create() site: if a disconnection callback lands DURING the
+        # initial subscribe (flips _connection=False), create() must NOT clobber
+        # _subscribed back to True with an unconditional assignment.
+        m = NativeMqttClient(FakeHon([]), "MID")
+
+        async def fake_start():
+            m._client = object()
+            m._connection = True
+
+        async def dropping_sub():
+            # The awscrt thread fires a disconnection mid-subscribe.
+            m._connection = False
+            m._subscribed = False
+
+        async def ok_watchdog():
+            return None
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = dropping_sub  # type: ignore[assignment]
+        m._start_watchdog = ok_watchdog  # type: ignore[assignment]
+        _run(m.create())
+        self.assertFalse(m._subscribed)  # not clobbered back to healthy
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -9,6 +9,7 @@ the awscrt API (`_start`/`_subscribe`) are validated live.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import sys
 import types
@@ -143,11 +144,9 @@ class CreatePathTest(unittest.TestCase):
         import awscrt
         import awsiot
 
-        calls = {}
+        import concurrent.futures
 
-        class FakeSubResult:
-            def result(self, timeout=None):
-                return None
+        calls = {}
 
         class FakeClient:
             def __init__(self) -> None:
@@ -158,9 +157,13 @@ class CreatePathTest(unittest.TestCase):
             def start(self) -> None:
                 self.started = True
 
-            def subscribe(self, packet) -> "FakeSubResult":
+            def subscribe(self, packet):
+                # awscrt subscribe() returns a concurrent.futures.Future; the code now
+                # awaits it via asyncio.wrap_future, so a resolved Future is required.
                 self.subscribed.append(packet)
-                return FakeSubResult()
+                fut: concurrent.futures.Future = concurrent.futures.Future()
+                fut.set_result(None)
+                return fut
 
             def stop(self) -> None:
                 self.stopped = True
@@ -565,6 +568,169 @@ class StartGenerationWiringTest(unittest.TestCase):
         # The current client's disconnection still takes effect.
         gen2["on_lifecycle_disconnection"](None)
         self.assertFalse(m._connection)
+
+
+class WatchdogResilienceTest(unittest.TestCase):
+    """#3: the watchdog must survive a transient rebuild error (instead of dying and
+    leaving realtime dead until a reload), re-raise CancelledError (else shutdown
+    deadlocks), and back off (capped, reset on recovery) on repeated failures."""
+
+    def _drive(self, states, start_fn):
+        import custom_components.addhon.client.transport.mqtt as mod
+        m = NativeMqttClient(FakeHon([]), "MID")
+        intervals: list = []
+        seq = list(states)
+
+        async def fake_sleep(interval):
+            intervals.append(interval)
+            if not seq:
+                raise asyncio.CancelledError
+            m._connection = seq.pop(0)
+
+        async def noop_sub():
+            return None
+
+        m._start = start_fn  # type: ignore[assignment]
+        m._subscribe_appliances = noop_sub  # type: ignore[assignment]
+        real = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real
+        return intervals
+
+    def test_watchdog_survives_start_raising(self) -> None:
+        starts: list = []
+
+        async def boom():
+            starts.append(True)
+            raise RuntimeError("load_aws_token 5xx")
+
+        self._drive([False] * 7, boom)  # two rebuild windows
+        # Pre-fix the first raise would end the task -> starts == 1. Surviving -> >= 2.
+        self.assertGreaterEqual(len(starts), 2)
+
+    def test_watchdog_cancelled_propagates(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+        m = NativeMqttClient(FakeHon([]), "MID")
+
+        async def fake_sleep(_i):
+            raise asyncio.CancelledError
+
+        async def noop_start():
+            return None
+
+        m._start = noop_start  # type: ignore[assignment]
+        real = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                with self.assertRaises(asyncio.CancelledError):
+                    loop.run_until_complete(m._watchdog())
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real
+
+    def test_watchdog_backoff_grows_and_resets(self) -> None:
+        from custom_components.addhon.client.transport.mqtt import _WATCHDOG_INTERVAL
+
+        async def boom():
+            raise RuntimeError("x")
+
+        intervals = self._drive([False] * 9 + [True], boom)
+        base = _WATCHDOG_INTERVAL
+        self.assertIn(base * 2, intervals)   # grew after the 1st rebuild failure
+        self.assertIn(base * 3, intervals)   # grew again
+        self.assertEqual(intervals[-1], base)  # reset after the recovery tick
+
+    def test_watchdog_backoff_caps(self) -> None:
+        from custom_components.addhon.client.transport.mqtt import (
+            _WATCHDOG_INTERVAL,
+            _RECONNECT_BACKOFF_CAP,
+        )
+
+        async def boom():
+            raise RuntimeError("x")
+
+        intervals = self._drive([False] * 60, boom)
+        self.assertLessEqual(max(intervals), _WATCHDOG_INTERVAL + _RECONNECT_BACKOFF_CAP)
+
+
+class SubscribeNonBlockingTest(unittest.TestCase):
+    """#13: _subscribe must await the awscrt future (yield the loop) instead of a
+    blocking .result(), preserving topic order and the timeout bound."""
+
+    def _client(self, topics):
+        import awscrt
+        awscrt.mqtt5.SubscribePacket = lambda subs: ("pkt", subs)
+        awscrt.mqtt5.Subscription = lambda topic: topic
+        m = NativeMqttClient(FakeHon([]), "MID")
+        app = FakeAppliance("t")
+        app.info = {"topics": {"subscribe": topics}}
+        return m, app
+
+    def test_subscribe_order_preserved(self) -> None:
+        order: list = []
+
+        class C:
+            def subscribe(self, packet):
+                order.append(packet[1])  # ("pkt", [topic])
+                fut: concurrent.futures.Future = concurrent.futures.Future()
+                fut.set_result(None)
+                return fut
+
+        m, app = self._client(["t1", "t2", "t3"])
+        m._client = C()
+        _run(m._subscribe(app))
+        self.assertEqual(order, [["t1"], ["t2"], ["t3"]])
+
+    def test_subscribe_yields_loop(self) -> None:
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+
+        class C:
+            def subscribe(self, packet):
+                return fut  # not resolved yet
+
+        m, app = self._client(["t1"])
+        m._client = C()
+        progressed: list = []
+
+        async def resolver():
+            progressed.append(True)
+            fut.set_result(None)
+
+        async def body():
+            await asyncio.gather(m._subscribe(app), resolver())
+
+        _run(body())
+        # If _subscribe blocked (old .result()), resolver could not run first.
+        self.assertEqual(progressed, [True])
+
+    def test_subscribe_timeout_bound(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        class C:
+            def subscribe(self, packet):
+                return concurrent.futures.Future()  # never resolves
+
+        m, app = self._client(["t1"])
+        m._client = C()
+        orig = mod._SUBSCRIBE_TIMEOUT
+        mod._SUBSCRIBE_TIMEOUT = 0.01
+        try:
+            with self.assertRaises(asyncio.TimeoutError):
+                _run(m._subscribe(app))
+        finally:
+            mod._SUBSCRIBE_TIMEOUT = orig
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -230,6 +230,54 @@ class PublishReceivedTest(unittest.TestCase):
         self.assertEqual(app.synced, ["settings"])
         self.assertEqual(hon.notified, 1)
 
+    _LOGGER_NAME = "custom_components.addhon.client.transport.mqtt"
+
+    def test_non_dict_parameter_skipped_valid_applied(self) -> None:
+        # A null/garbage element must be skipped; the valid params in the SAME batch
+        # are still applied and notify still fires (no whole-message drop).
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m, hon = self._client(app)
+        m._on_publish_received(_packet(topic, {"parameters": [
+            None,
+            {"parName": "temp", "parValue": "5"},
+            "garbage",
+        ]}))
+        self.assertEqual(app.attributes["parameters"]["temp"].updated,
+                         {"parName": "temp", "parValue": "5"})
+        self.assertEqual(app.synced, ["settings"])
+        self.assertEqual(hon.notified, 1)
+
+    def test_parameters_not_a_list_does_not_drop(self) -> None:
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m, hon = self._client(app)
+        m._on_publish_received(_packet(topic, {"parameters": None}))
+        m._on_publish_received(_packet(topic, {"parameters": {"x": 1}}))
+        self.assertEqual(hon.notified, 2)  # both still processed + notified
+
+    def test_non_dict_parameter_no_warning(self) -> None:
+        # Dirty cloud data is DEBUG, not WARNING (WARNING is reserved for real bugs).
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m, _ = self._client(app)
+        with self.assertNoLogs(self._LOGGER_NAME, level="WARNING"):
+            m._on_publish_received(_packet(topic, {"parameters": [None, "x"]}))
+
+    def test_appliance_topics_null_does_not_block_others(self) -> None:
+        # An appliance whose info["topics"] is null must not break the topic lookup
+        # for the OTHER appliances.
+        good = FakeAppliance("haier/X/appliancestatus")
+        bad = FakeAppliance("haier/Y/appliancestatus")
+        bad.info = {"topics": None}
+        hon = FakeHon([bad, good])
+        m = NativeMqttClient(hon, "MID")
+        m._on_publish_received(_packet("haier/X/appliancestatus",
+                                       {"parameters": [{"parName": "temp", "parValue": "9"}]}))
+        self.assertEqual(good.attributes["parameters"]["temp"].updated,
+                         {"parName": "temp", "parValue": "9"})
+        self.assertEqual(hon.notified, 1)
+
     def test_disconnected_sets_connection_false(self) -> None:
         topic = "haier/things/MAC/event/disconnected"
         app = FakeAppliance(topic)

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -340,5 +340,144 @@ class StartReconnectTest(unittest.TestCase):
         self.assertIs(m._client, built[1])
 
 
+class WatchdogThresholdTest(unittest.TestCase):
+    """Covers the watchdog's sustained-downtime threshold: it must force a rebuild ONLY
+    after _RECONNECT_AFTER_FAILED_TICKS consecutive down ticks, and reset the counter as
+    soon as the connection comes back (an off-by-one or a missing reset would otherwise
+    slip past the leak-fix tests, which only check _start in isolation)."""
+
+    def _rebuilds_for(self, states):
+        # Drive _watchdog over a scripted sequence of self._connection values (one per
+        # tick) and count how many times it forces a rebuild (_start). asyncio.sleep is
+        # stubbed to advance the script and to end the loop when the script runs out.
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        starts = []
+        seq = list(states)
+
+        async def fake_start():
+            starts.append(True)
+
+        async def fake_sleep(_interval):
+            if not seq:
+                raise asyncio.CancelledError
+            m._connection = seq.pop(0)
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = lambda: None  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+        return len(starts)
+
+    def test_no_rebuild_before_threshold(self) -> None:
+        # Two consecutive down ticks (< _RECONNECT_AFTER_FAILED_TICKS=3) -> no rebuild.
+        self.assertEqual(self._rebuilds_for([False, False]), 0)
+
+    def test_rebuild_after_sustained_downtime(self) -> None:
+        # Exactly _RECONNECT_AFTER_FAILED_TICKS down ticks -> a single rebuild.
+        self.assertEqual(self._rebuilds_for([False, False, False]), 1)
+
+    def test_reconnect_resets_failed_ticks(self) -> None:
+        # A healthy tick before the threshold resets the counter, so two down ticks on
+        # either side of it never reach three-in-a-row -> no rebuild.
+        self.assertEqual(self._rebuilds_for([False, False, True, False, False]), 0)
+
+
+class StaleLifecycleCallbackTest(unittest.TestCase):
+    """Covers the generation guard: after a rebuild, a late lifecycle event from the
+    previous (stopped) client must NOT flip self._connection on the new one (awscrt
+    stop() is async, so the old client can emit a disconnection after the new one
+    connected)."""
+
+    def test_stale_callback_does_not_flip_connection(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+        # Pretend we are on the 2nd client generation.
+        m._generation = 2
+        # The current generation's success marks the connection up.
+        m._on_lifecycle_connection_success(None, generation=2)
+        self.assertTrue(m._connection)
+        # A late disconnection/failure from the OLD generation (1) is ignored.
+        m._on_lifecycle_disconnection(None, generation=1)
+        self.assertTrue(m._connection)
+        m._on_lifecycle_connection_failure(None, generation=1)
+        self.assertTrue(m._connection)
+        # The current generation's disconnection still takes effect.
+        m._on_lifecycle_disconnection(None, generation=2)
+        self.assertFalse(m._connection)
+
+
+class StartGenerationWiringTest(unittest.TestCase):
+    """Covers the _start <-> guard wiring: _start must bind the state-mutating lifecycle
+    callbacks to the CURRENT generation via functools.partial, so awscrt (which calls
+    them with a single positional `data`) supplies the right generation and a callback
+    captured from a previous client is ignored after a rebuild. Without this test a
+    regression on the partial wiring (or the functools import) would pass every other
+    test (the guard logic test sets the generation by hand, not through _start)."""
+
+    def _make_client(self):
+        import awsiot
+
+        builds: list = []
+
+        class FakeClient:
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        def fake_builder(**kwargs):
+            builds.append(kwargs)
+            return FakeClient()
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = fake_builder
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        return NativeMqttClient(hon, "MID"), builds
+
+    def test_start_binds_callbacks_to_current_generation(self) -> None:
+        m, builds = self._make_client()
+
+        async def body():
+            await m._start()  # generation 1
+            await m._start()  # rebuild -> generation 2 (stops the first)
+
+        _run(body())
+        self.assertEqual(len(builds), 2)
+        gen1, gen2 = builds[0], builds[1]
+        # awscrt invokes the registered callback with a SINGLE positional `data`; the
+        # partial must supply the generation it was bound to (a bare method would raise
+        # TypeError here for the missing generation arg).
+        gen2["on_lifecycle_connection_success"](None)  # current generation -> up
+        self.assertTrue(m._connection)
+        # A late disconnection from the FIRST client (old generation) must be ignored.
+        gen1["on_lifecycle_disconnection"](None)
+        self.assertTrue(m._connection)
+        # The current client's disconnection still takes effect.
+        gen2["on_lifecycle_disconnection"](None)
+        self.assertFalse(m._connection)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -1002,6 +1002,10 @@ class SubscribeNonBlockingTest(unittest.TestCase):
 
     def test_subscribe_timeout_bound(self) -> None:
         import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.error_codes import (
+            MQTT_SUBSCRIBE_TIMEOUT,
+            HonCodedError,
+        )
 
         class C:
             def subscribe(self, packet):
@@ -1012,8 +1016,12 @@ class SubscribeNonBlockingTest(unittest.TestCase):
         orig = mod._SUBSCRIBE_TIMEOUT
         mod._SUBSCRIBE_TIMEOUT = 0.01
         try:
-            with self.assertRaises(asyncio.TimeoutError):
+            # The bound still holds, but the stall is now surfaced as a coded error
+            # (its cause is the underlying asyncio.TimeoutError).
+            with self.assertRaises(HonCodedError) as ctx:
                 _run(m._subscribe(app))
+            self.assertIs(ctx.exception.error_code, MQTT_SUBSCRIBE_TIMEOUT)
+            self.assertIsInstance(ctx.exception.__cause__, asyncio.TimeoutError)
         finally:
             mod._SUBSCRIBE_TIMEOUT = orig
 

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -214,6 +214,186 @@ class CreatePathTest(unittest.TestCase):
         self.assertTrue(fake_client.stopped)
         self.assertIsNone(m._watchdog_task)
 
+    def test_create_stops_client_when_subscribe_fails(self) -> None:
+        # #21: _start() already started the awscrt client; if a later step raises,
+        # create() must stop it before re-raising (otherwise NativeHon never gets a
+        # reference and the client leaks).
+        class StoppableClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        client = StoppableClient()
+
+        async def fake_start():
+            m._client = client  # _start started the awscrt client
+
+        async def boom_subscribe():
+            raise asyncio.TimeoutError("subscribe timeout")
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+
+        with self.assertRaises(asyncio.TimeoutError):
+            _run(m.create())
+        self.assertEqual(client.stops, 1)   # stopped -> no leak
+        self.assertIsNone(m._client)        # stop() cleared the reference
+
+    def test_create_stops_client_when_watchdog_start_fails(self) -> None:
+        # Same guarantee if the failure is in _start_watchdog (after subscribe).
+        class StoppableClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        client = StoppableClient()
+
+        async def fake_start():
+            m._client = client
+
+        async def ok_subscribe():
+            return None
+
+        async def boom_watchdog():
+            raise RuntimeError("watchdog boom")
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = ok_subscribe  # type: ignore[assignment]
+        m._start_watchdog = boom_watchdog  # type: ignore[assignment]
+
+        with self.assertRaises(RuntimeError):
+            _run(m.create())
+        self.assertEqual(client.stops, 1)
+        self.assertIsNone(m._client)
+
+    def test_create_stops_client_on_cancellation(self) -> None:
+        # The cleanup must catch BaseException (not just Exception): a setup cancelled
+        # mid-subscribe (CancelledError) must still stop the started client.
+        class StoppableClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        client = StoppableClient()
+
+        async def fake_start():
+            m._client = client
+
+        async def cancelled_subscribe():
+            raise asyncio.CancelledError
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = cancelled_subscribe  # type: ignore[assignment]
+
+        with self.assertRaises(asyncio.CancelledError):
+            _run(m.create())
+        self.assertEqual(client.stops, 1)  # stopped despite cancellation
+        self.assertIsNone(m._client)
+
+    def test_create_stops_client_on_keyboardinterrupt(self) -> None:
+        # Pins the `except BaseException` (vs a narrower (Exception, CancelledError)):
+        # a non-Exception, non-CancelledError BaseException must still clean up.
+        class StoppableClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        client = StoppableClient()
+
+        async def fake_start():
+            m._client = client
+
+        async def boom_subscribe():
+            raise KeyboardInterrupt
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+
+        with self.assertRaises(KeyboardInterrupt):
+            _run(m.create())
+        self.assertEqual(client.stops, 1)
+        self.assertIsNone(m._client)
+
+    def test_create_stops_client_when_start_method_raises(self) -> None:
+        # Real _start path: the builder returns a client whose start() raises AFTER
+        # _start assigned self._client; create() must stop it (covers the real
+        # self.client.start() line, not just a stubbed _start).
+        import awscrt
+        import awsiot
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def start(self) -> None:
+                raise RuntimeError("native start boom")
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        fake_client = FakeClient()
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = lambda **kw: fake_client
+        awscrt.mqtt5.SubscribePacket = lambda subs: ("pkt", subs)
+        awscrt.mqtt5.Subscription = lambda topic: topic
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        m = NativeMqttClient(hon, "MID")
+        with self.assertRaises(RuntimeError):
+            _run(m.create())
+        self.assertEqual(fake_client.stops, 1)
+        self.assertIsNone(m._client)
+
+    def test_double_stop_after_failed_create(self) -> None:
+        # After create() self-cleaned, an extra stop() (e.g. from a later close())
+        # is idempotent: the client is not stopped twice and stays cleared.
+        class StoppableClient:
+            def __init__(self) -> None:
+                self.stops = 0
+
+            def stop(self) -> None:
+                self.stops += 1
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        client = StoppableClient()
+
+        async def fake_start():
+            m._client = client
+
+        async def boom_subscribe():
+            raise asyncio.TimeoutError
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+
+        with self.assertRaises(asyncio.TimeoutError):
+            _run(m.create())
+        self.assertEqual(client.stops, 1)
+        _run(m.stop())  # second teardown
+        self.assertEqual(client.stops, 1)  # not stopped again
+        self.assertIsNone(m._client)
+
 
 class PublishReceivedTest(unittest.TestCase):
     def _client(self, appliance):


### PR DESCRIPTION
Automated release PR for `v5.2.0`.

<!-- release-tag: v5.2.0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional “minimal/validation” setup mode speeds configuration flow typing and reduces unnecessary data loading.
  * AC write-path enhancements: climate entities derive modes, ranges, and capabilities from live device settings; enum-based discrete temperature setpoints are supported.
* **Bug Fixes**
  * Prevent fractional temperatures from being truncated; improve HVAC/fan/swing command payload handling and rollback on failed sends.
  * Sensor fallback now treats specific “zero/empty” values as placeholders.
  * Legacy “power” entity cleanup is now limited to the correct entity type.
* **Improvements**
  * MQTT realtime updates are more robust; config flow now shows structured, code-based connection/auth errors and diagnostics include last error details.
  * Stronger privacy by consistently redacting sensitive identifiers in logs.
* **Tests**
  * Expanded coverage for MQTT, config flow errors, redaction, and AC write paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release adds a structured `ADDHON-NNN` error-code catalog, a minimal/validation setup mode for config-flow that skips MQTT and per-appliance loads, capability-gated HVAC/fan/swing/temperature ranges derived from live device settings, discrete enum-based temperature setpoints for number entities, and a refactored MQTT watchdog with a `_subscribed` flag that distinguishes "transport up" from "topics subscribed" — closing the silent dead-realtime window described in a prior review. Privacy is tightened by replacing raw IDs throughout debug logs with `redact_id`/`redact_mac`/`redact_identity`, and the HTTP layer gains a `_refresh_lock` + `_refresh_gen` mechanism to collapse concurrent token-refresh races into a single call.

- **MQTT watchdog** (`transport/mqtt.py`): introduces `_subscribed` flag and `_generation` tagging to correctly distinguish connected-but-unsubscribed from healthy; adds `_MAX_RESUBSCRIBE_FAILURES` escalation to rebuild path, fixing the prior silent dead-realtime bug.
- **Error catalog** (`error_codes.py` + `config_flow.py`): every setup/connection failure is mapped to a stable `ADDHON-NNN` code surfaced in the config-flow UI, logs, and downloadable diagnostics; config-flow now aborts duplicate accounts before the costly network validation.
- **AC + number write path** (`climate.py`, `number.py`): HVAC modes, fan modes, swing capability, and temperature ranges are derived at init from live device settings; enum-typed discrete setpoints snap to the nearest allowed value before sending.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The core fixes (MQTT watchdog subscribed-state tracking, token-refresh serialization, structured error codes, fractional temperature preservation) are well-targeted and the added test coverage is substantial.

Both findings are cosmetic or consistency issues that do not affect correctness: the empty-parentheses rendering only appears on a legacy code path never exercised in production, and the missing HomeAssistantError guard wraps the error into an equivalent generic message rather than losing it entirely.

climate.py (async_set_temperature / async_set_fan_mode / async_set_hvac_mode / async_turn_on missing HomeAssistantError re-raise guard) and translations/en.json (empty-code rendering in cannot_connect / invalid_auth / unknown strings).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/transport/mqtt.py | Major rework: adds `_subscribed` flag + `_generation` tagging to correctly separate transport-connected from topics-subscribed, introduces `_MAX_RESUBSCRIBE_FAILURES` cap to escalate stalled in-place re-subscribes to a full rebuild, and resets `_connection` at the start of every `_start()`. |
| custom_components/addhon/error_codes.py | New file: stable ADDHON-NNN error catalog with `classify()`, `HonCodedError`, and `phase_timeout_code()`. Pure module with no HA/aiohttp imports; `_reg()` enforces no duplicate codes or slugs at import time. |
| custom_components/addhon/client/transport/connection.py | Adds per-request aiohttp timeouts, `_refresh_lock`+`_refresh_gen` to collapse concurrent token-refresh races, and `_refresh_after_rejection()` for 401/403 recovery. Double-checked locking and generation comparison are implemented correctly. |
| custom_components/addhon/climate.py | HVAC/fan/swing capabilities and temperature range now derived from live device settings. `async_set_swing_mode` guards HomeAssistantError re-raise but `async_set_temperature`, `async_set_fan_mode`, `async_set_hvac_mode`, and `async_turn_on` lack that guard. |
| custom_components/addhon/hon_client.py | Adds `validation` mode, `_first_poll_done` strict/resilient switch, `_representative_failure()` for meaningful error codes, `build_realtime_snapshot()` / `subscribe_updates()` for MQTT push, and consistent identity redaction. |
| custom_components/addhon/config_flow.py | Error codes surfaced in the form via `_error_base_and_code`; duplicate-account abort correctly moved before network validation. Legacy string-constructed CannotConnect/InvalidAuth still works but renders empty parentheses. |
| custom_components/addhon/number.py | Adds discrete numeric enum setpoints with correct snap-to-member tolerance logic. `async_set_native_value` correctly guards HomeAssistantError re-raise before the broad handler. |
| custom_components/addhon/debug_utils.py | New redaction helpers: `redact_identity`, `redact_mac`, `redact_id`, `redact_topic`, `redact_store`. Pure module, no HA imports. MAC regex correct for both `:` and `-` separators. |
| custom_components/addhon/translations/en.json | Adds localized error strings for all new ADDHON-NNN UI codes; `{error_code}` placeholder in `cannot_connect`, `invalid_auth`, and `unknown` renders as `()` when empty (legacy code path). |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant HA as Home Assistant
    participant Init as __init__.py
    participant Client as HonClient
    participant Session as NativeHon
    participant Conn as HonConnection
    participant MQTT as NativeMqttClient

    HA->>Init: async_setup_entry
    Init->>Client: setup_sync (executor thread)
    Client->>Session: "NativeHon(minimal=False)"
    Session->>Conn: create() + authenticate()
    Note over Conn: _refresh_lock guards concurrent refresh
    Session->>Session: load_appliances / load_commands
    Session->>MQTT: NativeMqttClient.create()
    MQTT->>MQTT: _start() (bump generation)
    MQTT->>MQTT: _subscribe_appliances()
    MQTT->>MQTT: "_subscribed = _connection AND gen==_generation"
    MQTT->>MQTT: _start_watchdog()
    Client-->>Init: setup_sync returns
    Init->>HA: coordinator.async_config_entry_first_refresh()
    HA->>Client: async_get_appliances_data()
    Note over Client: _first_poll_done=False - strict mode
    Client-->>HA: snapshot dict
    Note over Client: _first_poll_done=True - resilient mode

    loop MQTT realtime push
        MQTT-->>Client: _on_realtime_push (awscrt thread)
        Client->>Client: build_realtime_snapshot()
        Client-->>HA: call_soon_threadsafe to coordinator.async_set_updated_data
    end

    loop Watchdog every 5s
        MQTT->>MQTT: check _connection AND _subscribed
        alt healthy
            MQTT->>MQTT: reset counters, continue
        else connected but not subscribed
            MQTT->>MQTT: in-place _subscribe_appliances()
            Note over MQTT: escalate after _MAX_RESUBSCRIBE_FAILURES
        else not connected
            MQTT->>MQTT: wait _RECONNECT_AFTER_FAILED_TICKS ticks
            MQTT->>MQTT: _start() rebuild + _subscribe_appliances()
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant HA as Home Assistant
    participant Init as __init__.py
    participant Client as HonClient
    participant Session as NativeHon
    participant Conn as HonConnection
    participant MQTT as NativeMqttClient

    HA->>Init: async_setup_entry
    Init->>Client: setup_sync (executor thread)
    Client->>Session: "NativeHon(minimal=False)"
    Session->>Conn: create() + authenticate()
    Note over Conn: _refresh_lock guards concurrent refresh
    Session->>Session: load_appliances / load_commands
    Session->>MQTT: NativeMqttClient.create()
    MQTT->>MQTT: _start() (bump generation)
    MQTT->>MQTT: _subscribe_appliances()
    MQTT->>MQTT: "_subscribed = _connection AND gen==_generation"
    MQTT->>MQTT: _start_watchdog()
    Client-->>Init: setup_sync returns
    Init->>HA: coordinator.async_config_entry_first_refresh()
    HA->>Client: async_get_appliances_data()
    Note over Client: _first_poll_done=False - strict mode
    Client-->>HA: snapshot dict
    Note over Client: _first_poll_done=True - resilient mode

    loop MQTT realtime push
        MQTT-->>Client: _on_realtime_push (awscrt thread)
        Client->>Client: build_realtime_snapshot()
        Client-->>HA: call_soon_threadsafe to coordinator.async_set_updated_data
    end

    loop Watchdog every 5s
        MQTT->>MQTT: check _connection AND _subscribed
        alt healthy
            MQTT->>MQTT: reset counters, continue
        else connected but not subscribed
            MQTT->>MQTT: in-place _subscribe_appliances()
            Note over MQTT: escalate after _MAX_RESUBSCRIBE_FAILURES
        else not connected
            MQTT->>MQTT: wait _RECONNECT_AFTER_FAILED_TICKS ticks
            MQTT->>MQTT: _start() rebuild + _subscribe_appliances()
        end
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `custom_components/addhon/__init__.py`, line 126-135 ([link](https://github.com/tis24dev/addhon/blob/ada45383c35f5bba4458257e23171e723a226f39/custom_components/addhon/__init__.py#L126-L135)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`classify(err)` called twice for the same exception in the coordinator update path**

   `err` is classified once here to set `hon_client.last_error_code`, and then `_raise_update_error(err)` immediately classifies the same exception a second time internally. The result is discarded from the first call except for the `last_error_code` side-effect. Consider passing the already-computed code into `_raise_update_error` (or returning it from the function) to avoid the duplicated work.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2F__init__.py%0ALine%3A%20126-135%0A%0AComment%3A%0A**%60classify%28err%29%60%20called%20twice%20for%20the%20same%20exception%20in%20the%20coordinator%20update%20path**%0A%0A%60err%60%20is%20classified%20once%20here%20to%20set%20%60hon_client.last_error_code%60%2C%20and%20then%20%60_raise_update_error%28err%29%60%20immediately%20classifies%20the%20same%20exception%20a%20second%20time%20internally.%20The%20result%20is%20discarded%20from%20the%20first%20call%20except%20for%20the%20%60last_error_code%60%20side-effect.%20Consider%20passing%20the%20already-computed%20code%20into%20%60_raise_update_error%60%20%28or%20returning%20it%20from%20the%20function%29%20to%20avoid%20the%20duplicated%20work.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2F__init__.py%0ALine%3A%20126-135%0A%0AComment%3A%0A**%60classify%28err%29%60%20called%20twice%20for%20the%20same%20exception%20in%20the%20coordinator%20update%20path**%0A%0A%60err%60%20is%20classified%20once%20here%20to%20set%20%60hon_client.last_error_code%60%2C%20and%20then%20%60_raise_update_error%28err%29%60%20immediately%20classifies%20the%20same%20exception%20a%20second%20time%20internally.%20The%20result%20is%20discarded%20from%20the%20first%20call%20except%20for%20the%20%60last_error_code%60%20side-effect.%20Consider%20passing%20the%20already-computed%20code%20into%20%60_raise_update_error%60%20%28or%20returning%20it%20from%20the%20function%29%20to%20avoid%20the%20duplicated%20work.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2F__init__.py%0ALine%3A%20126-135%0A%0AComment%3A%0A**%60classify%28err%29%60%20called%20twice%20for%20the%20same%20exception%20in%20the%20coordinator%20update%20path**%0A%0A%60err%60%20is%20classified%20once%20here%20to%20set%20%60hon_client.last_error_code%60%2C%20and%20then%20%60_raise_update_error%28err%29%60%20immediately%20classifies%20the%20same%20exception%20a%20second%20time%20internally.%20The%20result%20is%20discarded%20from%20the%20first%20call%20except%20for%20the%20%60last_error_code%60%20side-effect.%20Consider%20passing%20the%20already-computed%20code%20into%20%60_raise_update_error%60%20%28or%20returning%20it%20from%20the%20function%29%20to%20avoid%20the%20duplicated%20work.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["test: correct redact\_identity threat-mod..."](https://github.com/tis24dev/addhon/commit/5e6db14959e014bc4d9407d2917a29fa5b70b967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39393706)</sub>

<!-- /greptile_comment -->