### PR TITLE
Release v5.4.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: tis24dev

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 - **Asyncio optimization** — dedicated background loop for reliable API communication
 - **Smart attribute mapping** — device-specific attribute keys extracted from real diagnostics
 - **Full Lovelace support** — integrates seamlessly with Home Assistant UI and automations
+- **Two-factor authentication (2FA)** — Two-factor authentication during the login process is supported
+- **Multilingual integration** — Currently available in Italian and English, with additional languages available upon request.
 
 ## Installation
 
@@ -88,97 +90,6 @@ controls where they have been mapped.
 
 Other hOn-compatible Haier appliances should work; feel free to test and report.
 
-## Localization
-
-The user interface is multi-language. Entity names, the config and options
-screens, service names and descriptions, and user-facing error messages are
-provided as translations (currently English and Italian) and follow Home
-Assistant's configured language. The code, comments and log messages are
-English-only.
-
-## How It Works
-
-The integration operates in three layers:
-
-### 1. Home Assistant Integration Layer
-
-Handles entity discovery, service calls, and data updates. On initialization, it queries your Haier account for all paired devices and creates Home Assistant entities for each one.
-
-### 2. Native hOn Client
-
-A self-contained Python client (`custom_components/addhon/client/`), with no
-third-party hOn library vendored in. It manages:
-- **Authentication**: Salesforce OAuth login exchanging credentials for the
-  Cognito/id tokens the API expects (`client/transport/auth.py`)
-- **Device enumeration**: fetches the full device list and metadata, including
-  offline appliances (`client/transport/api.py`)
-- **Command routing**: builds and sends control commands (startProgram,
-  settings, stopProgram) with their parameters and rules (`client/engine/`)
-- **State polling and real-time updates**: HTTP polling plus an AWS IoT MQTT
-  stream for live state (`client/transport/mqtt.py`)
-
-### 3. Haier Cloud API (hOn)
-
-The backend cloud service that handles:
-- Token exchange and session management
-- Command execution on your physical devices
-- Real-time state synchronization
-- Device pairing and account management
-
-## Entities
-
-Each discovered appliance becomes a Home Assistant **device**; the entities it
-exposes depend on its type. A **connectivity** binary sensor is always present and
-stays available even when the appliance is offline, so you can tell whether it is
-reachable (all other entities become *unavailable* while it is offline).
-
-### Climate (AC)
-
-- **HVAC modes:** off, auto, cool, dry, heat, fan_only
-- **Fan modes:** auto, low, medium, high
-- **Swing:** off / on (vertical swing), when the device exposes it
-- **Temperature:** current temperature and target set point (16-30 °C)
-
-### Laundry (washing machine, tumble dryer, washer-dryer)
-
-- **Sensors:** state, program name, program phase, remaining time and, depending
-  on the model, wash temperature, spin speed, dry level, delay time, plus energy
-  and water counters
-- **Controls:** start/stop and the available programs and options, via switch,
-  select, number and button entities
-
-### Other appliances
-
-Refrigerators, ovens, dishwashers, water heaters, robot vacuums and the remaining
-types are exposed mainly through sensors (and a few controls where they have been
-mapped).
-
-## Services
-
-Device control is done through the normal entities (climate, switch, number,
-select, button), not through a service call. The integration exposes only two
-diagnostic services (also available from Developer Tools → Actions):
-
-### `addhon.set_log_level`
-
-Set the integration's diagnostic log level at runtime.
-
-```yaml
-action: addhon.set_log_level
-data:
-  level: debug   # one of: debug, info, warning, error
-```
-
-### `addhon.set_mqtt_log_level`
-
-Set the verbosity of the realtime MQTT stream logger at runtime.
-
-```yaml
-action: addhon.set_mqtt_log_level
-data:
-  level: warning   # one of: debug, info, warning, error
-```
-
 ## Troubleshooting
 
 ### Capture debug logs
@@ -233,16 +144,11 @@ To add support for a new Haier device:
 3. Add or extend the relevant platform file (`sensor.py`, `binary_sensor.py`, `number.py`, `select.py`, `switch.py`, ...) and, if the device type needs it, its capability map
 4. Test with your device, then open a pull request (or an issue with the captured diagnostics)
 
-## License
-
-MIT License — see LICENSE file for details.
-
 ## Contributing
 
 Issues and pull requests are welcome! Please include:
 - Home Assistant version
 - Device model number
-- Debug logs (see [`docs/discovery-debugging.md`](docs/discovery-debugging.md))
 - Steps to reproduce
 
 ## Support

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -38,7 +38,7 @@ from .logging_utils import (
     reset_integration_log_level,
     silence_mqtt_noise,
 )
-from .debug_utils import redact_mac
+from .debug_utils import redact_id, redact_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -286,12 +286,13 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if domain == "switch" and unique_id.endswith("_power"):
             registry.async_remove(reg_entry.entity_id)
             removed += 1
-            _LOGGER.info("Removed legacy power switch: %s", reg_entry.entity_id)
+            _LOGGER.info("Removed legacy power switch: id=%s", redact_id(reg_entry.unique_id))
         elif unique_id in td_orphans:
             registry.async_remove(reg_entry.entity_id)
             removed += 1
             _LOGGER.info(
-                "Removed invalid consumption entity for tumble dryer: %s", reg_entry.entity_id
+                "Removed invalid consumption entity for tumble dryer: id=%s",
+                redact_id(reg_entry.unique_id),
             )
     _LOGGER.debug(
         "Setup debug: legacy cleanup completed for entry=%s, checked=%d, removed=%d",

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
     SCAN_INTERVAL,
+    SERVICE_REFRESH,
     SERVICE_SET_LOG_LEVEL,
     SERVICE_SET_MQTT_LOG_LEVEL,
 )
@@ -57,7 +58,8 @@ def _async_register_services(hass: HomeAssistant) -> None:
     """
     mqtt_service_exists = hass.services.has_service(DOMAIN, SERVICE_SET_MQTT_LOG_LEVEL)
     log_service_exists = hass.services.has_service(DOMAIN, SERVICE_SET_LOG_LEVEL)
-    if mqtt_service_exists and log_service_exists:
+    refresh_service_exists = hass.services.has_service(DOMAIN, SERVICE_REFRESH)
+    if mqtt_service_exists and log_service_exists and refresh_service_exists:
         return
 
     import voluptuous as vol
@@ -82,6 +84,41 @@ def _async_register_services(hass: HomeAssistant) -> None:
             "Haier hOn diagnostic log level set to %s", level_name.upper()
         )
 
+    async def _handle_refresh(call: ServiceCall) -> None:
+        """Force an immediate cloud poll on every loaded config entry.
+
+        Domain-wide equivalent of the per-device "Refresh now" button: it reads
+        hass.data live at call time and asks each loaded coordinator for a
+        debounced refresh (async_request_refresh, like the button). Per-entry
+        failures are isolated (asyncio.gather(..., return_exceptions=True)) and
+        logged at warning; the service NEVER re-raises to the caller, so one
+        unhealthy account does not break an automation refreshing the others.
+        """
+        coordinators = [
+            entry_data["coordinator"]
+            for entry_data in hass.data.get(DOMAIN, {}).values()
+            if isinstance(entry_data, dict) and entry_data.get("coordinator") is not None
+        ]
+        _LOGGER.debug(
+            "Refresh service: requesting refresh on %d coordinator(s)",
+            len(coordinators),
+        )
+
+        async def _refresh_one(coordinator) -> None:
+            # Wrap the call INSIDE a coroutine so even a SYNCHRONOUS raise from
+            # async_request_refresh (e.g. a future refactor storing a wrapper /
+            # wrong-typed object) is captured by gather(return_exceptions=True)
+            # instead of escaping the generator and aborting the other refreshes.
+            await coordinator.async_request_refresh()
+
+        results = await asyncio.gather(
+            *(_refresh_one(coordinator) for coordinator in coordinators),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                _LOGGER.warning("Refresh service: a coordinator refresh failed: %s", result)
+
     level_schema = vol.Schema(
         {vol.Required(ATTR_LEVEL, default="debug"): vol.In(tuple(MQTT_LOG_LEVELS))}
     )
@@ -100,6 +137,14 @@ def _async_register_services(hass: HomeAssistant) -> None:
             SERVICE_SET_LOG_LEVEL,
             _handle_set_log_level,
             schema=level_schema,
+        )
+
+    if not refresh_service_exists:
+        # No schema: the service takes no fields and no target (domain-wide).
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REFRESH,
+            _handle_refresh,
         )
 
 
@@ -545,7 +590,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Unload debug: no HonClient to close for entry=%s", entry.entry_id)
         # Last entry removed: remove the global debug services.
         if not hass.data.get(DOMAIN):
-            for service in (SERVICE_SET_MQTT_LOG_LEVEL, SERVICE_SET_LOG_LEVEL):
+            for service in (SERVICE_SET_MQTT_LOG_LEVEL, SERVICE_SET_LOG_LEVEL, SERVICE_REFRESH):
                 if hass.services.has_service(DOMAIN, service):
                     hass.services.async_remove(DOMAIN, service)
                     _LOGGER.debug("Unload debug: removed service %s", service)

--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import datetime, timedelta
+from time import monotonic
 from typing import Any, Optional
 
 from ..helpers import parse_cloud_timestamp
@@ -63,11 +64,12 @@ class HonAppliance:
         # comparison against the cloud-stamped lastConnEvent is skew-free. See
         # mark_realtime_seen and load_attributes.
         self._last_realtime_ts: Optional[datetime] = None
-        # Local (wall-clock) receipt time of the last realtime message. Used ONLY for the
-        # freshness bound (_REALTIME_LIVENESS_TTL) -- a local-vs-local comparison, so it
-        # is skew-free; distinct from _last_realtime_ts, which is the CLOUD timestamp used
-        # for ordering against the cloud-stamped lastConnEvent.
-        self._last_realtime_local: Optional[datetime] = None
+        # MONOTONIC receipt time (seconds) of the last realtime message. Used ONLY for the
+        # freshness bound (_REALTIME_LIVENESS_TTL): a monotonic-vs-monotonic elapsed
+        # measure, immune to wall-clock jumps (NTP steps, DST transitions) that a naive
+        # datetime.now() would distort. Distinct from _last_realtime_ts, which is the CLOUD
+        # timestamp used for ordering against the cloud-stamped lastConnEvent.
+        self._last_realtime_local: Optional[float] = None
         # Per-type layer (resolved via the static registry).
         self._extra = _native_appliances.get_extra(self)
 
@@ -194,10 +196,10 @@ class HonAppliance:
         """
         self._connection = True
         self._attributes["available"] = True
-        # Wall-clock receipt time for the freshness bound (see load_attributes). Recorded
+        # Monotonic receipt time for the freshness bound (see load_attributes). Recorded
         # unconditionally -- even a timestamp-less message proves the appliance is live
         # NOW -- and only ever moves forward.
-        local_now = datetime.now()
+        local_now = monotonic()
         if self._last_realtime_local is None or local_now > self._last_realtime_local:
             self._last_realtime_local = local_now
         ts = parse_cloud_timestamp(timestamp)
@@ -278,8 +280,8 @@ class HonAppliance:
                     and realtime_ts > disconnect_ts
                 )
                 realtime_fresh = self._last_realtime_local is not None and (
-                    datetime.now() - self._last_realtime_local
-                    < timedelta(seconds=self._REALTIME_LIVENESS_TTL)
+                    monotonic() - self._last_realtime_local
+                    < self._REALTIME_LIVENESS_TTL
                 )
                 # Newer-than-disconnect AND still fresh -> trust realtime; else offline.
                 self._connection = realtime_newer and realtime_fresh

--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -15,6 +15,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
+from ..helpers import parse_cloud_timestamp
 from .appliances import registry as _native_appliances
 from .attributes import HonAttribute
 from .command_loader import HonCommandLoader
@@ -27,6 +28,15 @@ _LOGGER = logging.getLogger(__name__)
 
 class HonAppliance:
     _MINIMAL_UPDATE_INTERVAL = 5  # seconds
+    # Realtime liveness is authoritative only while RECENT: a realtime message overrides
+    # a STALE REST DISCONNECTED only if received within this wall-clock window. Without
+    # the bound, a once-seen realtime time would keep a silently-dead appliance online
+    # FOREVER, because the cloud's lastConnEvent can stay frozen at an OLD disconnect
+    # indefinitely (observed: frozen ~2.5h) and never emit a disconnect newer than the
+    # last traffic. After the window we defer to the REST lastConnEvent. 5 poll cycles:
+    # long enough to avoid flicker for a connected-but-quiet device, short enough to
+    # recover a dead one promptly.
+    _REALTIME_LIVENESS_TTL = 300  # seconds
 
     def __init__(self, api: Any, info: dict[str, Any], zone: int = 0) -> None:
         if attributes := info.get("attributes"):
@@ -45,6 +55,19 @@ class HonAppliance:
             not self._attributes.get("lastConnEvent", {}).get("category", "")
             == "DISCONNECTED"
         )
+        # Most recent CLOUD-stamped time at which we saw realtime MQTT traffic from this
+        # appliance (None until the first push). Realtime traffic is positive evidence of
+        # connectivity (the hOn app trusts it): it sets `_connection` True and is compared
+        # against `lastConnEvent` so a STALE REST disconnect cannot clobber a live device
+        # back offline at the next 60s poll. Cloud-stamped (not wall-clock) so the
+        # comparison against the cloud-stamped lastConnEvent is skew-free. See
+        # mark_realtime_seen and load_attributes.
+        self._last_realtime_ts: Optional[datetime] = None
+        # Local (wall-clock) receipt time of the last realtime message. Used ONLY for the
+        # freshness bound (_REALTIME_LIVENESS_TTL) -- a local-vs-local comparison, so it
+        # is skew-free; distinct from _last_realtime_ts, which is the CLOUD timestamp used
+        # for ordering against the cloud-stamped lastConnEvent.
+        self._last_realtime_local: Optional[datetime] = None
         # Per-type layer (resolved via the static registry).
         self._extra = _native_appliances.get_extra(self)
 
@@ -146,6 +169,58 @@ class HonAppliance:
     def connection(self, connection: bool) -> None:
         self._connection = connection
 
+    def mark_realtime_seen(self, timestamp: Any = None) -> None:
+        """Record positive realtime evidence: this appliance just sent MQTT traffic.
+
+        Called from the MQTT transport for any thing-scoped realtime message. It is
+        POSITIVE-ONLY: it sets `connection` True and remembers WHEN (the cloud-stamped
+        message `timestamp`, not local wall-clock, to stay comparable with
+        `lastConnEvent` and skew-free). It NEVER sets False -- absence of traffic stays
+        the job of the REST lastConnEvent / disconnect events / watchdog.
+
+        Defensive (runs on the awscrt callback thread, must never raise): a
+        missing/garbage/None timestamp is tolerated -- we still mark connected (the
+        message itself is the evidence) but, lacking a usable time, do NOT advance
+        `_last_realtime_ts`, so reconciliation falls back to the REST-only behavior for
+        that appliance rather than asserting a bogus ordering. The recorded time only
+        ever moves FORWARD (max), so an out-of-order older message cannot rewind it.
+
+        `available` is mirrored onto the cached attribute dict (not just `_connection`)
+        because the entities read the RAW `available` key: the connectivity
+        binary_sensor (attr_key="available") and the availability gate
+        (base_entity: `_attributes.get("available")`). `attributes` returns the cached
+        dict WITHOUT recomputing from `connection`, so without this the sensor would
+        only flip at the next 60s poll instead of the instant the MQTT proof arrives.
+        """
+        self._connection = True
+        self._attributes["available"] = True
+        # Wall-clock receipt time for the freshness bound (see load_attributes). Recorded
+        # unconditionally -- even a timestamp-less message proves the appliance is live
+        # NOW -- and only ever moves forward.
+        local_now = datetime.now()
+        if self._last_realtime_local is None or local_now > self._last_realtime_local:
+            self._last_realtime_local = local_now
+        ts = parse_cloud_timestamp(timestamp)
+        if ts is not None and (
+            self._last_realtime_ts is None or ts > self._last_realtime_ts
+        ):
+            self._last_realtime_ts = ts
+
+    def mark_realtime_disconnected(self) -> None:
+        """Record EXPLICIT negative realtime evidence (MQTT `disconnected` / presence).
+
+        An explicit disconnect is authoritative: the appliance is offline NOW. Beyond
+        setting `connection`/`available` False, it CLEARS the realtime liveness marks so a
+        subsequent STALE REST `lastConnEvent=DISCONNECTED` (whose timestamp may predate
+        the last realtime traffic) cannot resurrect the appliance at the next poll. Like
+        mark_realtime_seen it mirrors onto the cached `available` attribute so the
+        connectivity binary_sensor reflects the disconnect immediately, not a poll later.
+        """
+        self._connection = False
+        self._attributes["available"] = False
+        self._last_realtime_ts = None
+        self._last_realtime_local = None
+
     # --- loading ---
     async def load_commands(self) -> None:
         command_loader = HonCommandLoader(self.api, self)
@@ -174,7 +249,40 @@ class HonAppliance:
         # absent, malformed, or a dict without `category`, keep the (MQTT-derived) state
         # rather than forcing it True.
         if isinstance(lce, dict) and "category" in lce:
-            self._connection = lce["category"] != "DISCONNECTED"
+            if lce["category"] != "DISCONNECTED":
+                # A non-DISCONNECTED (e.g. CONNECTED) REST event is itself positive
+                # cloud evidence -> connected, unchanged behavior.
+                self._connection = True
+            else:
+                # DISCONNECTED from REST. Realtime MQTT traffic is also authoritative
+                # connectivity evidence, so a STALE disconnect must NOT clobber a device
+                # we KNOW is live. We keep it online only when the realtime evidence is
+                # BOTH:
+                #   * NEWER than this disconnect event (cloud-vs-cloud ordering, so a
+                #     genuinely later disconnect wins -> self-correcting); AND
+                #   * RECENT in wall-clock terms (within _REALTIME_LIVENESS_TTL), so a
+                #     once-seen realtime time cannot pin a now-silent appliance online
+                #     forever while the cloud's lastConnEvent stays frozen in the past
+                #     (the exact failure the washer's frozen 13:35 disconnect would cause
+                #     after the device stops talking). Past the window we defer to REST.
+                # If either timestamp is missing/unparseable we cannot order -> honor the
+                # DISCONNECTED (prior REST-only behavior). Prefer epoch-ms `timestampEvent`;
+                # fall back to ISO `instantTime` when absent OR explicitly null.
+                disconnect_ts = parse_cloud_timestamp(lce.get("timestampEvent"))
+                if disconnect_ts is None:
+                    disconnect_ts = parse_cloud_timestamp(lce.get("instantTime"))
+                realtime_ts = self._last_realtime_ts
+                realtime_newer = (
+                    realtime_ts is not None
+                    and disconnect_ts is not None
+                    and realtime_ts > disconnect_ts
+                )
+                realtime_fresh = self._last_realtime_local is not None and (
+                    datetime.now() - self._last_realtime_local
+                    < timedelta(seconds=self._REALTIME_LIVENESS_TTL)
+                )
+                # Newer-than-disconnect AND still fresh -> trust realtime; else offline.
+                self._connection = realtime_newer and realtime_fresh
         # `available` UNIVERSAL (even for types without a per-type layer, e.g. AC):
         # connectivity is first-class as in the app. The per-type layer re-sets it (same value).
         self._attributes["available"] = self._connection

--- a/custom_components/addhon/client/helpers.py
+++ b/custom_components/addhon/client/helpers.py
@@ -6,6 +6,72 @@ pinned by the golden test, so values parse exactly as the cloud expects.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def parse_cloud_timestamp(value: Any) -> Optional[datetime]:
+    """Parse a cloud-stamped timestamp into a timezone-aware UTC `datetime`.
+
+    Accepts the two shapes the hOn cloud uses for the SAME wall-clock instant, so a
+    `lastConnEvent` time and an `appliancestatus` payload time are directly comparable:
+      - ISO8601 string, e.g. `lastConnEvent.instantTime` "2026-06-25T13:35:13Z" or the
+        realtime payload `timestamp` "2026-06-25T16:04:21.1Z" (note: the cloud emits a
+        VARIABLE number of fractional digits, including a single one);
+      - epoch milliseconds (int or numeric string), e.g. `lastConnEvent.timestampEvent`
+        1782394513133.
+
+    Returns `None` on anything it cannot establish an ordering from (None, empty,
+    garbage, wrong type) so the caller can degrade gracefully instead of raising -- this
+    runs in connectivity reconciliation and on the awscrt callback thread, neither of
+    which may raise. The result is ALWAYS tz-aware UTC, so naive/aware mismatches never
+    crash a comparison: a bare ISO string with no offset is assumed UTC (the cloud stamps
+    UTC, hence the trailing "Z").
+    """
+    if value is None or isinstance(value, bool):
+        # bool is an int subclass; a True/False epoch is meaningless -> reject it
+        # rather than treating it as 0/1 ms past the epoch.
+        return None
+    # Epoch milliseconds: int/float, or a purely-numeric string.
+    if isinstance(value, (int, float)):
+        # Guard the float() too: an arbitrary-precision int (e.g. a 300+ digit value from
+        # json.loads) overflows float() with OverflowError BEFORE the fromtimestamp guard
+        # below. This function must be TOTAL (never raises) -- it runs on the awscrt
+        # callback thread and in the per-appliance setup loop, where OverflowError
+        # (an ArithmeticError, not a ValueError) would escape the boundary catch.
+        try:
+            epoch_ms: Optional[float] = float(value)
+        except (ValueError, OverflowError):
+            return None
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        epoch_ms = None
+        if text.lstrip("+-").isdigit():
+            try:
+                epoch_ms = float(text)
+            except (ValueError, OverflowError):
+                epoch_ms = None
+        if epoch_ms is None:
+            # ISO8601. fromisoformat (Py>=3.7) handles the variable fractional digits;
+            # normalize a trailing "Z" to "+00:00" for the 3.10 interpreter (3.11+ takes
+            # "Z" natively, but the substitution is harmless there).
+            iso = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
+            try:
+                parsed = datetime.fromisoformat(iso)
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+    else:
+        return None
+    try:
+        return datetime.fromtimestamp(epoch_ms / 1000.0, tz=timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return None
+
 
 def str_to_float(value: str | float) -> float:
     """Convert an hOn value (usually a string) into a number.

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -297,6 +297,11 @@ class NativeMqttClient:
                     "MQTT: client session presence on %s, ignored for connectivity",
                     redact_topic(topic),
                 )
+                # Nothing about appliance state changed: return WITHOUT notifying the
+                # coordinator or logging the payload at INFO. Falling through would push a
+                # spurious HA state update and echo the session payload for every client
+                # (re)connect/disconnect.
+                return
             elif topic and "appliancestatus" in topic:
                 # Realtime traffic is authoritative connectivity evidence (the hOn app
                 # trusts it): mark the appliance connected and remember WHEN, using the

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -467,7 +467,17 @@ class NativeMqttClient:
                 continue
             try:
                 await self._subscribe_topic(topic)
-            except HonCodedError as err:
+            except asyncio.CancelledError:
+                # stop() cancels+awaits the watchdog: a cancellation must propagate,
+                # never be swallowed as a per-topic failure (it is not one).
+                raise
+            except Exception as err:
+                # Isolate EVERY non-cancellation failure, not just the HonCodedError
+                # timeout: client.subscribe()/the awscrt future can also raise transport
+                # or awscrt errors, and letting those escape would abort the loop and
+                # re-open the exact H1 starvation (every later topic skipped this pass).
+                # A failed topic stays missing and is retried next tick; if NOTHING
+                # subscribes the watchdog's blackout escalation still fires.
                 _LOGGER.warning(
                     "MQTT: subscribe failed for one topic, continuing: %s", err
                 )

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -272,7 +272,29 @@ class NativeMqttClient:
                     "MQTT: topic with no matching appliance: %s", redact_topic(topic)
                 )
                 return
-            if topic and "appliancestatus" in topic:
+            if topic and topic.startswith("$aws/events/presence/"):
+                # AWS-IoT SESSION presence of OUR MQTT client (clientId-scoped; payload
+                # carries clientId/sessionIdentifier/principalIdentifier). It is matched to
+                # whichever single appliance subscribes the topic but says NOTHING about
+                # that appliance's connectivity. It must NOT arm (connected) NOR clear
+                # (disconnected) the appliance's stale-disconnect protection: our client
+                # reconnects/drops on its own schedule, so arming would pin a genuinely
+                # offline appliance online on every reconnect, and clearing would knock a
+                # live, streaming appliance offline on a transient session blip (both
+                # non-self-correcting while the cloud's lastConnEvent stays stale).
+                # Appliance connectivity comes only from device-scoped events
+                # (haier/things/<mac>/event/...) and the REST lastConnEvent.
+                _LOGGER.debug(
+                    "MQTT: client session presence on %s, ignored for connectivity",
+                    redact_topic(topic),
+                )
+            elif topic and "appliancestatus" in topic:
+                # Realtime traffic is authoritative connectivity evidence (the hOn app
+                # trusts it): mark the appliance connected and remember WHEN, using the
+                # cloud-stamped payload `timestamp` (skew-free vs lastConnEvent), BEFORE
+                # parsing parameters so the liveness is recorded even if a later param is
+                # dirty. mark_realtime_seen is positive-only and never raises.
+                appliance.mark_realtime_seen(payload.get("timestamp"))
                 params = appliance.attributes.get("parameters", {})
                 raw_params = payload.get("parameters")
                 if not isinstance(raw_params, list):
@@ -313,8 +335,27 @@ class NativeMqttClient:
                     redact_id(appliance.nick_name),
                     payload.get("disconnectReason"),
                 )
-                appliance.connection = False
+                # Device-scoped disconnect (haier/things/<mac>/event/disconnected): the
+                # APPLIANCE itself reports offline -- authoritative. Session-presence
+                # disconnects ($aws/events/presence/...) were already intercepted above, so
+                # this never fires on OUR client's session drop. Route through
+                # mark_realtime_disconnected so it CLEARS the realtime liveness marks too --
+                # otherwise a stale REST lastConnEvent=DISCONNECTED (older than the last
+                # traffic) would resurrect the appliance at the next poll. Falls back to the
+                # plain setter for any appliance object that predates the method.
+                mark = getattr(appliance, "mark_realtime_disconnected", None)
+                if callable(mark):
+                    mark()
+                else:  # pragma: no cover - production appliances have the method
+                    appliance.connection = False
             elif topic and "connected" in topic:
+                # Device-scoped connect (haier/things/<mac>/event/connected): the appliance
+                # reports online. Session-presence connects ($aws/events/presence/...) were
+                # intercepted above, so this is not OUR client's session event. Keep the
+                # transient behavior (connection True, self-corrected at the next REST poll);
+                # we deliberately do NOT arm the realtime liveness here -- only true
+                # mac-scoped `appliancestatus` traffic records liveness, so a bare connect
+                # event cannot over-extend the stale-disconnect protection window.
                 appliance.connection = True
                 _LOGGER.info("Connected %s", redact_id(appliance.nick_name))
             elif topic and "discovery" in topic:

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -88,20 +88,26 @@ class NativeMqttClient:
         self._appliances = hon.appliances
         self._client: mqtt5.Client | None = None
         self._connection = False
-        # Distinct from _connection: tracks whether _subscribe_appliances() last
-        # completed without raising. _connection ("transport connected", set by the
-        # awscrt connection-success callback) and "appliance topics actually
-        # subscribed" are TWO states; conflating them made the watchdog treat a
-        # connected-but-unsubscribed client as healthy and stop rebuilding, so realtime
-        # pushes were silently dead until the next full AWS IoT disconnect (the 60s HTTP
-        # poll masks it). Two failure modes leave us connected-but-unsubscribed:
-        #   1. a rebuild whose _subscribe_appliances() hits _SUBSCRIBE_TIMEOUT (success
-        #      callback already flipped _connection=True before the SUBACK stalled);
+        # Distinct from _connection: the SET of topic strings currently subscribed
+        # (acked). _connection ("transport connected", set by the awscrt connection-
+        # success callback) and "appliance topics actually subscribed" are TWO states;
+        # conflating them made the watchdog treat a connected-but-unsubscribed client as
+        # healthy and stop rebuilding, so realtime pushes were silently dead until the
+        # next full AWS IoT disconnect (the 60s HTTP poll masks it). Two failure modes
+        # leave us connected-but-unsubscribed:
+        #   1. a rebuild whose subscribe hits _SUBSCRIBE_TIMEOUT (success callback
+        #      already flipped _connection=True before the SUBACK stalled);
         #   2. awscrt's own auto-reconnect after a transient blip -- AWS IoT custom-
         #      authorizer websocket sessions are clean (no session_behavior is set in
         #      _start(), so subscriptions are NOT restored across a reconnect).
         # Both are recovered by the watchdog: see _watchdog().
-        self._subscribed = False
+        #
+        # A SET (per topic) rather than a single binary flag gives PER-TOPIC isolation:
+        # one appliance whose SUBACK stalls no longer blocks the rest (H1 starvation),
+        # and the watchdog can distinguish "one bad appliance" (some topics subscribed,
+        # transport alive -> keep retrying the missing, do NOT rebuild) from "dead
+        # connection" (no topic subscribes at all -> escalate to a full rebuild).
+        self._subscribed_topics_set: set[str] = set()
         # Bumped on every _start(): the state-mutating lifecycle callbacks are bound
         # to the generation of the client that registered them, so a late event from a
         # client we already stopped cannot flip self._connection on the new one (awscrt
@@ -132,16 +138,17 @@ class NativeMqttClient:
             await self._start()
             gen = self._generation
             self._set_setup_phase("mqtt_subscribe")
-            await self._subscribe_appliances()
-            # Subscriptions are now in place: mark healthy so the watchdog does not
+            await self._subscribe_missing()
+            # Subscriptions are now in place: commit the set so the watchdog does not
             # treat the initial connect as connected-but-unsubscribed (see _watchdog).
             # Re-check connection AND generation AFTER the await, not unconditionally:
             # a disconnection callback (on the awscrt thread) can fire mid-subscribe and
-            # set _connection=_subscribed=False; an unconditional `= True` here would
-            # clobber that back, leaving a stuck "healthy on a dropped session" state
-            # (the exact bug class this flag exists to kill). gen == _generation also
-            # guards against a rebuild landing during the await.
-            self._subscribed = self._connection and (gen == self._generation)
+            # clear the set (via the lifecycle callback); committing it unconditionally
+            # here would resurrect a "healthy on a dropped session" state (the exact bug
+            # class this set exists to kill). gen == _generation also guards against a
+            # rebuild landing during the await.
+            if not (self._connection and gen == self._generation):
+                self._subscribed_topics_set = set()
             await self._start_watchdog()
         except BaseException:
             # _start() has already started the awscrt client; if a later step fails
@@ -213,9 +220,11 @@ class NativeMqttClient:
             return
         self._connection = False
         # A failed/dropped connection loses all subscriptions (clean session): clear
-        # the flag so the watchdog re-subscribes once awscrt reconnects. The generation
-        # guard above already prevents a late event from an old client clearing it.
-        self._subscribed = False
+        # the set so the watchdog re-subscribes once awscrt reconnects. Rebind (atomic)
+        # rather than .clear() so a concurrent reader on the hon_loop never observes a
+        # half-emptied set. The generation guard above already prevents a late event
+        # from an old client clearing it.
+        self._subscribed_topics_set = set()
         _LOGGER.info("Lifecycle Connection Failure: %s", data)
 
     def _on_lifecycle_disconnection(
@@ -225,8 +234,8 @@ class NativeMqttClient:
             return
         self._connection = False
         # See _on_lifecycle_connection_failure: a disconnect drops subscriptions, so
-        # the watchdog must re-establish them after the auto-reconnect.
-        self._subscribed = False
+        # the watchdog must re-establish them after the auto-reconnect. Rebind (atomic).
+        self._subscribed_topics_set = set()
         _LOGGER.info("Lifecycle Disconnection: %s", data)
 
     def _on_publish_received(self, data: "mqtt5.PublishReceivedData") -> None:
@@ -380,21 +389,21 @@ class NativeMqttClient:
             except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
             self._client = None
-        # A fresh client carries over no subscriptions: clear the flag here (the caller
-        # -- create() or the watchdog rebuild path -- sets it True only after
-        # _subscribe_appliances() succeeds).
-        self._subscribed = False
+        # A fresh client carries over no subscriptions: clear the set here (the caller
+        # -- create() or the watchdog rebuild path -- re-populates it only after the
+        # subscribe succeeds). Rebind (atomic) rather than .clear().
+        self._subscribed_topics_set = set()
         # Reset _connection too so it tracks the CURRENT client: the new one is not up
         # until ITS generation-tagged success callback fires below. A rebuild reached via
         # the escalation branch (connected-but-unsubscribed) would otherwise carry over
         # _connection=True from the just-stopped client. That is NOT a false-healthy
-        # (_subscribed above is already False, so the watchdog never treats it as
-        # healthy), but a rebuild whose _subscribe_appliances() then fails would leave a
+        # (the set above is already empty, so the watchdog never treats it as
+        # healthy), but a rebuild whose subscribe then fails would leave a
         # stale connected-but-unsubscribed state on a client that is not actually up yet,
         # sending the next tick down the in-place re-subscribe path against a dead client
         # instead of rebuilding. The only late callback the stopped client can still emit
         # is a disconnection (-> False), never a spurious success, and the generation bump
-        # below rejects every other stale event; so this reset cannot be clobbered True.
+        # below rejects every other stale event; so this reset cannot be flipped True.
         self._connection = False
         # Tag this client's state-mutating callbacks with a fresh generation so a late
         # event from the client just stopped cannot flip self._connection (see
@@ -423,26 +432,60 @@ class NativeMqttClient:
         )
         self.client.start()
 
+    def _all_topics(self) -> set[str]:
+        """Union of the subscribe topics of every appliance (the target set)."""
+        topics: set[str] = set()
+        for appliance in self._appliances:
+            topics.update(_subscribed_topics(appliance))
+        return topics
+
+    async def _subscribe_topic(self, topic: str) -> None:
+        # awscrt subscribe() returns a concurrent.futures.Future; await it via
+        # wrap_future instead of a blocking .result(), so the hon_loop is not
+        # frozen up to _SUBSCRIBE_TIMEOUT. The timeout bound is unchanged.
+        future = self.client.subscribe(
+            mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
+        )
+        try:
+            await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
+        except asyncio.TimeoutError as err:
+            # Attribute the stall to a stable code. No identity in the message
+            # (the topic embeds the MAC) -> the bare timeout str only.
+            raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, str(err)) from err
+        _LOGGER.info("Subscribed to topic %s", redact_topic(topic))
+
+    async def _subscribe_missing(self) -> None:
+        # Per-topic isolation (H1): subscribe ONLY the topics not already in the set,
+        # and a single topic's failure does NOT abort the others. The earlier
+        # sequential "raise on the first timeout" loop starved every appliance AFTER a
+        # slow one (it never got subscribed), so a single bad appliance early in the
+        # list permanently killed realtime push for the rest. Here a failed topic is
+        # logged and skipped; it is simply retried on the next watchdog tick, while the
+        # healthy topics stay subscribed.
+        for topic in self._all_topics():
+            if topic in self._subscribed_topics_set:
+                continue
+            try:
+                await self._subscribe_topic(topic)
+            except HonCodedError as err:
+                _LOGGER.warning(
+                    "MQTT: subscribe failed for one topic, continuing: %s", err
+                )
+                continue
+            self._subscribed_topics_set.add(topic)
+
+    # Thin compatibility wrappers over the per-topic primitives above. _subscribe_missing
+    # is the path used by create()/the watchdog; these keep the per-appliance call shape
+    # for callers/tests that still drive a single appliance (note: unlike
+    # _subscribe_missing they propagate a HonCodedError so the per-topic timeout
+    # contract stays testable).
+    async def _subscribe(self, appliance: Any) -> None:
+        for topic in _subscribed_topics(appliance):
+            await self._subscribe_topic(topic)
+
     async def _subscribe_appliances(self) -> None:
         for appliance in self._appliances:
             await self._subscribe(appliance)
-
-    async def _subscribe(self, appliance: Any) -> None:
-        for topic in _subscribed_topics(appliance):
-            # awscrt subscribe() returns a concurrent.futures.Future; await it via
-            # wrap_future instead of a blocking .result(), so the hon_loop is not
-            # frozen up to _SUBSCRIBE_TIMEOUT per topic. Order is preserved (await
-            # each before the next); the timeout bound is unchanged.
-            future = self.client.subscribe(
-                mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
-            )
-            try:
-                await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
-            except asyncio.TimeoutError as err:
-                # Attribute the stall to a stable code. No identity in the message
-                # (the topic embeds the MAC) -> the bare timeout str only.
-                raise HonCodedError(MQTT_SUBSCRIBE_TIMEOUT, str(err)) from err
-            _LOGGER.info("Subscribed to topic %s", redact_topic(topic))
 
     async def _start_watchdog(self) -> None:
         if not self._watchdog_task or self._watchdog_task.done():
@@ -451,84 +494,92 @@ class NativeMqttClient:
     async def _watchdog(self) -> None:
         failed_ticks = 0
         backoff = 0
-        # Consecutive in-place re-subscribe FAILURES (Issue 1): a transport that awscrt
-        # keeps reporting connected but whose SUBACK never lands (half-open socket /
-        # stale custom-authorizer session that never fires a disconnection callback)
-        # would otherwise loop the in-place re-subscribe forever and never refresh the
-        # AWS token via _start(). After _MAX_RESUBSCRIBE_FAILURES we escalate to a full
-        # rebuild. Reset to 0 on ANY successful subscribe (re-subscribe or rebuild).
+        # Consecutive TOTAL-BLACKOUT re-subscribe ticks (Issue 1): a transport that awscrt
+        # keeps reporting connected but on which NOT A SINGLE topic subscribes (half-open
+        # socket / stale custom-authorizer session that never fires a disconnection
+        # callback) would otherwise loop the in-place re-subscribe forever and never
+        # refresh the AWS token via _start(). After _MAX_RESUBSCRIBE_FAILURES we escalate
+        # to a full rebuild. Reset to 0 on ANY subscribe progress (a non-empty set after
+        # the pass) or a rebuild. NOTE the change vs the binary-flag design: this counts
+        # ONLY a blackout, NOT a partial miss -- one chronically broken appliance topic
+        # (transport alive, other topics subscribed) is appliance-specific and must NOT
+        # escalate to a rebuild that would drop the healthy subscriptions too (H1).
         resubscribe_failures = 0
         while True:
             # The rebuild (load_aws_token / subscribe) can raise transiently; without
             # this guard one exception would end the task and kill realtime until a
             # reload. Re-raise CancelledError FIRST (stop() cancels+awaits us, so
             # swallowing it would deadlock shutdown); on any other error log and keep
-            # looping with an additive backoff (capped, reset on recovery). A re-subscribe
-            # failure (Issue 1) increments resubscribe_failures via attempted_resubscribe.
-            attempted_resubscribe = False
+            # looping with an additive backoff (capped, reset on recovery).
             try:
                 await asyncio.sleep(_WATCHDOG_INTERVAL + backoff)
-                # Healthy ONLY when the transport is connected AND the appliance topics
-                # are subscribed. Checking _connection alone treated a connected-but-
-                # unsubscribed client as healthy and stopped rebuilding (the original
-                # bug), so realtime pushes died silently until the next full disconnect.
-                if self._connection and self._subscribed:
+                # Healthy ONLY when the transport is connected AND every target topic is
+                # in the subscribed set (no missing topics). Checking _connection alone
+                # treated a connected-but-unsubscribed client as healthy and stopped
+                # rebuilding (the original bug), so realtime pushes died silently until
+                # the next full disconnect.
+                if self._connection and not (
+                    self._all_topics() - self._subscribed_topics_set
+                ):
                     failed_ticks = 0
                     backoff = 0
                     resubscribe_failures = 0
                     continue
-                # Connected but the subscription is missing (a rebuild whose subscribe
-                # timed out, OR awscrt's own auto-reconnect on a clean session): the
-                # transport is up, so a full rebuild would needlessly tear down a working
-                # connection and re-hit the AWS authorizer endpoint. Re-subscribe in
-                # place instead -- UNLESS the in-place re-subscribe has already failed
-                # _MAX_RESUBSCRIBE_FAILURES times in a row (Issue 1): a connection awscrt
-                # still believes is up but that never SUBACKs is dead at the application
-                # layer, and only _start() can refresh the token + rebuild the client, so
-                # we fall through to the rebuild path below instead of looping forever.
-                if (
-                    self._connection
-                    and not self._subscribed
-                    and resubscribe_failures < _MAX_RESUBSCRIBE_FAILURES
-                ):
+                # Connected but at least one topic is missing (a rebuild whose subscribe
+                # timed out, awscrt's own auto-reconnect on a clean session, OR one
+                # chronically broken appliance topic): the transport is up, so a full
+                # rebuild would needlessly tear down a working connection and re-hit the
+                # AWS authorizer endpoint -- AND drop the topics that ARE subscribed.
+                # Re-subscribe the MISSING topics in place instead -- UNLESS we have hit
+                # _MAX_RESUBSCRIBE_FAILURES total-blackout ticks (Issue 1): a connection
+                # awscrt still reports up but on which nothing SUBACKs at all is dead at
+                # the application layer, and only _start() can refresh the token + rebuild
+                # the client, so we fall through to the rebuild path below.
+                if self._connection and resubscribe_failures < _MAX_RESUBSCRIBE_FAILURES:
                     _LOGGER.info("Re-subscribe mqtt topics")
                     gen = self._generation
-                    # Mark BEFORE the await so a raise (e.g. MQTT_SUBSCRIBE_TIMEOUT)
-                    # landing in the shared `except` is counted as a re-subscribe failure
-                    # (Issue 1 escalation). It is cleared again right after a successful
-                    # subscribe so a successful tick never counts.
-                    attempted_resubscribe = True
-                    await self._subscribe_appliances()
-                    attempted_resubscribe = False
+                    await self._subscribe_missing()
                     # Re-check connection AND generation AFTER the await, not an
-                    # unconditional True (Issue 3): a disconnection callback can land on
-                    # the awscrt thread during the subscribe and set
-                    # _connection=_subscribed=False; clobbering it back to True here would
-                    # leave a stuck "healthy on a dropped session". gen == _generation
-                    # also rejects a rebuild that landed mid-await.
-                    self._subscribed = self._connection and (gen == self._generation)
-                    if not self._subscribed:
+                    # unconditional commit (Issue 3): a disconnection callback can land on
+                    # the awscrt thread during the subscribe and clear the set (and
+                    # _connection); trusting the set here would leave a stuck "healthy on
+                    # a dropped session". gen == _generation also rejects a rebuild that
+                    # landed mid-await.
+                    if not (self._connection and gen == self._generation):
+                        self._subscribed_topics_set = set()
                         # The connection dropped (or a new client generation landed)
-                        # during the subscribe: do NOT treat this tick as a recovery.
-                        # Leave the counters untouched and let the next tick's
-                        # not-connected path count the outage normally.
+                        # during the subscribe: do NOT treat this tick as recovery. Leave
+                        # the counters untouched and let the next tick's not-connected
+                        # path count the outage normally.
                         continue
-                    resubscribe_failures = 0  # subscribe succeeded
-                    # Issue 2: a genuine recovery resets the outage counters, same as the
-                    # healthy branch. Leaving failed_ticks set across a successful
-                    # re-subscribe would force a full rebuild one tick early on a flapping
-                    # connection, breaking the _RECONNECT_AFTER_FAILED_TICKS contract.
-                    failed_ticks = 0
-                    backoff = 0  # re-subscribe succeeded
+                    if self._subscribed_topics_set:
+                        # At least one topic subscribed -> the connection is ALIVE. Any
+                        # topics still missing are appliance-specific (one bad SUBACK),
+                        # NOT a dead connection: do NOT escalate to a rebuild (it would
+                        # drop the healthy subscriptions). Reset the outage counters as a
+                        # genuine recovery (Issue 2 symmetry with the healthy branch) and
+                        # keep retrying the missing topics on the next tick.
+                        resubscribe_failures = 0
+                        failed_ticks = 0
+                        backoff = 0
+                        continue
+                    # Total blackout: NOTHING subscribed though awscrt reports connected.
+                    # Count toward the escalation cap and back off (capped). Always
+                    # `continue`: the escalation fires on the NEXT tick, where the
+                    # re-subscribe branch is skipped (resubscribe_failures >= the cap) and
+                    # `escalated` routes straight to the rebuild that refreshes the token
+                    # and tears down the dead client. (Mirrors the old except-driven
+                    # increment timing: the rebuild lands one tick past the cap.)
+                    resubscribe_failures += 1
+                    backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
                     continue
                 # Not connected (or re-subscribe escalated to a rebuild): sustained
                 # downtime only forces a rebuild. Give awscrt's own auto-reconnect a
                 # chance first (see _RECONNECT_AFTER_FAILED_TICKS) -- but an escalation
-                # (resubscribe_failures exceeded) skips the wait, the connection is
-                # already known dead.
+                # (blackout cap reached) skips the wait, the connection is already known
+                # dead.
                 escalated = (
                     self._connection
-                    and not self._subscribed
                     and resubscribe_failures >= _MAX_RESUBSCRIBE_FAILURES
                 )
                 if not escalated:
@@ -539,24 +590,25 @@ class NativeMqttClient:
                 _LOGGER.info("Restart mqtt connection")
                 await self._start()
                 gen = self._generation
-                await self._subscribe_appliances()
-                # Rebuild + subscribe both succeeded: mark healthy. _start() reset
-                # _subscribed to False, so leaving it unset on a subscribe failure (which
-                # raises before this line) keeps the recovery loop honest. Re-check
-                # connection AND generation AFTER the await (Issue 3), not an
-                # unconditional True, so a disconnect or newer generation landing during
-                # the subscribe is not clobbered.
-                self._subscribed = self._connection and (gen == self._generation)
+                await self._subscribe_missing()
+                # Rebuild + subscribe done: commit the set. _start() reset it to empty, so
+                # leaving it empty on a subscribe failure keeps the recovery loop honest.
+                # Re-check connection AND generation AFTER the await (Issue 3), not an
+                # unconditional commit, so a disconnect or newer generation landing during
+                # the subscribe is not trusted.
+                if not (self._connection and gen == self._generation):
+                    self._subscribed_topics_set = set()
                 resubscribe_failures = 0  # the rebuild re-subscribed
                 backoff = 0  # rebuild succeeded
             except asyncio.CancelledError:
                 raise
             except Exception:
-                if attempted_resubscribe:
-                    # Issue 1: an in-place re-subscribe attempt raised. Count it so a
-                    # connection awscrt keeps reporting up but that never SUBACKs is
-                    # escalated to a full rebuild after _MAX_RESUBSCRIBE_FAILURES.
-                    resubscribe_failures += 1
+                # Only the REBUILD path (load_aws_token / _start / the rebuild's
+                # _subscribe_missing) can land here now: the in-place re-subscribe uses
+                # _subscribe_missing(), which swallows a per-topic HonCodedError (the
+                # blackout escalation is driven inline by resubscribe_failures, not by a
+                # raise). Back off (capped, reset on recovery) so a persistent 5xx from
+                # the AWS authorizer is not hammered every tick.
                 backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
                 _LOGGER.warning(
                     "MQTT watchdog: reconnect failed, retrying in %ss",

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -195,8 +195,18 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             )
             return HVACMode.OFF
 
-        # Read machMode (e.g. "2") using the constant from const.py
-        mode_val = str(self._get_attr(AC_ATTR_MODE, "1"))
+        # Read machMode (e.g. "2") using the constant from const.py. NO default: a
+        # powered-on unit whose current mode is absent (settings.machMode missing) must
+        # report unknown (None), not a guessed mode. Defaulting to "1" here coerced an
+        # absent mode into COOL, defeating the unknown-state contract below.
+        raw_mode = self._get_attr(AC_ATTR_MODE)
+        if raw_mode is None:
+            _LOGGER.debug(
+                "Climate debug: machMode missing id=%s -> hvac_mode None",
+                redact_id(self._appliance_id),
+            )
+            return None
+        mode_val = str(raw_mode)
 
         # Retrieve the text from const.py (e.g. "cool"). No default: an unmapped raw
         # value must not be coerced into a guessed mode -- HA rejects a current option

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -183,7 +183,7 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         return self._live_temp_range[2]
 
     @property
-    def hvac_mode(self) -> HVACMode:
+    def hvac_mode(self) -> HVACMode | None:
         """Return the current HVAC state, translating the const.py string into the HA enum."""
         on_off = self._get_attr(AC_ATTR_ON_OFF, "0")
         if str(on_off) == "0":
@@ -198,28 +198,49 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         # Read machMode (e.g. "2") using the constant from const.py
         mode_val = str(self._get_attr(AC_ATTR_MODE, "1"))
 
-        # Retrieve the text from const.py (e.g. "cool")
-        mode_str = AC_MODE_MAP.get(mode_val, "cool")
+        # Retrieve the text from const.py (e.g. "cool"). No default: an unmapped raw
+        # value must not be coerced into a guessed mode -- HA rejects a current option
+        # outside hvac_modes ("is not a valid option") and logs a warning. Report
+        # unknown (None) instead, which HA represents honestly.
+        mode_str = AC_MODE_MAP.get(mode_val)
+        if mode_str is None:
+            _LOGGER.debug(
+                "Climate debug: machMode=%s not in AC_MODE_MAP, hvac_mode -> None",
+                mode_val,
+            )
+            return None
 
         # Convert the string into the correct Home Assistant enum
         try:
             mode = HVACMode(str(mode_str).lower())
-            _LOGGER.debug(
-                "Climate debug: hvac_mode '%s' id=%s onOffStatus=%s machMode=%s -> %s",
-                redact_id(self._attr_unique_id, self._appliance_id),
-                redact_id(self._appliance_id),
-                on_off,
-                mode_val,
-                mode,
-            )
-            return mode
         except ValueError:
             _LOGGER.debug(
-                "Climate debug: machMode=%s translated to mode_str=%s invalid, fallback COOL",
+                "Climate debug: machMode=%s translated to mode_str=%s invalid, hvac_mode -> None",
                 mode_val,
                 mode_str,
             )
-            return HVACMode.COOL
+            return None
+
+        # Never report a mode outside the advertised capability list (HA would ignore
+        # it and warn). With the full-list fallback this can only trigger when the
+        # device exposed a restricted machMode enum that excludes the current value.
+        if mode not in self._attr_hvac_modes:
+            _LOGGER.debug(
+                "Climate debug: hvac_mode %s not in advertised modes %s -> None",
+                mode,
+                self._attr_hvac_modes,
+            )
+            return None
+
+        _LOGGER.debug(
+            "Climate debug: hvac_mode '%s' id=%s onOffStatus=%s machMode=%s -> %s",
+            redact_id(self._attr_unique_id, self._appliance_id),
+            redact_id(self._appliance_id),
+            on_off,
+            mode_val,
+            mode,
+        )
+        return mode
 
     @property
     def target_temperature(self) -> float | None:
@@ -249,7 +270,12 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
     def fan_mode(self) -> str | None:
         """Return the fan speed based on the reversed map."""
         val = str(self._get_attr(AC_ATTR_FAN_SPEED, "0"))
-        fan = AC_FAN_MAP.get(val, "auto")
+        # No default: an unmapped raw value, or one outside the advertised fan_modes,
+        # must report unknown (None) rather than a guessed speed HA would reject.
+        fan = AC_FAN_MAP.get(val)
+        if fan is None or fan not in (self._attr_fan_modes or []):
+            _LOGGER.debug("Climate debug: fan_mode raw=%s not advertised -> None", val)
+            return None
         _LOGGER.debug("Climate debug: fan_mode raw=%s -> %s", val, fan)
         return fan
 

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -63,6 +63,11 @@ SERVICE_SET_MQTT_LOG_LEVEL = "set_mqtt_log_level"
 SERVICE_SET_LOG_LEVEL = "set_log_level"
 ATTR_LEVEL = "level"
 
+# Domain-wide service that forces an immediate cloud poll for ALL loaded config
+# entries: the automation-callable equivalent of the per-device "Refresh now"
+# button. Global to the domain (no target, no fields), registered once.
+SERVICE_REFRESH = "refresh"
+
 # Option keys (entry.options) of the two debug toggles exposed in the
 # Configure/Options screen of the integration. They persist across restarts and
 # are applied on the fly (see _apply_debug_options in __init__). enable_debug ->

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.3.0"
+  "version": "5.4.0"
 }

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
             continue
         if HonProgramSelect.supports_appliance(appliance):
             entities.append(HonProgramSelect(coordinator, appliance_id, client))
-            _LOGGER.info("Added program select: %s", data.get("name"))
+            _LOGGER.info("Added program select: id=%s", redact_id(appliance_id))
         else:
             _LOGGER.debug(
                 "Select debug: no program select for '%s' id=%s; "

--- a/custom_components/addhon/services.yaml
+++ b/custom_components/addhon/services.yaml
@@ -1,3 +1,5 @@
+refresh:
+
 set_log_level:
   fields:
     level:

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -102,7 +102,7 @@ async def async_setup_entry(
                 if "pauseProgram" in cmds and "resumeProgram" in cmds:
                     _LOGGER.debug("Switch debug: creating pause switch for id=%s", redact_id(appliance_id))
                     entities.append(HonWashingMachinePauseSwitch(coordinator, appliance_id, client))
-                    _LOGGER.info("Added switch: %s", data.get("name"))
+                    _LOGGER.info("Added pause switch: id=%s", redact_id(appliance_id))
                 else:
                     _LOGGER.debug(
                         "Switch debug: pause switch not created for id=%s; pause/resume missing",

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -72,6 +72,10 @@
     }
   },
   "services": {
+    "refresh": {
+      "name": "Refresh now",
+      "description": "Force an immediate cloud poll for all configured hOn accounts. The automation-callable equivalent of the per-device \"Refresh now\" button: it asks every loaded coordinator to fetch fresh data right away, instead of waiting for the next scheduled poll. Takes no options and applies to the whole integration."
+    },
     "set_log_level": {
       "name": "Set diagnostic log level",
       "description": "Change the log level of the Haier hOn integration and the native hOn client loggers used to diagnose login, device discovery, reauth and polling. Use \"debug\" when devices do not appear, then return to \"warning\" to reduce noise. Does not enable MQTT realtime noise: for that use the dedicated set_mqtt_log_level service.",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -72,6 +72,10 @@
     }
   },
   "services": {
+    "refresh": {
+      "name": "Aggiorna ora",
+      "description": "Forza un polling immediato dal cloud per tutti gli account hOn configurati. L'equivalente richiamabile da automazione del pulsante \"Aggiorna ora\" per dispositivo: chiede a ogni coordinator caricato di recuperare subito i dati aggiornati, senza attendere il prossimo polling pianificato. Non richiede opzioni e si applica all'intera integrazione."
+    },
     "set_log_level": {
       "name": "Imposta livello log diagnostico",
       "description": "Cambia il livello di log dell'integrazione Haier hOn e dei logger del client hOn nativo utili a diagnosticare login, discovery dispositivi, reauth e polling. Usa \"debug\" quando i dispositivi non appaiono, poi torna a \"warning\" per ridurre il rumore. Non abilita il rumore MQTT realtime: per quello usa il service dedicato set_mqtt_log_level.",

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -538,6 +538,17 @@ class AcClimateReadPathTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(HVACMode.OFF, entity.hvac_mode)
 
+    async def test_hvac_mode_missing_machmode_returns_none(self) -> None:
+        # Powered on (onOffStatus=1) but settings.machMode is ABSENT entirely: report
+        # unknown (None), not a guessed COOL. This is the separate branch from the
+        # unmapped/non-advertised cases -- the old code defaulted a missing machMode to
+        # "1" (COOL).
+        entity, _, _ = _climate(
+            {"machMode": Param("1", values=["0", "1", "2", "4", "6"])},
+            attributes={"settings.onOffStatus": "1"},  # no settings.machMode
+        )
+        self.assertIsNone(entity.hvac_mode)
+
     async def test_fan_mode_valid_returns_speed(self) -> None:
         entity, _, _ = _climate(
             {"windSpeed": Param("5", values=["5", "3", "2", "1"])},

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -498,6 +498,72 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(0, settings.send_calls)
 
 
+class AcClimateReadPathTest(unittest.IsolatedAsyncioTestCase):
+    """hvac_mode / fan_mode read semantics: never report a value outside the
+    advertised capability list (HA logs 'is not a valid option' and ignores it).
+    A current value that is unmapped, or mapped but not advertised, -> None.
+    """
+
+    async def test_hvac_mode_valid_mapped_and_advertised(self) -> None:
+        entity, _, _ = _climate(
+            {"machMode": Param("1", values=["0", "1", "2", "4", "6"])},
+            attributes={"settings.onOffStatus": "1", "settings.machMode": "1"},
+        )
+        self.assertEqual(HVACMode.COOL, entity.hvac_mode)
+
+    async def test_hvac_mode_unmapped_raw_returns_none(self) -> None:
+        # Cloud reports a machMode code not in AC_MODE_MAP (e.g. "3"): report
+        # unknown instead of guessing COOL (which HA would then reject).
+        entity, _, _ = _climate(
+            {"machMode": Param("1", values=["0", "1", "2", "4", "6"])},
+            attributes={"settings.onOffStatus": "1", "settings.machMode": "3"},
+        )
+        self.assertIsNone(entity.hvac_mode)
+
+    async def test_hvac_mode_mapped_but_not_advertised_returns_none(self) -> None:
+        # Device exposes only AUTO+DRY; a current machMode of "1" (cool) is mapped
+        # but is NOT in the advertised list -> None (no HA "not a valid option").
+        entity, _, _ = _climate(
+            {"machMode": Param("0", values=["0", "2"])},
+            attributes={"settings.onOffStatus": "1", "settings.machMode": "1"},
+        )
+        self.assertNotIn(HVACMode.COOL, entity._attr_hvac_modes)
+        self.assertIsNone(entity.hvac_mode)
+
+    async def test_hvac_mode_off_wins_over_unmapped(self) -> None:
+        # onOffStatus=0 -> OFF regardless of an unmapped machMode.
+        entity, _, _ = _climate(
+            {"machMode": Param("1", values=["0", "1"])},
+            attributes={"settings.onOffStatus": "0", "settings.machMode": "3"},
+        )
+        self.assertEqual(HVACMode.OFF, entity.hvac_mode)
+
+    async def test_fan_mode_valid_returns_speed(self) -> None:
+        entity, _, _ = _climate(
+            {"windSpeed": Param("5", values=["5", "3", "2", "1"])},
+            attributes={"settings.windSpeed": "3"},
+        )
+        self.assertEqual("low", entity.fan_mode)
+
+    async def test_fan_mode_unmapped_raw_returns_none(self) -> None:
+        # windSpeed "0" is not in AC_FAN_MAP -> None instead of guessing "auto".
+        entity, _, _ = _climate(
+            {"windSpeed": Param("5", values=["5", "3", "2", "1"])},
+            attributes={"settings.windSpeed": "0"},
+        )
+        self.assertIsNone(entity.fan_mode)
+
+    async def test_fan_mode_mapped_but_not_advertised_returns_none(self) -> None:
+        # Device exposes only auto+high; a current "3" (low) is mapped but not
+        # advertised -> None.
+        entity, _, _ = _climate(
+            {"windSpeed": Param("5", values=["5", "1"])},
+            attributes={"settings.windSpeed": "3"},
+        )
+        self.assertNotIn("low", entity._attr_fan_modes)
+        self.assertIsNone(entity.fan_mode)
+
+
 class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
     """switch.HonAcSwitch send semantics."""
 

--- a/tests/test_client_str_to_float.py
+++ b/tests/test_client_str_to_float.py
@@ -24,6 +24,63 @@ def _load(path: Path, name: str):
     return module
 
 
+class ParseCloudTimestampTest(unittest.TestCase):
+    """parse_cloud_timestamp must turn the two cloud time shapes into the SAME
+    comparable tz-aware UTC datetime and degrade gracefully (None) on bad input -- it
+    runs in connectivity reconciliation and on the awscrt callback thread, neither of
+    which may raise. The real cloud emits a VARIABLE number of fractional digits."""
+
+    def setUp(self) -> None:
+        self.parse = _load(_OUR_HELPER, "addhon_client_helpers2").parse_cloud_timestamp
+
+    def test_iso_and_epoch_ms_same_instant(self) -> None:
+        # The real diagnostics lastConnEvent: instantTime and timestampEvent are the SAME
+        # instant in the two shapes -> must parse equal.
+        a = self.parse("2026-06-25T13:35:13Z")
+        b = self.parse(1782394513133)
+        self.assertIsNotNone(a)
+        self.assertIsNotNone(b)
+        # within a second (timestampEvent has ms precision, instantTime is to the second)
+        self.assertLess(abs((a - b).total_seconds()), 1.0)
+
+    def test_variable_fractional_digits(self) -> None:
+        # The realtime payload timestamp has a SINGLE fractional digit ("...21.1Z").
+        ts = self.parse("2026-06-25T16:04:21.1Z")
+        self.assertIsNotNone(ts)
+        self.assertEqual(ts.isoformat(), "2026-06-25T16:04:21.100000+00:00")
+
+    def test_numeric_string_epoch(self) -> None:
+        self.assertEqual(
+            self.parse("1782394513133"), self.parse(1782394513133)
+        )
+
+    def test_result_is_tz_aware_utc(self) -> None:
+        self.assertIsNotNone(self.parse("2026-06-25T13:35:13Z").tzinfo)
+        # A naive ISO (no offset) is assumed UTC (the cloud stamps UTC).
+        self.assertEqual(
+            self.parse("2026-06-25T13:35:13"),
+            self.parse("2026-06-25T13:35:13Z"),
+        )
+
+    def test_ordering_iso_vs_epoch(self) -> None:
+        older = self.parse(1782394513133)            # 13:35:13
+        newer = self.parse("2026-06-25T16:04:21.1Z")  # 16:04
+        self.assertLess(older, newer)
+
+    def test_bad_input_returns_none(self) -> None:
+        for bad in (None, "", "   ", "garbage", "not-a-date", [], {}, True, False, object()):
+            self.assertIsNone(self.parse(bad), f"expected None for {bad!r}")
+
+    def test_total_never_raises_on_extreme_numbers(self) -> None:
+        # Totality contract: even an arbitrary-precision int (e.g. from json.loads) or an
+        # out-of-range/NaN float must return None, never raise -- the function runs on the
+        # awscrt callback thread and in the per-appliance setup loop, where an OverflowError
+        # (ArithmeticError, not ValueError) would escape the boundary catch.
+        for extreme in (10 ** 400, -(10 ** 400), 1e308, -1e308, float("inf"),
+                        float("-inf"), float("nan")):
+            self.assertIsNone(self.parse(extreme), f"expected None for {extreme!r}")
+
+
 class StrToFloatCharacterizationTest(unittest.TestCase):
     def setUp(self) -> None:
         self.ours = _load(_OUR_HELPER, "addhon_client_helpers").str_to_float

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -101,7 +101,9 @@ class CoordinatorConfigEntryTest(unittest.TestCase):
             "the coordinator debug summary 'id' (= MAC/serial) must be redacted",
         )
         self.assertNotIn('"id": appliance_id,', source)
-        self.assertIn("from .debug_utils import redact_mac", source)
+        # Robust to import ordering / extra co-imports (e.g. redact_id added for the
+        # INFO privacy-log fixes): only require redact_mac to be imported here.
+        self.assertRegex(source, r"from \.debug_utils import [^\n]*\bredact_mac\b")
 
     def test_coordinator_summary_redacts_mac_ast(self) -> None:
         # Robust (decoy/whitespace-proof) version of the guard above: AST-parse the

--- a/tests/test_engine_appliance_root.py
+++ b/tests/test_engine_appliance_root.py
@@ -315,7 +315,7 @@ class RealtimeReconciliationTest(unittest.TestCase):
         # NOT stay online forever while the cloud's lastConnEvent is frozen at an old
         # disconnect. Once the last realtime message ages past _REALTIME_LIVENESS_TTL, the
         # stale disconnect is honored -> offline (recovers a dead device within the window).
-        from datetime import datetime, timedelta
+        from time import monotonic
 
         app = self._build(
             [self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)] * 2
@@ -323,11 +323,9 @@ class RealtimeReconciliationTest(unittest.TestCase):
         app.mark_realtime_seen(self._REALTIME_ISO)  # cloud ts 16:04 (newer than 13:35)
         _run(app.load_attributes())
         self.assertTrue(app.connection)  # still fresh -> online
-        # Age the LOCAL receipt time past the freshness window (cloud ts unchanged, still
-        # newer than the disconnect): realtime is no longer recent enough to be trusted.
-        app._last_realtime_local = datetime.now() - timedelta(
-            seconds=app._REALTIME_LIVENESS_TTL + 60
-        )
+        # Age the MONOTONIC receipt time past the freshness window (cloud ts unchanged,
+        # still newer than the disconnect): realtime is no longer recent enough to trust.
+        app._last_realtime_local = monotonic() - (app._REALTIME_LIVENESS_TTL + 60)
         _run(app.load_attributes())
         self.assertFalse(app.connection)  # stale realtime -> defer to REST -> offline
         self.assertFalse(app.attributes["available"])

--- a/tests/test_engine_appliance_root.py
+++ b/tests/test_engine_appliance_root.py
@@ -171,6 +171,182 @@ class ConnectivityTest(unittest.TestCase):
         self.assertFalse(app.attributes["available"])
 
 
+class RealtimeReconciliationTest(unittest.TestCase):
+    """Realtime MQTT traffic is authoritative connectivity evidence (the hOn app trusts
+    it): a realtime message marks the appliance available, and the 60s REST poll must NOT
+    clobber that back offline with a STALE `lastConnEvent.category=DISCONNECTED` (older
+    than the realtime traffic). A genuinely NEWER disconnect DOES set it offline
+    (self-correcting). Mirrors the user's washer: disconnect@13:35 < traffic@16:04.
+    """
+
+    # Cloud-stamped times from the real diagnostics dump (washer WM): the REST
+    # lastConnEvent disconnect is ~2.5h OLDER than the realtime stream.
+    _DISCONNECT_ISO = "2026-06-25T13:35:13Z"
+    _DISCONNECT_MS = 1782394513133  # same instant, epoch ms (timestampEvent)
+    _REALTIME_ISO = "2026-06-25T16:04:21.1Z"  # newer; note the single fractional digit
+
+    def _build(self, payloads, type_name="WM"):
+        class _SeqApi(FakeApi):
+            def __init__(self, seq) -> None:
+                self._payloads = list(seq)
+                self._i = 0
+
+            async def load_attributes(self, a):
+                payload = self._payloads[min(self._i, len(self._payloads) - 1)]
+                self._i += 1
+                return payload
+
+        info = dict(_INFO)
+        info["applianceTypeName"] = type_name
+        app = NaRoot(_SeqApi(payloads), json.loads(json.dumps(info)), zone=0)
+        _run(app.load_commands())
+        return app
+
+    @staticmethod
+    def _lce(category, *, ts_ms=None, iso=None):
+        lce = {"category": category}
+        if ts_ms is not None:
+            lce["timestampEvent"] = ts_ms
+        if iso is not None:
+            lce["instantTime"] = iso
+        return {"shadow": {"parameters": {}}, "lastConnEvent": lce}
+
+    def test_realtime_message_marks_available(self) -> None:
+        # (a) A realtime appliancestatus marks a previously-disconnected appliance
+        # available (the engine entry point the MQTT transport calls).
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        _run(app.load_attributes())
+        self.assertFalse(app.connection)  # stale REST disconnect, no realtime yet
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        self.assertTrue(app.connection)
+
+    def test_realtime_marks_available_attr_immediately(self) -> None:
+        # Regression guard: the connectivity binary_sensor (attr_key="available") and the
+        # availability gate read the RAW `available` attribute, NOT `connection` directly,
+        # and `attributes` returns the cached dict without recomputing. So the realtime
+        # mark must flip `available` AT ONCE, not only at the next 60s poll.
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        _run(app.load_attributes())
+        self.assertFalse(app.attributes["available"])
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        self.assertTrue(app.attributes["available"])  # instant, no poll in between
+
+    def test_stale_disconnect_does_not_clobber_realtime(self) -> None:
+        # (b) THE bug: realtime says online (16:04); a subsequent REST poll whose
+        # lastConnEvent is a STALE DISCONNECTED (13:35) must NOT force it offline.
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        self.assertTrue(app.connection)
+        _run(app.load_attributes())  # stale disconnect@13:35 < traffic@16:04
+        self.assertTrue(app.connection)  # stays online
+        self.assertTrue(app.attributes["available"])
+
+    def test_newer_disconnect_does_set_offline(self) -> None:
+        # (c) A genuinely NEWER disconnect (after the last realtime traffic) DOES win ->
+        # offline. Self-correcting: a real later disconnect is honored.
+        # Pick a disconnect strictly AFTER the realtime instant.
+        newer_iso = "2026-06-25T16:10:00Z"
+        app = self._build([self._lce("DISCONNECTED", iso=newer_iso)])
+        app.mark_realtime_seen(self._REALTIME_ISO)  # 16:04
+        self.assertTrue(app.connection)
+        _run(app.load_attributes())  # disconnect@16:10 > traffic@16:04 -> offline
+        self.assertFalse(app.connection)
+        self.assertFalse(app.attributes["available"])
+
+    def test_connected_event_still_online_regardless_of_realtime(self) -> None:
+        # A non-DISCONNECTED REST event is itself positive evidence -> online (unchanged).
+        app = self._build([self._lce("CONNECTED", ts_ms=self._DISCONNECT_MS)])
+        _run(app.load_attributes())
+        self.assertTrue(app.connection)
+
+    def test_missing_disconnect_timestamp_falls_back_to_rest(self) -> None:
+        # Defensive fallback: if the disconnect carries NO usable timestamp we cannot
+        # order it against the realtime traffic, so honor the DISCONNECTED (prior
+        # REST-only behavior) rather than trusting possibly-stale realtime.
+        app = self._build([self._lce("DISCONNECTED")])  # no timestampEvent/instantTime
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        self.assertTrue(app.connection)
+        _run(app.load_attributes())  # no ordering possible -> honor DISCONNECTED
+        self.assertFalse(app.connection)
+
+    def test_realtime_without_timestamp_still_marks_connected_but_no_protection(self) -> None:
+        # A realtime message with a missing/garbage timestamp still marks connected (the
+        # message IS the evidence) but does not record a liveness time, so a later REST
+        # disconnect is honored (cannot assert a bogus ordering).
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        app.mark_realtime_seen(None)  # no usable time
+        self.assertTrue(app.connection)
+        self.assertIsNone(app._last_realtime_ts)
+        _run(app.load_attributes())
+        self.assertFalse(app.connection)  # no protection without a timestamp
+
+    def test_realtime_timestamp_iso_vs_epoch_ms_comparable(self) -> None:
+        # The realtime payload time (ISO) and the lastConnEvent time (epoch ms) are the
+        # SAME clock: a realtime ISO newer than an epoch-ms disconnect protects it.
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        app.mark_realtime_seen(self._REALTIME_ISO)  # ISO, newer
+        _run(app.load_attributes())  # epoch-ms disconnect, older
+        self.assertTrue(app.connection)
+
+    def test_realtime_ts_only_moves_forward(self) -> None:
+        # An out-of-order OLDER realtime message must not rewind the recorded liveness.
+        app = self._build([self._lce("DISCONNECTED", iso="2026-06-25T15:00:00Z")])
+        app.mark_realtime_seen("2026-06-25T16:04:00Z")  # newer first
+        app.mark_realtime_seen("2026-06-25T15:30:00Z")  # older, out of order
+        self.assertEqual(
+            app._last_realtime_ts.isoformat(), "2026-06-25T16:04:00+00:00"
+        )
+        _run(app.load_attributes())  # disconnect@15:00 < kept 16:04 -> online
+        self.assertTrue(app.connection)
+
+    def test_type_agnostic_ac_without_extra(self) -> None:
+        # The fix is not WM-specific: an AC (no per-type layer) is protected too.
+        app = self._build(
+            [self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)], type_name="AC"
+        )
+        self.assertIsNone(app._extra)
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        _run(app.load_attributes())
+        self.assertTrue(app.connection)
+        self.assertTrue(app.attributes["available"])
+
+    def test_silently_dead_appliance_goes_offline_after_ttl(self) -> None:
+        # Stuck-online guard: an appliance that streamed realtime then went SILENT must
+        # NOT stay online forever while the cloud's lastConnEvent is frozen at an old
+        # disconnect. Once the last realtime message ages past _REALTIME_LIVENESS_TTL, the
+        # stale disconnect is honored -> offline (recovers a dead device within the window).
+        from datetime import datetime, timedelta
+
+        app = self._build(
+            [self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)] * 2
+        )
+        app.mark_realtime_seen(self._REALTIME_ISO)  # cloud ts 16:04 (newer than 13:35)
+        _run(app.load_attributes())
+        self.assertTrue(app.connection)  # still fresh -> online
+        # Age the LOCAL receipt time past the freshness window (cloud ts unchanged, still
+        # newer than the disconnect): realtime is no longer recent enough to be trusted.
+        app._last_realtime_local = datetime.now() - timedelta(
+            seconds=app._REALTIME_LIVENESS_TTL + 60
+        )
+        _run(app.load_attributes())
+        self.assertFalse(app.connection)  # stale realtime -> defer to REST -> offline
+        self.assertFalse(app.attributes["available"])
+
+    def test_explicit_disconnect_clears_liveness_no_resurrection(self) -> None:
+        # An explicit MQTT `disconnected` clears the realtime marks so a subsequent STALE
+        # REST disconnect (older than the prior traffic) cannot resurrect the appliance.
+        app = self._build([self._lce("DISCONNECTED", ts_ms=self._DISCONNECT_MS)])
+        app.mark_realtime_seen(self._REALTIME_ISO)
+        self.assertTrue(app.connection)
+        app.mark_realtime_disconnected()
+        self.assertFalse(app.connection)
+        self.assertFalse(app.attributes["available"])
+        self.assertIsNone(app._last_realtime_ts)
+        self.assertIsNone(app._last_realtime_local)
+        _run(app.load_attributes())  # stale disconnect@13:35, no liveness left
+        self.assertFalse(app.connection)  # NOT resurrected
+
+
 class RootGoldenTest(unittest.TestCase):
     def test_native_root_matches_golden(self) -> None:
         snap = _native_snapshot()

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -502,7 +502,17 @@ class RealtimeWiringSourceGuard(unittest.TestCase):
         # The realtime publish must use the snapshot, not async_request_refresh
         # (which would re-trigger the slow HTTP poll on every push).
         self.assertIn("build_realtime_snapshot", src)
-        self.assertNotIn("async_request_refresh", src)
+        # Scope the no-repoll guard to the realtime push wiring only: the
+        # domain-wide addhon.refresh service legitimately calls
+        # async_request_refresh elsewhere (the explicit "Refresh now" path), so a
+        # whole-file ban would be a false positive. The region is from the
+        # _publish_realtime definition up to the unload detachment that closes the
+        # realtime wiring -- exactly the push path that must never re-poll.
+        start = src.index("def _publish_realtime")
+        end = src.index("subscribe_updates(None)", start)
+        push_region = src[start:end]
+        self.assertIn("async_set_updated_data", push_region)
+        self.assertNotIn("async_request_refresh", push_region)
 
     def test_hon_client_exposes_realtime_api(self) -> None:
         src = (self._COMPONENT / "hon_client.py").read_text(encoding="utf-8")

--- a/tests/test_legacy_cleanup.py
+++ b/tests/test_legacy_cleanup.py
@@ -128,6 +128,30 @@ class LegacyCleanupTest(unittest.TestCase):
         )
         self.assertEqual(removed, [])
 
+    def test_legacy_power_removal_log_redacts_identity(self) -> None:
+        # Privacy: the INFO removal log must carry the redacted id, never the
+        # entity_id (whose object_id is the nickname slug). INFO is not gated by
+        # the debug toggles, so it always reaches home-assistant.log.
+        with self.assertLogs("custom_components.addhon", level="INFO") as logs:
+            removed = _run([FakeRegEntry("switch.foo_power", "ID_power")])
+        self.assertEqual(removed, ["switch.foo_power"])
+        blob = "\n".join(logs.output)
+        self.assertIn("id=***", blob)
+        self.assertNotIn("foo_power", blob)
+        self.assertNotIn("ID_power", blob)
+
+    def test_td_orphan_removal_log_redacts_identity(self) -> None:
+        with self.assertLogs("custom_components.addhon", level="INFO") as logs:
+            removed = _run(
+                [FakeRegEntry("sensor.td_total_water", "tdid_total_water")],
+                coord_data={"tdid": {"type": "TD"}},
+            )
+        self.assertEqual(removed, ["sensor.td_total_water"])
+        blob = "\n".join(logs.output)
+        self.assertIn("id=***", blob)
+        self.assertNotIn("td_total_water", blob)
+        self.assertNotIn("tdid", blob)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -12,6 +12,14 @@ entity-layer + diagnostics + mqtt logs (all simple `%s, <ref>` forms). It delibe
 does NOT cover hon_client.py, whose identity passes through helper calls and f-strings
 (`_get_name(a)`, `f"name={...}"`) that a top-level check can't reason about; those are
 covered behaviorally by test_hon_client_realtime.DiscoveryLogRedactionTest.
+
+Beyond bare Name/Attribute refs, a second check (`_identity_call_offender`) forbids the
+appliance NAME/NICKNAME being resolved inline for a NON-gated log: `<x>.get("name")` /
+`_get_name(...)` passed to `_LOGGER.info/.warning/.error/.exception/.critical`. That is
+the exact leak class found on v5.2.0 (the nickname reached home-assistant.log at INFO,
+which the debug toggles do not gate). The SAME pattern at `_LOGGER.debug` is allowed on
+purpose (debug is gated), so this check is level-aware and skips `.debug`. A redacted
+form `redact_id(_get_name(a))` is a `redact_*` Call at the top level and is not flagged.
 """
 from __future__ import annotations
 
@@ -22,6 +30,11 @@ from pathlib import Path
 COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "addhon"
 
 _LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical", "log"}
+
+# Dict keys / helpers that resolve the appliance nickname (identity). _get_name()
+# in hon_client.py prefers nick_name/nickName, and coordinator data["name"] is that
+# same nickname; logging either in clear at a non-gated level is a leak.
+_IDENTITY_GET_KEYS = frozenset({"name", "nick_name", "nickName", "nickname"})
 
 # Entity layer: the appliance id (MAC/serial/code), the entity unique_id, and the
 # raw device-identity attributes a future log line might reach for directly.
@@ -34,6 +47,7 @@ _ENTITY_ATTRS = frozenset(
         "serial_number",
         "_serial",
         "nick_name",
+        "nickName",  # camelCase sibling of nick_name (_get_name reads both via getattr)
     }
 )
 
@@ -47,6 +61,14 @@ _FILES = {
     "sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "binary_sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "climate.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    # Setup orchestration: the legacy-entity cleanup logs a registry entry's
+    # entity_id (object_id = nickname slug) / unique_id (MAC-derived). They must go
+    # through redact_id(...). The 2026-06-25 INFO leak was a bare reg_entry.entity_id
+    # here; this registration (absent before) gives forward protection.
+    "__init__.py": (
+        _ENTITY_NAMES,
+        _ENTITY_ATTRS | frozenset({"entity_id", "unique_id"}),
+    ),
     "diagnostics.py": (frozenset({"appliance_id"}), frozenset()),
     # Setup orchestration: the raw cloud appliance dict (CR#2 malformed-appliance
     # log). It must never be passed bare to _LOGGER -- key-name redaction cannot mask
@@ -126,6 +148,30 @@ def _dict_dump_offender(arg: ast.AST) -> str | None:
     return None
 
 
+def _identity_call_offender(arg: ast.AST) -> str | None:
+    """Label the arg if it resolves the appliance NAME/NICKNAME inline, else None.
+
+    Catches `<x>.get("name"|"nick_name"|...)` and `_get_name(...)` -- the nickname
+    leak class. The caller applies this ONLY to non-gated logs (everything but
+    `_LOGGER.debug`): the nickname in clear is acceptable at DEBUG (gated by the
+    toggles) but not at INFO+ (always in home-assistant.log). A redacted form like
+    `redact_id(_get_name(a))` has `redact_id(...)` as its TOP-LEVEL node, so it is
+    not flagged (only the outermost call is inspected, as everywhere in this guard)."""
+    if not isinstance(arg, ast.Call):
+        return None
+    if isinstance(arg.func, ast.Name) and arg.func.id == "_get_name":
+        return "_get_name(...)"
+    if (
+        isinstance(arg.func, ast.Attribute)
+        and arg.func.attr == "get"
+        and arg.args
+        and isinstance(arg.args[0], ast.Constant)
+        and arg.args[0].value in _IDENTITY_GET_KEYS
+    ):
+        return f'.get("{arg.args[0].value}")'
+    return None
+
+
 class LogIdentityRedactionTest(unittest.TestCase):
     def test_no_raw_identity_in_logger_calls(self) -> None:
         offenders: list[str] = []
@@ -136,8 +182,14 @@ class LogIdentityRedactionTest(unittest.TestCase):
             for node in ast.walk(tree):
                 if not _is_logger_call(node):
                     continue
+                # Nickname in clear is allowed at DEBUG (gated by the toggles), not at
+                # INFO+ (always written). The bare Name/Attr and dict-dump checks apply
+                # at every level (a raw id must never be logged, even at debug).
+                gated = node.func.attr == "debug"
                 for arg in node.args:
                     label = _bare_offender(arg, names, attrs) or _dict_dump_offender(arg)
+                    if not label and not gated:
+                        label = _identity_call_offender(arg)
                     if label:
                         offenders.append(f"{rel}:{node.lineno}: raw {label}")
         self.assertEqual(
@@ -168,6 +220,28 @@ class LogIdentityRedactionTest(unittest.TestCase):
         self.assertIsNone(_dict_dump_offender(safe.args[1]))
         literal = ast.parse('_LOGGER.debug("x %s", {"k": v})').body[0].value
         self.assertIsNone(_dict_dump_offender(literal.args[1]))
+
+    def test_guard_detects_identity_call_leak(self) -> None:
+        # Meta: the nickname-resolving call class is caught, while a redacted form,
+        # a non-identity key, and a non-call arg are not.
+        get_leak = ast.parse('_LOGGER.info("x %s", data.get("name"))').body[0].value
+        self.assertEqual(_identity_call_offender(get_leak.args[1]), '.get("name")')
+        nick_leak = ast.parse('_LOGGER.warning("x %s", a.get("nick_name"))').body[0].value
+        self.assertEqual(_identity_call_offender(nick_leak.args[1]), '.get("nick_name")')
+        fn_leak = ast.parse('_LOGGER.error("x %s", _get_name(a))').body[0].value
+        self.assertEqual(_identity_call_offender(fn_leak.args[1]), "_get_name(...)")
+        safe = ast.parse('_LOGGER.info("x %s", redact_id(_get_name(a)))').body[0].value
+        self.assertIsNone(_identity_call_offender(safe.args[1]))
+        benign = ast.parse('_LOGGER.info("x %s", d.get("count"))').body[0].value
+        self.assertIsNone(_identity_call_offender(benign.args[1]))
+
+    def test_nickname_call_allowed_at_debug_not_at_info(self) -> None:
+        # Meta: the level gate. The SAME data.get("name") arg is a leak at INFO but
+        # allowed at DEBUG (gated). Mirrors the loop's `gated = attr == "debug"`.
+        for method, gated in (("debug", True), ("info", False), ("warning", False)):
+            call = ast.parse(f'_LOGGER.{method}("x %s", data.get("name"))').body[0].value
+            flagged = (not gated) and _identity_call_offender(call.args[1]) is not None
+            self.assertEqual(flagged, not gated, f"method={method}")
 
 
 if __name__ == "__main__":

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -761,6 +761,36 @@ class DiagnosticsTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("person", diagnostics["entry"]["title"])
 
 
+class SelectLoggingTest(unittest.IsolatedAsyncioTestCase):
+    async def test_added_select_log_redacts_identity(self) -> None:
+        # Privacy: the INFO "Added program select" log must carry the redacted id,
+        # never the appliance nickname (INFO is not gated by the debug toggles, so
+        # it always lands in home-assistant.log and gets attached to public issues).
+        from custom_components.addhon import select
+        from custom_components.addhon.const import DOMAIN
+
+        commands = {
+            "startProgram": RecordingCommand(
+                {"program": Param(values={"1": "Cotone", "2": "Sintetici"})}
+            )
+        }
+        coordinator = FakeCoordinator(_washer(commands))
+        hass = FakeHass(
+            {DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}}
+        )
+        added: list = []
+
+        with self.assertLogs(select._LOGGER.name, level="INFO") as logs:
+            await select.async_setup_entry(hass, FakeEntry(), added.extend)
+
+        added = [e for e in added if not getattr(e, "_addhon_account", False)]
+        self.assertEqual(1, len(added))
+        blob = "\n".join(logs.output)
+        self.assertIn("Added program select: id=***", blob)
+        self.assertNotIn("Washer", blob)
+        self.assertNotIn("washer-1", blob)
+
+
 class SwitchLoggingTest(unittest.IsolatedAsyncioTestCase):
     async def test_added_switch_log_only_emitted_when_entity_is_created(self) -> None:
         from custom_components.addhon import switch
@@ -795,7 +825,12 @@ class SwitchLoggingTest(unittest.IsolatedAsyncioTestCase):
 
         added = [e for e in added if not getattr(e, "_addhon_account", False)]
         self.assertEqual(1, len(added))
-        self.assertIn("Added switch: Washer", "\n".join(logs.output))
+        # Privacy: the INFO "added" log must carry the redacted id, never the
+        # nickname (it lands in home-assistant.log even with debug off).
+        blob = "\n".join(logs.output)
+        self.assertIn("Added pause switch: id=***", blob)
+        self.assertNotIn("Washer", blob)
+        self.assertNotIn("washer-1", blob)
 
 
 class DebugLoggingGuardTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_refresh_service.py
+++ b/tests/test_refresh_service.py
@@ -1,0 +1,310 @@
+"""Tests for the domain-wide ``addhon.refresh`` service.
+
+The service forces an immediate cloud poll on every loaded config entry: the
+automation-callable equivalent of the per-device "Refresh now" button (asked for
+in discussion #34). It is global to the domain (registered once, removed on the
+last unload), takes no fields and no target, isolates per-entry failures and must
+never re-raise to the caller.
+
+Like test_debug_panel, this uses stdlib unittest with hand-rolled HA stubs so no
+real Home Assistant is required. ``FakeHass`` here gains a minimal services
+registry (the debug-panel one has none): it records the registered handlers keyed
+by ``(domain, name)`` and supports ``has_service`` / ``async_register`` /
+``async_remove`` -- exactly what ``_async_register_services`` and
+``async_unload_entry`` touch. A source-level wiring guard mirrors
+test_mqtt_log_level.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    """Minimal HA stubs needed to import custom_components.addhon (the package).
+
+    Tolerant ``getattr`` defaults mean the first test module that wins the shared
+    ``sys.modules`` race keeps its richer stub; we only fill the gaps so importing
+    ``__init__`` works under this module in isolation too.
+    """
+    ha = _mod("homeassistant")
+
+    config_entries = _mod("homeassistant.config_entries")
+    config_entries.ConfigEntry = getattr(
+        config_entries, "ConfigEntry", type("ConfigEntry", (), {})
+    )
+
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    core.ServiceCall = getattr(core, "ServiceCall", type("ServiceCall", (), {}))
+    if not hasattr(core, "callback"):
+        core.callback = lambda func: func
+
+    exceptions = _mod("homeassistant.exceptions")
+    base_err = getattr(
+        exceptions, "HomeAssistantError", type("HomeAssistantError", (Exception,), {})
+    )
+    exceptions.HomeAssistantError = base_err
+    exceptions.ConfigEntryNotReady = getattr(
+        exceptions, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {})
+    )
+    exceptions.ConfigEntryAuthFailed = getattr(
+        exceptions, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {})
+    )
+
+    helpers = _mod("homeassistant.helpers")
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(
+        uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {})
+    )
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+
+    ha.config_entries = config_entries
+    ha.core = core
+    ha.exceptions = exceptions
+    ha.helpers = helpers
+    helpers.update_coordinator = uc
+
+    # voluptuous is imported lazily inside _async_register_services (to build the
+    # level schema of the OTHER two services). It is not a test dependency, so
+    # stub it when absent -- the refresh service itself takes no schema.
+    vol = sys.modules.get("voluptuous")
+    if vol is None or not hasattr(vol, "Marker"):
+        vol = _mod("voluptuous")
+        vol.Schema = lambda schema=None, **kwargs: schema
+
+        class _Marker:
+            def __init__(self, key, *args, **kwargs):
+                self.key = key
+                self.default = kwargs.get("default")
+
+        vol.Required = _Marker
+        vol.Optional = _Marker
+        vol.In = lambda container=None, *args, **kwargs: container
+
+
+_install_stubs()
+
+from custom_components.addhon import _async_register_services  # noqa: E402
+from custom_components.addhon.const import (  # noqa: E402
+    DOMAIN,
+    SERVICE_REFRESH,
+    SERVICE_SET_LOG_LEVEL,
+    SERVICE_SET_MQTT_LOG_LEVEL,
+)
+
+COMPONENT = REPO_ROOT / "custom_components" / "addhon"
+INIT = COMPONENT / "__init__.py"
+CONST = COMPONENT / "const.py"
+SERVICES = COMPONENT / "services.yaml"
+
+
+class FakeServices:
+    """Minimal HA services registry: records handlers keyed by (domain, name)."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[tuple[str, str], object] = {}
+
+    def has_service(self, domain: str, name: str) -> bool:
+        return (domain, name) in self.handlers
+
+    def async_register(self, domain, name, handler, schema=None) -> None:
+        self.handlers[(domain, name)] = handler
+
+    def async_remove(self, domain, name) -> None:
+        self.handlers.pop((domain, name), None)
+
+
+class FakeHass:
+    def __init__(self, data=None) -> None:
+        self.data = data or {}
+        self.services = FakeServices()
+
+
+class FakeCoordinator:
+    def __init__(self) -> None:
+        self.refreshes = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refreshes += 1
+
+
+class RaisingCoordinator:
+    def __init__(self) -> None:
+        self.refreshes = 0
+
+    async def async_request_refresh(self) -> None:
+        self.refreshes += 1
+        raise RuntimeError("boom")
+
+
+class SyncRaisingCoordinator:
+    """async_request_refresh raises SYNCHRONOUSLY (not async) when called -- i.e.
+    before yielding a coroutine. The handler wraps the call inside a coroutine so even
+    this is captured by gather(return_exceptions=True) rather than escaping to the
+    caller and aborting the other refreshes."""
+
+    def async_request_refresh(self):
+        raise RuntimeError("sync boom")
+
+
+class FakeServiceCall:
+    """A trivial ServiceCall: the refresh handler ignores ``data`` entirely."""
+
+    def __init__(self) -> None:
+        self.data: dict = {}
+
+
+def _entry_data(coordinator, entry_id: str) -> dict:
+    return {
+        entry_id: {
+            "coordinator": coordinator,
+            "client": None,
+            "integration_version": "9.9.9",
+        }
+    }
+
+
+class RefreshServiceRegistrationTest(unittest.TestCase):
+    def test_register_adds_refresh_service_without_schema(self) -> None:
+        hass = FakeHass()
+        _async_register_services(hass)
+        self.assertTrue(hass.services.has_service(DOMAIN, SERVICE_REFRESH))
+        # All three domain-wide services land in the same registry.
+        self.assertTrue(hass.services.has_service(DOMAIN, SERVICE_SET_LOG_LEVEL))
+        self.assertTrue(hass.services.has_service(DOMAIN, SERVICE_SET_MQTT_LOG_LEVEL))
+
+    def test_registration_is_idempotent(self) -> None:
+        hass = FakeHass()
+        _async_register_services(hass)
+        first = hass.services.handlers[(DOMAIN, SERVICE_REFRESH)]
+        # A second call (e.g. a second entry's setup) must not re-register / replace.
+        _async_register_services(hass)
+        self.assertIs(first, hass.services.handlers[(DOMAIN, SERVICE_REFRESH)])
+
+    def test_registers_refresh_when_only_it_is_missing(self) -> None:
+        # The combined early-return guard must still register refresh if the other
+        # two already exist (e.g. an upgrade from a build that lacked refresh).
+        hass = FakeHass()
+        hass.services.handlers[(DOMAIN, SERVICE_SET_MQTT_LOG_LEVEL)] = object()
+        hass.services.handlers[(DOMAIN, SERVICE_SET_LOG_LEVEL)] = object()
+        _async_register_services(hass)
+        self.assertTrue(hass.services.has_service(DOMAIN, SERVICE_REFRESH))
+
+
+class RefreshServiceBehaviorTest(unittest.IsolatedAsyncioTestCase):
+    def _registered_handler(self, hass: FakeHass):
+        return hass.services.handlers[(DOMAIN, SERVICE_REFRESH)]
+
+    async def test_refreshes_every_loaded_coordinator(self) -> None:
+        hass = FakeHass()
+        _async_register_services(hass)
+        coord_a, coord_b = FakeCoordinator(), FakeCoordinator()
+        hass.data[DOMAIN] = {}
+        hass.data[DOMAIN].update(_entry_data(coord_a, "entry-a"))
+        hass.data[DOMAIN].update(_entry_data(coord_b, "entry-b"))
+
+        await self._registered_handler(hass)(FakeServiceCall())
+
+        self.assertEqual(1, coord_a.refreshes)
+        self.assertEqual(1, coord_b.refreshes)
+
+    async def test_per_entry_failure_is_isolated(self) -> None:
+        hass = FakeHass()
+        _async_register_services(hass)
+        good, bad = FakeCoordinator(), RaisingCoordinator()
+        hass.data[DOMAIN] = {}
+        hass.data[DOMAIN].update(_entry_data(bad, "entry-bad"))
+        hass.data[DOMAIN].update(_entry_data(good, "entry-good"))
+
+        # Must NOT raise even though one coordinator blows up.
+        await self._registered_handler(hass)(FakeServiceCall())
+
+        self.assertEqual(1, bad.refreshes)
+        self.assertEqual(1, good.refreshes)
+
+    async def test_synchronous_raise_is_isolated(self) -> None:
+        # A coordinator whose async_request_refresh raises SYNCHRONOUSLY (before
+        # returning a coroutine) must not abort the others nor reach the caller: the
+        # handler wraps each call in a coroutine so gather(return_exceptions=True)
+        # captures it.
+        hass = FakeHass()
+        _async_register_services(hass)
+        good, bad = FakeCoordinator(), SyncRaisingCoordinator()
+        hass.data[DOMAIN] = {}
+        hass.data[DOMAIN].update(_entry_data(bad, "entry-bad"))
+        hass.data[DOMAIN].update(_entry_data(good, "entry-good"))
+
+        # Must NOT raise even though one coordinator raises synchronously.
+        await self._registered_handler(hass)(FakeServiceCall())
+
+        self.assertEqual(1, good.refreshes)
+
+    async def test_skips_none_coordinators_and_no_data(self) -> None:
+        hass = FakeHass()
+        _async_register_services(hass)
+        handler = self._registered_handler(hass)
+
+        # No DOMAIN bucket at all: a no-op, no raise.
+        await handler(FakeServiceCall())
+
+        # An entry mid-setup may have a None coordinator; it must be skipped.
+        good = FakeCoordinator()
+        hass.data[DOMAIN] = {
+            "entry-partial": {"coordinator": None, "client": None},
+            "entry-good": {"coordinator": good, "client": None},
+        }
+        await handler(FakeServiceCall())
+        self.assertEqual(1, good.refreshes)
+
+    async def test_reads_hass_data_live_at_call_time(self) -> None:
+        # The handler captures ``hass`` but must enumerate coordinators at call
+        # time, so an entry added AFTER registration is still refreshed.
+        hass = FakeHass()
+        _async_register_services(hass)
+        handler = self._registered_handler(hass)
+
+        late = FakeCoordinator()
+        hass.data[DOMAIN] = _entry_data(late, "entry-late")
+        await handler(FakeServiceCall())
+        self.assertEqual(1, late.refreshes)
+
+
+class RefreshServiceWiringTest(unittest.TestCase):
+    """Source-level guards: the service must stay declared and wired."""
+
+    def test_const_declares_service_name(self) -> None:
+        self.assertIn(
+            'SERVICE_REFRESH = "refresh"',
+            CONST.read_text(encoding="utf-8"),
+        )
+
+    def test_services_yaml_declares_refresh(self) -> None:
+        self.assertIn("refresh:", SERVICES.read_text(encoding="utf-8"))
+
+    def test_init_registers_and_unregisters_refresh(self) -> None:
+        src = INIT.read_text(encoding="utf-8")
+        self.assertIn("SERVICE_REFRESH", src)
+        self.assertIn("async_request_refresh", src)
+        # Debounced refresh like the button, not a forced async_refresh.
+        self.assertNotIn("async_refresh(", src)
+        # Per-entry isolation: gather with return_exceptions, never re-raise.
+        self.assertIn("return_exceptions=True", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -549,10 +549,11 @@ class PublishReceivedTest(unittest.TestCase):
         topic = "$aws/events/presence/connected/myclient"
         app = FakeAppliance(topic)
         app.connection = False  # genuinely offline
-        m, _ = self._client(app)
+        m, hon = self._client(app)
         m._on_publish_received(_packet(topic, {"clientId": "myclient", "eventType": "connected"}))
         self.assertFalse(app.connection)        # not pinned online by our session
         self.assertEqual(app.realtime_seen, [])  # liveness not armed
+        self.assertEqual(hon.notified, 0)        # session presence: no HA state push
 
     def test_session_presence_disconnected_does_not_clobber_live_appliance(self) -> None:
         # `$aws/events/presence/disconnected/<clientId>` is OUR client's session blip; it
@@ -561,10 +562,11 @@ class PublishReceivedTest(unittest.TestCase):
         topic = "$aws/events/presence/disconnected/myclient"
         app = FakeAppliance(topic)
         app.connection = True  # appliance is live (streaming appliancestatus)
-        m, _ = self._client(app)
+        m, hon = self._client(app)
         m._on_publish_received(_packet(topic, {"clientId": "myclient", "eventType": "disconnected"}))
         self.assertTrue(app.connection)          # still live
         self.assertEqual(app.disconnected_calls, 0)  # marks NOT cleared
+        self.assertEqual(hon.notified, 0)        # session presence: no HA state push
 
     def test_connected_does_not_arm_realtime_liveness(self) -> None:
         # The presence "connected" event is OUR client's AWS-IoT session presence, not the

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -1690,6 +1690,26 @@ class _PerTopicFakeClient:
         return fut
 
 
+class _RaisingTopicFakeClient:
+    """A fake awscrt mqtt5 client whose subscribe() future RAISES a NON-timeout exception
+    for `raise_topics` (modelling an awscrt/transport error surfaced on the future), to
+    prove _subscribe_missing isolates more than just the HonCodedError timeout."""
+
+    def __init__(self, raise_topics) -> None:
+        self.raise_topics = set(raise_topics)
+        self.subscribed: list = []
+
+    def subscribe(self, packet):
+        topic = packet[1][0]
+        self.subscribed.append(topic)
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        if topic in self.raise_topics:
+            fut.set_exception(RuntimeError("awscrt subscribe failure"))
+        else:
+            fut.set_result(None)
+        return fut
+
+
 class SubscribeMissingIsolationTest(unittest.TestCase):
     """H1 direct guard: _subscribe_missing must subscribe every topic it CAN, isolating a
     single failing topic instead of aborting the whole pass (the old sequential
@@ -1766,6 +1786,51 @@ class SubscribeMissingIsolationTest(unittest.TestCase):
         blob = "\n".join(cm.output)
         self.assertIn("subscribe failed for one topic, continuing", blob)
         self.assertEqual(m._subscribed_topics_set, {"t/good"})
+
+    def test_non_timeout_exception_is_isolated(self) -> None:
+        # A subscribe failure that is NOT the HonCodedError timeout (e.g. an awscrt
+        # transport error surfaced on the future) must ALSO be isolated, not abort the
+        # pass: otherwise H1 starvation reopens for any non-timeout failure. With the
+        # old `except HonCodedError`-only handler this RuntimeError escaped and starved
+        # t/good2.
+        topics = ["t/good1", "t/raises", "t/good2"]
+        app = MultiTopicAppliance(topics)
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._client = _RaisingTopicFakeClient(raise_topics={"t/raises"})
+        name = "custom_components.addhon.client.transport.mqtt"
+        with self.assertLogs(name, level="WARNING") as cm:
+            _run(m._subscribe_missing())  # must NOT raise out of the loop
+        self.assertIn(
+            "subscribe failed for one topic, continuing", "\n".join(cm.output)
+        )
+        # The other topics still got subscribed; all three were attempted.
+        self.assertEqual(m._subscribed_topics_set, {"t/good1", "t/good2"})
+        self.assertEqual(set(m._client.subscribed), set(topics))
+
+    def test_cancelled_error_propagates(self) -> None:
+        # A CancelledError (stop() cancels the watchdog) must NOT be swallowed as a
+        # per-topic failure: it has to propagate so shutdown is not deadlocked.
+        app = MultiTopicAppliance(["t/x"])
+        m = NativeMqttClient(FakeHon([app]), "MID")
+
+        async def _cancel(_topic):
+            raise asyncio.CancelledError
+
+        m._subscribe_topic = _cancel  # type: ignore[assignment]
+        with self.assertRaises(asyncio.CancelledError):
+            _run(m._subscribe_missing())
+
+        # Forward-protection: today CancelledError propagates because it is
+        # BaseException-derived and `except Exception` cannot catch it, so the behavioral
+        # check above passes with OR without the explicit re-raise. The REAL risk is a
+        # future refactor to `except BaseException`, which WOULD swallow the cancellation
+        # and deadlock stop(). Pin the isolation handler against that: it must catch
+        # `Exception` (not `BaseException`) and keep the explicit CancelledError re-raise.
+        import inspect
+
+        src = inspect.getsource(NativeMqttClient._subscribe_missing)
+        self.assertIn("except asyncio.CancelledError", src)
+        self.assertNotIn("except BaseException", src)
 
 
 class WatchdogPartialMissEscalationTest(unittest.TestCase):

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -250,7 +250,7 @@ class CreatePathTest(unittest.TestCase):
             raise asyncio.TimeoutError("subscribe timeout")
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+        m._subscribe_missing = boom_subscribe  # type: ignore[assignment]
 
         with self.assertRaises(asyncio.TimeoutError):
             _run(m.create())
@@ -279,7 +279,7 @@ class CreatePathTest(unittest.TestCase):
             raise RuntimeError("watchdog boom")
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = ok_subscribe  # type: ignore[assignment]
+        m._subscribe_missing = ok_subscribe  # type: ignore[assignment]
         m._start_watchdog = boom_watchdog  # type: ignore[assignment]
 
         with self.assertRaises(RuntimeError):
@@ -307,7 +307,7 @@ class CreatePathTest(unittest.TestCase):
             raise asyncio.CancelledError
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = cancelled_subscribe  # type: ignore[assignment]
+        m._subscribe_missing = cancelled_subscribe  # type: ignore[assignment]
 
         with self.assertRaises(asyncio.CancelledError):
             _run(m.create())
@@ -334,7 +334,7 @@ class CreatePathTest(unittest.TestCase):
             raise KeyboardInterrupt
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+        m._subscribe_missing = boom_subscribe  # type: ignore[assignment]
 
         with self.assertRaises(KeyboardInterrupt):
             _run(m.create())
@@ -400,7 +400,7 @@ class CreatePathTest(unittest.TestCase):
             raise asyncio.TimeoutError
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = boom_subscribe  # type: ignore[assignment]
+        m._subscribe_missing = boom_subscribe  # type: ignore[assignment]
 
         with self.assertRaises(asyncio.TimeoutError):
             _run(m.create())
@@ -783,18 +783,18 @@ class WatchdogThresholdTest(unittest.TestCase):
         async def fake_sleep(_interval):
             if not seq:
                 raise asyncio.CancelledError
-            # A scripted state is "healthy" (connected + subscribed) or fully "down":
-            # the watchdog now requires BOTH flags to consider a tick healthy, so set
-            # them together to keep this test about the failed-tick/rebuild threshold.
+            # FakeHon([]) has no appliances, so _all_topics() is empty: with the set
+            # model "fully subscribed" reduces to "connected" (no missing topics). A
+            # scripted True is healthy, a scripted False routes to the rebuild path --
+            # which keeps this test about the failed-tick/rebuild threshold.
             state = seq.pop(0)
             m._connection = state
-            m._subscribed = state
 
         async def noop_sub():
             return None
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = noop_sub  # type: ignore[assignment]
+        m._subscribe_missing = noop_sub  # type: ignore[assignment]
         real_sleep = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -963,18 +963,18 @@ class WatchdogResilienceTest(unittest.TestCase):
             intervals.append(interval)
             if not seq:
                 raise asyncio.CancelledError
-            # Healthy = connected AND subscribed (the watchdog now requires both); a
-            # scripted state drives the pair together so this test stays focused on the
-            # rebuild backoff, not the re-subscribe recovery path.
+            # FakeHon([]) -> _all_topics() empty -> "fully subscribed" reduces to
+            # "connected": a scripted True is healthy, a False routes to the rebuild
+            # path. Keeps this test focused on the rebuild backoff, not the re-subscribe
+            # recovery path.
             state = seq.pop(0)
             m._connection = state
-            m._subscribed = state
 
         async def noop_sub():
             return None
 
         m._start = start_fn  # type: ignore[assignment]
-        m._subscribe_appliances = noop_sub  # type: ignore[assignment]
+        m._subscribe_missing = noop_sub  # type: ignore[assignment]
         real = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -1141,27 +1141,36 @@ class SubscribeNonBlockingTest(unittest.TestCase):
             mod._SUBSCRIBE_TIMEOUT = orig
 
 
+_RECOVERY_TOPIC = "haier/things/MAC/event/appliancestatus/update"
+
+
 class WatchdogSubscribedRecoveryTest(unittest.TestCase):
-    """Greptile P1: a single `self._connection` flag conflated 'transport connected'
-    with 'appliance topics subscribed'. The connection-success callback sets
-    _connection=True WITHOUT subscribing, so a rebuild whose _subscribe_appliances()
-    times out (or awscrt's own auto-reconnect on a clean session) left the client
-    connected-but-unsubscribed; the watchdog's `if self._connection:` check then treated
-    it as healthy and never recovered -> realtime pushes silently dead. The fix adds a
-    separate self._subscribed flag and a re-subscribe recovery branch. These tests fail
-    against the pre-fix one-flag watchdog and pass with the fix."""
+    """Greptile P1 + H1: a single `self._connection` flag conflated 'transport
+    connected' with 'appliance topics subscribed'. The connection-success callback sets
+    _connection=True WITHOUT subscribing, so a rebuild whose subscribe times out (or
+    awscrt's own auto-reconnect on a clean session) left the client connected-but-
+    unsubscribed; the watchdog's `if self._connection:` check then treated it as healthy
+    and never recovered -> realtime pushes silently dead. The fix replaces the binary
+    flag with a SET of subscribed topics: the watchdog re-subscribes only the MISSING
+    topics in place, and escalates to a rebuild ONLY on a total blackout (nothing
+    subscribed = dead connection), never on a partial miss (one bad appliance). These
+    tests fail against the pre-fix one-flag watchdog and pass with the fix."""
 
     def _drive(self, scripts, sub_fn=None):
         """Drive the REAL _watchdog over a scripted sequence. Each script entry is a
         (connection, subscribed) pair applied to the instance at the START of a tick
         (i.e. it is the state the awscrt callbacks would have produced before this
-        tick's health check). asyncio.sleep is stubbed to advance the script and end
-        the loop (CancelledError) when it runs out. Returns (resub_calls, rebuilds,
-        m), where `rebuilds` holds the 1-based tick index of each full _start()
+        tick's health check). `subscribed` True means the single target topic is in the
+        set, False means it is missing. asyncio.sleep is stubbed to advance the script
+        and end the loop (CancelledError) when it runs out. Returns (resub_calls,
+        rebuilds, m), where `rebuilds` holds the 1-based tick index of each full _start()
         rebuild (so a test can pin WHEN the rebuild fired, not just that it did)."""
         import custom_components.addhon.client.transport.mqtt as mod
 
-        m = NativeMqttClient(FakeHon([]), "MID")
+        # ONE appliance/topic: _all_topics() == {_RECOVERY_TOPIC}, so "fully subscribed"
+        # is exactly "the topic is in the set". With a single topic, a subscribe failure
+        # is a TOTAL blackout (the escalation trigger); a success fully subscribes.
+        m = NativeMqttClient(FakeHon([FakeAppliance(_RECOVERY_TOPIC)]), "MID")
         seq = list(scripts)
         rebuilds = []
         resub_calls = []
@@ -1169,14 +1178,24 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
 
         async def fake_start():
             rebuilds.append(tick["n"])
-            # The real _start() clears _subscribed (fresh client). Mirror that so a
-            # rebuild that does not re-subscribe is correctly seen as unsubscribed.
-            m._subscribed = False
+            # The real _start() clears the set (fresh client). Mirror that so a rebuild
+            # that does not re-subscribe is correctly seen as unsubscribed.
+            m._subscribed_topics_set = set()
 
         async def counted_sub():
+            # Replaces the real _subscribe_missing(): record the call, then either fail
+            # (sub_fn raises -> leave the topic out of the set = blackout, mirroring the
+            # real method which SWALLOWS a per-topic HonCodedError without adding it and
+            # returns normally) or succeed (add the single target topic).
+            from custom_components.addhon.error_codes import HonCodedError
+
             resub_calls.append(True)
             if sub_fn is not None:
-                await sub_fn()
+                try:
+                    await sub_fn()
+                except HonCodedError:
+                    return  # per-topic failure swallowed, topic stays missing
+            m._subscribed_topics_set = m._subscribed_topics_set | {_RECOVERY_TOPIC}
 
         async def fake_sleep(_interval):
             if not seq:
@@ -1184,10 +1203,10 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
             tick["n"] += 1
             conn, sub = seq.pop(0)
             m._connection = conn
-            m._subscribed = sub
+            m._subscribed_topics_set = {_RECOVERY_TOPIC} if sub else set()
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        m._subscribe_missing = counted_sub  # type: ignore[assignment]
         real_sleep = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -1209,7 +1228,8 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
         resub, rebuilds, m = self._drive([(True, False), (True, False)])
         self.assertEqual(len(resub), 2)        # re-subscribed on each tick
         self.assertEqual(len(rebuilds), 0)     # no full rebuild: transport is up
-        self.assertTrue(m._subscribed)         # recovered to healthy
+        # recovered to fully subscribed (the single target topic is in the set)
+        self.assertEqual(m._subscribed_topics_set, {_RECOVERY_TOPIC})
 
     def test_resubscribe_failure_retries_next_tick_no_stuck_healthy(self) -> None:
         # If the in-place re-subscribe RAISES (e.g. MQTT_SUBSCRIBE_TIMEOUT), the
@@ -1234,7 +1254,8 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
         )
         self.assertEqual(len(resub), 2)     # retried after the first failure
         self.assertEqual(len(rebuilds), 0)  # never escalated to a full rebuild
-        self.assertTrue(m._subscribed)      # recovered on the 2nd attempt
+        # recovered on the 2nd attempt (the target topic is now in the set)
+        self.assertEqual(m._subscribed_topics_set, {_RECOVERY_TOPIC})
 
     def test_healthy_when_connected_and_subscribed(self) -> None:
         # Both flags set -> healthy -> neither re-subscribe nor rebuild.
@@ -1357,18 +1378,12 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
     def test_lost_update_disconnect_mid_resubscribe_not_marked_healthy(self) -> None:
         # Issue 3 at the re-subscribe site: a disconnection callback lands DURING the
         # in-place re-subscribe await (flips _connection=False on the awscrt thread).
-        # The post-await assignment must re-check connection (and generation) instead of
-        # an unconditional True, so _subscribed ends up False (not clobbered) and the
-        # next tick is NOT treated as healthy.
-        def make_dropper(m):
-            async def dropping_sub():
-                # Simulate the awscrt disconnection callback landing mid-subscribe.
-                m._connection = False
-            return dropping_sub
-
+        # The post-await commit must re-check connection (and generation) instead of
+        # trusting the set, so the set ends EMPTY (not committed) and the next tick is
+        # NOT treated as healthy.
         import custom_components.addhon.client.transport.mqtt as mod
 
-        m = NativeMqttClient(FakeHon([]), "MID")
+        m = NativeMqttClient(FakeHon([FakeAppliance(_RECOVERY_TOPIC)]), "MID")
         # One tick: connected/unsubscribed -> re-subscribe runs, but the connection drops
         # during the await. Then a second scripted tick is NOT applied (loop ends), so we
         # observe the state the re-subscribe left.
@@ -1378,23 +1393,25 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
 
         async def fake_start():
             rebuilds.append(True)
-            m._subscribed = False
-
-        dropping = make_dropper(m)
+            m._subscribed_topics_set = set()
 
         async def counted_sub():
             resub_calls.append(True)
-            await dropping()
+            # The subscribe itself succeeds (topic added), but the awscrt disconnection
+            # callback lands mid-await and flips _connection=False. The watchdog's
+            # post-await guard must then DISCARD the committed set.
+            m._subscribed_topics_set = m._subscribed_topics_set | {_RECOVERY_TOPIC}
+            m._connection = False
 
         async def fake_sleep(_interval):
             if not seq:
                 raise asyncio.CancelledError
             conn, sub = seq.pop(0)
             m._connection = conn
-            m._subscribed = sub
+            m._subscribed_topics_set = {_RECOVERY_TOPIC} if sub else set()
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        m._subscribe_missing = counted_sub  # type: ignore[assignment]
         real_sleep = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -1409,7 +1426,7 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
             mod.asyncio.sleep = real_sleep
 
         self.assertEqual(len(resub_calls), 1)   # re-subscribe attempted
-        self.assertFalse(m._subscribed)         # NOT clobbered back to True
+        self.assertFalse(m._subscribed_topics_set)  # set NOT committed (empty)
         self.assertFalse(m._connection)         # the disconnect stuck
         self.assertEqual(len(rebuilds), 0)      # one tick only: no rebuild yet
 
@@ -1424,7 +1441,7 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
             _RECONNECT_AFTER_FAILED_TICKS,
         )
 
-        m = NativeMqttClient(FakeHon([]), "MID")
+        m = NativeMqttClient(FakeHon([FakeAppliance(_RECOVERY_TOPIC)]), "MID")
         # Sustained not-connected long enough to trip the rebuild threshold; the rebuild's
         # _start() then brings the transport up, but the subscribe drops it again.
         seq = [(False, False)] * _RECONNECT_AFTER_FAILED_TICKS
@@ -1433,14 +1450,17 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
 
         async def fake_start():
             rebuilds.append(True)
-            m._subscribed = False
+            m._subscribed_topics_set = set()
             # _start() built a fresh client; model the awscrt success callback bringing
             # the transport up before the subscribe runs.
             m._connection = True
 
         async def counted_sub():
             resub_calls.append(True)
-            # The disconnection callback lands on the awscrt thread mid-subscribe.
+            # The subscribe succeeds (topic added), but the awscrt disconnection callback
+            # lands mid-await and flips _connection=False; the post-await guard must then
+            # DISCARD the committed set.
+            m._subscribed_topics_set = m._subscribed_topics_set | {_RECOVERY_TOPIC}
             m._connection = False
 
         async def fake_sleep(_interval):
@@ -1448,10 +1468,10 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
                 raise asyncio.CancelledError
             conn, sub = seq.pop(0)
             m._connection = conn
-            m._subscribed = sub
+            m._subscribed_topics_set = {_RECOVERY_TOPIC} if sub else set()
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = counted_sub  # type: ignore[assignment]
+        m._subscribe_missing = counted_sub  # type: ignore[assignment]
         real_sleep = mod.asyncio.sleep
         mod.asyncio.sleep = fake_sleep
         try:
@@ -1467,53 +1487,54 @@ class WatchdogSubscribedRecoveryTest(unittest.TestCase):
 
         self.assertEqual(len(rebuilds), 1)   # the rebuild ran
         self.assertEqual(len(resub_calls), 1)
-        self.assertFalse(m._subscribed)      # NOT clobbered back to True
+        self.assertFalse(m._subscribed_topics_set)  # set NOT committed (empty)
         self.assertFalse(m._connection)      # the mid-subscribe disconnect stuck
 
 
 class SubscribedFlagLifecycleTest(unittest.TestCase):
-    """The companion of WatchdogSubscribedRecoveryTest at the flag level: _subscribed
-    must be reset by the disconnection/failure callbacks (respecting the generation
-    guard) and by _start(), and set only after _subscribe_appliances() succeeds."""
+    """The companion of WatchdogSubscribedRecoveryTest at the state level: the subscribed
+    SET must be cleared (rebound to empty) by the disconnection/failure callbacks
+    (respecting the generation guard) and by _start(), and populated only after the
+    subscribe succeeds."""
 
     def test_disconnection_resets_subscribed(self) -> None:
         m = NativeMqttClient(FakeHon([]), "MID")
         m._generation = 1
         m._connection = True
-        m._subscribed = True
+        m._subscribed_topics_set = {"t"}
         m._on_lifecycle_disconnection(None, generation=1)
         self.assertFalse(m._connection)
-        self.assertFalse(m._subscribed)
+        self.assertEqual(m._subscribed_topics_set, set())
 
     def test_connection_failure_resets_subscribed(self) -> None:
         m = NativeMqttClient(FakeHon([]), "MID")
         m._generation = 1
         m._connection = True
-        m._subscribed = True
+        m._subscribed_topics_set = {"t"}
         m._on_lifecycle_connection_failure(None, generation=1)
         self.assertFalse(m._connection)
-        self.assertFalse(m._subscribed)
+        self.assertEqual(m._subscribed_topics_set, set())
 
     def test_connection_success_does_not_set_subscribed(self) -> None:
-        # The success callback only flips _connection: it does NOT subscribe, so
-        # _subscribed must stay False (this is exactly the connected-but-unsubscribed
-        # window the watchdog must recover, incl. awscrt's clean-session auto-reconnect).
+        # The success callback only flips _connection: it does NOT subscribe, so the set
+        # must stay empty (this is exactly the connected-but-unsubscribed window the
+        # watchdog must recover, incl. awscrt's clean-session auto-reconnect).
         m = NativeMqttClient(FakeHon([]), "MID")
         m._generation = 1
         m._on_lifecycle_connection_success(None, generation=1)
         self.assertTrue(m._connection)
-        self.assertFalse(m._subscribed)
+        self.assertEqual(m._subscribed_topics_set, set())
 
     def test_stale_disconnection_does_not_reset_subscribed(self) -> None:
-        # A late event from an OLD generation must not clear _subscribed on the current
+        # A late event from an OLD generation must not clear the set on the current
         # healthy client (same guard that protects _connection).
         m = NativeMqttClient(FakeHon([]), "MID")
         m._generation = 2
         m._connection = True
-        m._subscribed = True
+        m._subscribed_topics_set = {"t"}
         m._on_lifecycle_disconnection(None, generation=1)  # stale
         self.assertTrue(m._connection)
-        self.assertTrue(m._subscribed)
+        self.assertEqual(m._subscribed_topics_set, {"t"})
 
     def test_start_resets_subscribed(self) -> None:
         import awscrt
@@ -1542,13 +1563,13 @@ class SubscribedFlagLifecycleTest(unittest.TestCase):
         hon = FakeHon([])
         hon.api = FakeApi()
         m = NativeMqttClient(hon, "MID")
-        m._subscribed = True  # pretend a previous client was subscribed
+        m._subscribed_topics_set = {"t"}  # pretend a previous client was subscribed
 
         _run(m._start())
-        self.assertFalse(m._subscribed)  # fresh client -> no subscriptions
+        self.assertEqual(m._subscribed_topics_set, set())  # fresh client -> none
 
     def test_start_resets_connection(self) -> None:
-        # CR#1: _start() must also reset _connection (symmetric with _subscribed): the
+        # CR#1: _start() must also reset _connection (symmetric with the set): the
         # new client is not up until ITS connection-success callback fires. An escalation
         # rebuild (connected-but-unsubscribed) reaches _start() with _connection=True
         # carried over from the just-stopped client; leaving it True would make a rebuild
@@ -1586,53 +1607,315 @@ class SubscribedFlagLifecycleTest(unittest.TestCase):
         self.assertFalse(m._connection)  # fresh client -> not up until its success cb
 
     def test_create_sets_subscribed_true_on_success(self) -> None:
-        m = NativeMqttClient(FakeHon([]), "MID")
+        m = NativeMqttClient(FakeHon([FakeAppliance("t")]), "MID")
 
         async def fake_start():
             m._client = object()
             # The real _start() builds the client; the awscrt connection-success
             # callback then flips _connection=True before subscribe completes. create()'s
-            # lost-update guard (Issue 3) only marks _subscribed when _connection is up,
+            # lost-update guard (Issue 3) only commits the set when _connection is up,
             # so model the connected transport here.
             m._connection = True
 
         async def ok_sub():
-            return None
+            # Model _subscribe_missing(): the topic subscribes -> goes into the set.
+            m._subscribed_topics_set = {"t"}
 
         async def ok_watchdog():
             return None
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = ok_sub  # type: ignore[assignment]
+        m._subscribe_missing = ok_sub  # type: ignore[assignment]
         m._start_watchdog = ok_watchdog  # type: ignore[assignment]
         _run(m.create())
-        self.assertTrue(m._subscribed)
+        self.assertEqual(m._subscribed_topics_set, {"t"})  # fully subscribed
 
     def test_create_does_not_clobber_subscribed_when_disconnect_lands_mid_subscribe(
         self,
     ) -> None:
         # Issue 3 at the create() site: if a disconnection callback lands DURING the
-        # initial subscribe (flips _connection=False), create() must NOT clobber
-        # _subscribed back to True with an unconditional assignment.
-        m = NativeMqttClient(FakeHon([]), "MID")
+        # initial subscribe (flips _connection=False), create() must DISCARD the set
+        # (not commit a "healthy on a dropped session").
+        m = NativeMqttClient(FakeHon([FakeAppliance("t")]), "MID")
 
         async def fake_start():
             m._client = object()
             m._connection = True
 
         async def dropping_sub():
-            # The awscrt thread fires a disconnection mid-subscribe.
+            # The subscribe adds the topic, but the awscrt thread fires a disconnection
+            # mid-subscribe; create()'s post-await guard must then DISCARD the set.
+            m._subscribed_topics_set = {"t"}
             m._connection = False
-            m._subscribed = False
 
         async def ok_watchdog():
             return None
 
         m._start = fake_start  # type: ignore[assignment]
-        m._subscribe_appliances = dropping_sub  # type: ignore[assignment]
+        m._subscribe_missing = dropping_sub  # type: ignore[assignment]
         m._start_watchdog = ok_watchdog  # type: ignore[assignment]
         _run(m.create())
-        self.assertFalse(m._subscribed)  # not clobbered back to healthy
+        self.assertFalse(m._subscribed_topics_set)  # set discarded, not committed
+
+
+class MultiTopicAppliance:
+    """An appliance that subscribes SEVERAL topics, to exercise the per-topic isolation
+    of _subscribe_missing (the binary _subscribed flag could not represent a partial
+    success)."""
+
+    def __init__(self, topics) -> None:
+        self.info = {"topics": {"subscribe": list(topics)}}
+
+
+class _PerTopicFakeClient:
+    """A fake awscrt mqtt5 client whose subscribe() resolves or stalls PER TOPIC.
+
+    `bad_topics` never SUBACK (their Future never resolves -> _SUBSCRIBE_TIMEOUT fires);
+    every other topic resolves immediately. Requires the test to set
+    awscrt.mqtt5.SubscribePacket/Subscription so the topic is recoverable from the
+    packet the production code builds."""
+
+    def __init__(self, bad_topics) -> None:
+        self.bad_topics = set(bad_topics)
+        self.subscribed: list = []
+
+    def subscribe(self, packet):
+        # SubscribePacket is stubbed to ("pkt", [topic]); pull the single topic out.
+        topic = packet[1][0]
+        self.subscribed.append(topic)
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        if topic not in self.bad_topics:
+            fut.set_result(None)
+        # else: leave it unresolved so asyncio.wait_for raises TimeoutError.
+        return fut
+
+
+class SubscribeMissingIsolationTest(unittest.TestCase):
+    """H1 direct guard: _subscribe_missing must subscribe every topic it CAN, isolating a
+    single failing topic instead of aborting the whole pass (the old sequential
+    _subscribe raised on the first timeout and starved every appliance after it)."""
+
+    def setUp(self) -> None:
+        import awscrt
+
+        awscrt.mqtt5.SubscribePacket = lambda subs: ("pkt", subs)
+        awscrt.mqtt5.Subscription = lambda topic: topic
+        # Keep the per-topic timeout tiny so the stalled topic fails fast.
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        self._mod = mod
+        self._orig_timeout = mod._SUBSCRIBE_TIMEOUT
+        mod._SUBSCRIBE_TIMEOUT = 0.01
+
+    def tearDown(self) -> None:
+        self._mod._SUBSCRIBE_TIMEOUT = self._orig_timeout
+
+    def test_one_bad_topic_does_not_block_the_others(self) -> None:
+        topics = ["t/good1", "t/bad", "t/good2", "t/good3"]
+        app = MultiTopicAppliance(topics)
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._client = _PerTopicFakeClient(bad_topics={"t/bad"})
+
+        _run(m._subscribe_missing())
+
+        # Every topic EXCEPT the broken one ends up subscribed (H1: the bad topic does
+        # not starve the rest).
+        self.assertEqual(m._subscribed_topics_set, {"t/good1", "t/good2", "t/good3"})
+        self.assertNotIn("t/bad", m._subscribed_topics_set)
+        # All four were attempted (the failing one did not short-circuit the loop).
+        self.assertEqual(set(m._client.subscribed), set(topics))
+
+    def test_already_subscribed_topic_is_skipped(self) -> None:
+        # _subscribe_missing only attempts the topics NOT already in the set: an
+        # already-subscribed topic is not re-issued (idempotent retries).
+        topics = ["t/a", "t/b"]
+        app = MultiTopicAppliance(topics)
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._client = _PerTopicFakeClient(bad_topics=set())
+        m._subscribed_topics_set = {"t/a"}  # already subscribed
+
+        _run(m._subscribe_missing())
+
+        self.assertEqual(m._subscribed_topics_set, {"t/a", "t/b"})
+        self.assertEqual(m._client.subscribed, ["t/b"])  # only the missing one issued
+
+    def test_recovered_topic_empties_missing_on_a_later_pass(self) -> None:
+        # First pass: the bad topic stalls -> stays missing. Second pass with the topic
+        # now healthy: the remaining miss is filled -> fully subscribed.
+        topics = ["t/good", "t/flaky"]
+        app = MultiTopicAppliance(topics)
+        m = NativeMqttClient(FakeHon([app]), "MID")
+
+        m._client = _PerTopicFakeClient(bad_topics={"t/flaky"})
+        _run(m._subscribe_missing())
+        self.assertEqual(m._subscribed_topics_set, {"t/good"})  # flaky still missing
+
+        # The flaky topic recovers; the next pass only needs to fill the miss.
+        m._client = _PerTopicFakeClient(bad_topics=set())
+        _run(m._subscribe_missing())
+        self.assertEqual(m._subscribed_topics_set, {"t/good", "t/flaky"})  # complete
+        self.assertEqual(m._client.subscribed, ["t/flaky"])  # only the miss re-issued
+
+    def test_one_bad_topic_logs_warning_and_continues(self) -> None:
+        app = MultiTopicAppliance(["t/good", "t/bad"])
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._client = _PerTopicFakeClient(bad_topics={"t/bad"})
+        name = "custom_components.addhon.client.transport.mqtt"
+        with self.assertLogs(name, level="WARNING") as cm:
+            _run(m._subscribe_missing())
+        blob = "\n".join(cm.output)
+        self.assertIn("subscribe failed for one topic, continuing", blob)
+        self.assertEqual(m._subscribed_topics_set, {"t/good"})
+
+
+class WatchdogPartialMissEscalationTest(unittest.TestCase):
+    """H1 watchdog discrimination: ONE chronically broken appliance topic (transport
+    alive, other topics subscribed) is appliance-specific and must NOT escalate to a full
+    _start() rebuild (which would drop the healthy subscriptions). A TOTAL blackout
+    (nothing subscribes) IS a dead connection and DOES escalate after the cap."""
+
+    def _drive(self, *, all_topics, healthy_topics, ticks, connected=True):
+        """Drive the REAL _watchdog. _subscribe_missing is replaced with a stub that adds
+        only `healthy_topics` to the set (the rest stay chronically missing). The
+        instance starts connected-but-unsubscribed. Returns (resub_calls, rebuilds, m).
+        """
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        appliance = MultiTopicAppliance(all_topics)
+        m = NativeMqttClient(FakeHon([appliance]), "MID")
+        m._connection = connected
+        seq_ticks = {"left": ticks}
+        rebuilds = []
+        resub_calls = []
+
+        async def fake_start():
+            rebuilds.append(True)
+            m._subscribed_topics_set = set()
+            # Model the awscrt success callback bringing the (new) transport up.
+            m._connection = True
+
+        async def fake_subscribe_missing():
+            resub_calls.append(True)
+            # Per-topic isolation: only the healthy topics make it into the set; the
+            # broken ones stay missing pass after pass.
+            m._subscribed_topics_set = m._subscribed_topics_set | set(healthy_topics)
+
+        async def fake_sleep(_interval):
+            if seq_ticks["left"] <= 0:
+                raise asyncio.CancelledError
+            seq_ticks["left"] -= 1
+            # The state at the start of each tick is connected (the awscrt callback keeps
+            # reporting up) but with the broken topic missing.
+            m._connection = True
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_missing = fake_subscribe_missing  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+        return resub_calls, rebuilds, m
+
+    def test_chronic_bad_topic_does_not_escalate_to_rebuild(self) -> None:
+        from custom_components.addhon.client.transport.mqtt import (
+            _MAX_RESUBSCRIBE_FAILURES,
+        )
+
+        # 3 topics; one is chronically broken. Run many ticks (well past the blackout
+        # cap) -- the watchdog must keep re-subscribing the missing topic and NEVER
+        # escalate, because some topics ARE subscribed (the connection is alive).
+        resub, rebuilds, m = self._drive(
+            all_topics=["t/good1", "t/good2", "t/bad"],
+            healthy_topics=["t/good1", "t/good2"],
+            ticks=_MAX_RESUBSCRIBE_FAILURES + 5,
+        )
+        self.assertEqual(len(rebuilds), 0)  # never escalated: healthy subs preserved
+        self.assertGreaterEqual(len(resub), 1)  # kept retrying the missing topic
+        # The healthy subscriptions survived every tick (never dropped by a rebuild).
+        self.assertEqual(m._subscribed_topics_set, {"t/good1", "t/good2"})
+
+    def test_total_blackout_escalates_after_cap(self) -> None:
+        from custom_components.addhon.client.transport.mqtt import (
+            _MAX_RESUBSCRIBE_FAILURES,
+        )
+
+        # NOTHING ever subscribes (healthy_topics empty) = dead connection: after
+        # _MAX_RESUBSCRIBE_FAILURES blackout ticks the watchdog DOES escalate to a full
+        # rebuild (today's behavior preserved). Give it enough ticks for the escalation.
+        resub, rebuilds, _ = self._drive(
+            all_topics=["t/a", "t/b"],
+            healthy_topics=[],
+            ticks=_MAX_RESUBSCRIBE_FAILURES + 2,
+        )
+        self.assertGreaterEqual(len(rebuilds), 1)  # blackout escalated to a rebuild
+        # The blackout re-subscribe was attempted up to the cap before escalating.
+        self.assertGreaterEqual(len(resub), _MAX_RESUBSCRIBE_FAILURES)
+
+
+class WatchdogDisconnectMidSubscribeClearsSetTest(unittest.TestCase):
+    """A disconnect landing mid-subscribe must clear the set (no 'healthy on a dropped
+    session'), driven through the REAL lifecycle callback rather than a hand-set flag."""
+
+    def test_disconnect_callback_mid_subscribe_clears_committed_set(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        app = MultiTopicAppliance(["t/x"])
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._generation = 1
+        m._connection = True
+        seq = [True]  # one tick: connected, topic missing
+        rebuilds = []
+
+        async def fake_start():
+            rebuilds.append(True)
+            m._subscribed_topics_set = set()
+            m._connection = True
+
+        async def subscribe_then_disconnect():
+            # A REAL awscrt disconnection callback fires mid-await on the current
+            # generation (clears _connection and rebinds the set to empty), then a LATE
+            # SUBACK lands and re-adds the topic AFTER the rebind. The set is now non-empty
+            # on a DROPPED session, so the ONLY thing that can discard it is the watchdog's
+            # post-await guard (the _connection/generation re-check). If that guard is
+            # removed, the stale topic survives -> "healthy on a dropped session". This
+            # ordering makes the assertion genuinely depend on the guard (the callback
+            # alone leaving the set empty would pass vacuously).
+            m._on_lifecycle_disconnection(None, generation=1)
+            m._subscribed_topics_set.add("t/x")
+
+        async def fake_sleep(_interval):
+            if not seq:
+                raise asyncio.CancelledError
+            seq.pop(0)
+            m._connection = True
+            m._subscribed_topics_set = set()
+
+        m._start = fake_start  # type: ignore[assignment]
+        m._subscribe_missing = subscribe_then_disconnect  # type: ignore[assignment]
+        real_sleep = mod.asyncio.sleep
+        mod.asyncio.sleep = fake_sleep
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(m._watchdog())
+            except asyncio.CancelledError:
+                pass
+            finally:
+                loop.close()
+        finally:
+            mod.asyncio.sleep = real_sleep
+
+        self.assertFalse(m._connection)             # the disconnect stuck
+        self.assertEqual(m._subscribed_topics_set, set())  # set cleared, not trusted
+        self.assertEqual(len(rebuilds), 0)          # one tick: no rebuild yet
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -78,9 +78,24 @@ class FakeAppliance:
         self.nick_name = "Nick"
         self.connection = True
         self.synced = []
+        # Mirrors HonAppliance.mark_realtime_seen book-keeping so the transport tests
+        # can assert the liveness time the handler records.
+        self.realtime_seen = []
+        self.disconnected_calls = 0
 
     def sync_params_to_command(self, name: str) -> None:
         self.synced.append(name)
+
+    def mark_realtime_seen(self, timestamp=None) -> None:
+        # Positive-only, mirroring the engine: realtime traffic -> connected, and the
+        # cloud timestamp is remembered for the test to inspect.
+        self.connection = True
+        self.realtime_seen.append(timestamp)
+
+    def mark_realtime_disconnected(self) -> None:
+        # Mirrors the engine: explicit negative evidence clears the liveness marks.
+        self.connection = False
+        self.disconnected_calls += 1
 
 
 class FakeHon:
@@ -483,6 +498,35 @@ class PublishReceivedTest(unittest.TestCase):
                          {"parName": "temp", "parValue": "9"})
         self.assertEqual(hon.notified, 1)
 
+    def test_appliancestatus_marks_realtime_seen_with_payload_timestamp(self) -> None:
+        # Realtime traffic is authoritative connectivity evidence: the handler must mark
+        # the appliance live and pass the CLOUD payload `timestamp` (not wall-clock) to
+        # mark_realtime_seen, so the engine can reconcile it against a stale lastConnEvent.
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        app.connection = False  # previously reported offline (stale REST disconnect)
+        m, hon = self._client(app)
+        ts = "2026-06-25T16:04:21.1Z"
+        m._on_publish_received(_packet(topic, {
+            "timestamp": ts,
+            "parameters": [{"parName": "temp", "parValue": "5"}],
+        }))
+        self.assertEqual(app.realtime_seen, [ts])   # cloud timestamp forwarded
+        self.assertTrue(app.connection)             # marked live again
+        self.assertEqual(hon.notified, 1)
+
+    def test_appliancestatus_marks_realtime_seen_even_without_timestamp(self) -> None:
+        # No payload timestamp: the message itself is still evidence -> mark_realtime_seen
+        # is called (with None) so connection is set live; the engine then declines the
+        # stale-disconnect protection for lack of an orderable time.
+        topic = "haier/things/MAC/event/appliancestatus/update"
+        app = FakeAppliance(topic)
+        m, _ = self._client(app)
+        m._on_publish_received(_packet(topic, {
+            "parameters": [{"parName": "temp", "parValue": "5"}],
+        }))
+        self.assertEqual(app.realtime_seen, [None])
+
     def test_disconnected_sets_connection_false(self) -> None:
         topic = "haier/things/MAC/event/disconnected"
         app = FakeAppliance(topic)
@@ -498,6 +542,42 @@ class PublishReceivedTest(unittest.TestCase):
         m, _ = self._client(app)
         m._on_publish_received(_packet(topic, {}))
         self.assertTrue(app.connection)
+
+    def test_session_presence_connected_does_not_touch_connectivity(self) -> None:
+        # `$aws/events/presence/connected/<clientId>` is OUR client's session presence, not
+        # the appliance's connectivity: it must NOT arm liveness NOR even set connection.
+        topic = "$aws/events/presence/connected/myclient"
+        app = FakeAppliance(topic)
+        app.connection = False  # genuinely offline
+        m, _ = self._client(app)
+        m._on_publish_received(_packet(topic, {"clientId": "myclient", "eventType": "connected"}))
+        self.assertFalse(app.connection)        # not pinned online by our session
+        self.assertEqual(app.realtime_seen, [])  # liveness not armed
+
+    def test_session_presence_disconnected_does_not_clobber_live_appliance(self) -> None:
+        # `$aws/events/presence/disconnected/<clientId>` is OUR client's session blip; it
+        # must NOT clear the appliance's liveness marks (which would knock a live, streaming
+        # appliance offline non-self-correcting while the cloud lastConnEvent stays stale).
+        topic = "$aws/events/presence/disconnected/myclient"
+        app = FakeAppliance(topic)
+        app.connection = True  # appliance is live (streaming appliancestatus)
+        m, _ = self._client(app)
+        m._on_publish_received(_packet(topic, {"clientId": "myclient", "eventType": "disconnected"}))
+        self.assertTrue(app.connection)          # still live
+        self.assertEqual(app.disconnected_calls, 0)  # marks NOT cleared
+
+    def test_connected_does_not_arm_realtime_liveness(self) -> None:
+        # The presence "connected" event is OUR client's AWS-IoT session presence, not the
+        # appliance's connectivity. It must set connection True (transient, self-corrected
+        # at the next poll) but must NOT record realtime liveness -- otherwise periodic
+        # client reconnects would pin a genuinely offline appliance online indefinitely.
+        topic = "haier/things/MAC/event/connected"
+        app = FakeAppliance(topic)
+        app.connection = False
+        m, _ = self._client(app)
+        m._on_publish_received(_packet(topic, {"timestamp": "2026-06-25T16:04:16Z"}))
+        self.assertTrue(app.connection)
+        self.assertEqual(app.realtime_seen, [])  # liveness NOT armed by presence
 
     def test_unknown_topic_no_crash_no_notify(self) -> None:
         # topic that matches no appliance -> exits without crashing (defensive:


### PR DESCRIPTION
Automated release PR for `v5.4.0`.

<!-- release-tag: v5.4.0 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Refresh now” service to trigger an immediate cloud update for all configured devices.
  * Expanded documentation to highlight 2FA login support and multilingual availability.

* **Bug Fixes**
  * Improved device connectivity handling for more reliable online/offline status.
  * Climate controls now avoid guessing unsupported heating/cooling and fan modes.
  * Sensitive device details are now better redacted in logs.

* **Chores**
  * Updated the integration version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release adds a domain-wide `addhon.refresh` service, fixes stale REST `DISCONNECTED` events clobbering live MQTT-connected devices, upgrades the MQTT subscription tracker from a binary flag to a per-topic set (H1 isolation), and replaces guessed HVAC/fan modes with explicit `None` returns when a mode is unmapped or unadvertised.

- **New `addhon.refresh` service**: registers once per domain, iterates all loaded coordinators via `asyncio.gather(return_exceptions=True)`, isolates per-entry failures, and is cleaned up on last unload alongside the existing log-level services.
- **Stale-disconnect fix** (`appliance.py` + `helpers.py`): `mark_realtime_seen()` records a cloud-stamped timestamp and a monotonic receipt time; `load_attributes` compares these against the REST `lastConnEvent` to prevent a frozen DISCONNECTED from knocking a live device offline, while still honoring a genuinely newer disconnect and expiring the protection after 300 s.
- **Per-topic MQTT subscription set** (`mqtt.py`): replaces `_subscribed: bool` with `_subscribed_topics_set: set[str]`; `_subscribe_missing()` skips already-subscribed topics, isolates per-topic failures, and the watchdog escalates to a full rebuild only on a total blackout (nothing subscribed at all), never on a single chronically-broken appliance topic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three core changes (stale-disconnect fix, per-topic MQTT set, new refresh service) are covered by dedicated tests and the previous monotonic/exception-handling concerns are resolved.

The stale-disconnect reconciliation uses `monotonic()` for TTL (immune to DST/NTP jumps) and cloud-stamped timestamps for ordering (skew-free). The MQTT subscription redesign swallows per-topic exceptions inside `_subscribe_missing()` and only escalates to a rebuild on a total blackout, which is well-tested and intentional. The refresh service isolates per-entry failures with `asyncio.gather(return_exceptions=True)` and never re-raises to the automation caller. No issues were found that would cause incorrect behavior at runtime.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/__init__.py | Adds the domain-wide `addhon.refresh` service with per-entry failure isolation; updates the unload cleanup and early-return guard to include the new service; switches legacy-cleanup INFO logs to redacted IDs. |
| custom_components/addhon/client/engine/appliance.py | Adds `mark_realtime_seen()` / `mark_realtime_disconnected()` for cloud-vs-cloud timestamp ordering; TTL freshness uses `monotonic()` (fixes the previous P2 about `datetime.now()` DST sensitivity); `load_attributes` now preserves liveness when realtime evidence is newer than a REST disconnect. |
| custom_components/addhon/client/helpers.py | New `parse_cloud_timestamp()` helper: total (never raises), accepts epoch-ms or ISO8601 with variable fractional digits, always returns tz-aware UTC; guards against OverflowError on arbitrary-precision ints from `json.loads`. |
| custom_components/addhon/client/transport/mqtt.py | Replaces `_subscribed: bool` with `_subscribed_topics_set: set[str]`; adds `_subscribe_missing()` with per-topic exception isolation; watchdog escalates to rebuild only on total blackout; `$aws/events/presence/` topics are intercepted and ignored for appliance connectivity; addresses both previous P2 findings. |
| custom_components/addhon/climate.py | `hvac_mode` now returns `HVACMode | None` instead of guessing COOL for unmapped/unadvertised modes; `fan_mode` similarly returns None for unmapped or unadvertised speeds, preventing HA's "not a valid option" warnings. |
| tests/test_refresh_service.py | New test file: covers registration idempotency, per-entry failure isolation (async and synchronous raises), None-coordinator skipping, live hass.data enumeration, and source-level wiring guards. |
| tests/test_engine_appliance_root.py | New `RealtimeReconciliationTest` class: 13 tests covering stale-disconnect protection, TTL expiry, explicit MQTT disconnect clearing liveness, ISO/epoch comparability, and out-of-order timestamp handling. |
| tests/test_transport_mqtt.py | Updated to use `_subscribe_missing` instead of `_subscribe_appliances` in test stubs; adds tests for `mark_realtime_seen` forwarding, session-presence topic isolation, and the per-topic subscription set model. |
| tests/test_ac_write_path.py | New `AcClimateReadPathTest` class: covers valid/unmapped/unadvertised hvac_mode and fan_mode cases, including missing `machMode` and the OFF-wins-over-unmapped invariant. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `custom_components/addhon/client/transport/mqtt.py`, line 698-702 ([link](https://github.com/tis24dev/addhon/blob/2e146eb32c1d2a302565b6c71602494d707e2f0d/custom_components/addhon/client/transport/mqtt.py#L698-L702)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unexpected subscribe exceptions bypass escalation counter**

   `_subscribe_missing` only catches `HonCodedError` (which wraps `asyncio.TimeoutError`). If the underlying `concurrent.futures.Future` from `self.client.subscribe()` fails with any other exception (e.g., a closed/bad-state client that raises directly), it escapes `_subscribe_missing` and is caught by the outer `except Exception` in the watchdog. That handler adds backoff but does **not** increment `resubscribe_failures`, so the escalation to a full rebuild never fires via that counter — the watchdog would retry indefinitely with capped backoff rather than refreshing the AWS token.

   In the old design, `attempted_resubscribe = True` ensured any exception from the re-subscribe path incremented the counter. The new design relies entirely on the `resubscribe_failures` inline path, which is only reached when `_subscribe_missing` returns normally with an empty set — not when it raises. The watchdog comment "Only the REBUILD path … can land here now" is also inaccurate for this edge case.

   In practice, awscrt failures tend to trigger the disconnection lifecycle callbacks first, so `_connection` would flip to False and a normal reconnect would occur. But the escalation guarantee is technically broken for the pathological case of a connected-but-subscribe-failing client without a disconnection callback.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Ftransport%2Fmqtt.py%0ALine%3A%20698-702%0A%0AComment%3A%0A**Unexpected%20subscribe%20exceptions%20bypass%20escalation%20counter**%0A%0A%60_subscribe_missing%60%20only%20catches%20%60HonCodedError%60%20%28which%20wraps%20%60asyncio.TimeoutError%60%29.%20If%20the%20underlying%20%60concurrent.futures.Future%60%20from%20%60self.client.subscribe%28%29%60%20fails%20with%20any%20other%20exception%20%28e.g.%2C%20a%20closed%2Fbad-state%20client%20that%20raises%20directly%29%2C%20it%20escapes%20%60_subscribe_missing%60%20and%20is%20caught%20by%20the%20outer%20%60except%20Exception%60%20in%20the%20watchdog.%20That%20handler%20adds%20backoff%20but%20does%20**not**%20increment%20%60resubscribe_failures%60%2C%20so%20the%20escalation%20to%20a%20full%20rebuild%20never%20fires%20via%20that%20counter%20%E2%80%94%20the%20watchdog%20would%20retry%20indefinitely%20with%20capped%20backoff%20rather%20than%20refreshing%20the%20AWS%20token.%0A%0AIn%20the%20old%20design%2C%20%60attempted_resubscribe%20%3D%20True%60%20ensured%20any%20exception%20from%20the%20re-subscribe%20path%20incremented%20the%20counter.%20The%20new%20design%20relies%20entirely%20on%20the%20%60resubscribe_failures%60%20inline%20path%2C%20which%20is%20only%20reached%20when%20%60_subscribe_missing%60%20returns%20normally%20with%20an%20empty%20set%20%E2%80%94%20not%20when%20it%20raises.%20The%20watchdog%20comment%20%22Only%20the%20REBUILD%20path%20%E2%80%A6%20can%20land%20here%20now%22%20is%20also%20inaccurate%20for%20this%20edge%20case.%0A%0AIn%20practice%2C%20awscrt%20failures%20tend%20to%20trigger%20the%20disconnection%20lifecycle%20callbacks%20first%2C%20so%20%60_connection%60%20would%20flip%20to%20False%20and%20a%20normal%20reconnect%20would%20occur.%20But%20the%20escalation%20guarantee%20is%20technically%20broken%20for%20the%20pathological%20case%20of%20a%20connected-but-subscribe-failing%20client%20without%20a%20disconnection%20callback.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Ftransport%2Fmqtt.py%0ALine%3A%20698-702%0A%0AComment%3A%0A**Unexpected%20subscribe%20exceptions%20bypass%20escalation%20counter**%0A%0A%60_subscribe_missing%60%20only%20catches%20%60HonCodedError%60%20%28which%20wraps%20%60asyncio.TimeoutError%60%29.%20If%20the%20underlying%20%60concurrent.futures.Future%60%20from%20%60self.client.subscribe%28%29%60%20fails%20with%20any%20other%20exception%20%28e.g.%2C%20a%20closed%2Fbad-state%20client%20that%20raises%20directly%29%2C%20it%20escapes%20%60_subscribe_missing%60%20and%20is%20caught%20by%20the%20outer%20%60except%20Exception%60%20in%20the%20watchdog.%20That%20handler%20adds%20backoff%20but%20does%20**not**%20increment%20%60resubscribe_failures%60%2C%20so%20the%20escalation%20to%20a%20full%20rebuild%20never%20fires%20via%20that%20counter%20%E2%80%94%20the%20watchdog%20would%20retry%20indefinitely%20with%20capped%20backoff%20rather%20than%20refreshing%20the%20AWS%20token.%0A%0AIn%20the%20old%20design%2C%20%60attempted_resubscribe%20%3D%20True%60%20ensured%20any%20exception%20from%20the%20re-subscribe%20path%20incremented%20the%20counter.%20The%20new%20design%20relies%20entirely%20on%20the%20%60resubscribe_failures%60%20inline%20path%2C%20which%20is%20only%20reached%20when%20%60_subscribe_missing%60%20returns%20normally%20with%20an%20empty%20set%20%E2%80%94%20not%20when%20it%20raises.%20The%20watchdog%20comment%20%22Only%20the%20REBUILD%20path%20%E2%80%A6%20can%20land%20here%20now%22%20is%20also%20inaccurate%20for%20this%20edge%20case.%0A%0AIn%20practice%2C%20awscrt%20failures%20tend%20to%20trigger%20the%20disconnection%20lifecycle%20callbacks%20first%2C%20so%20%60_connection%60%20would%20flip%20to%20False%20and%20a%20normal%20reconnect%20would%20occur.%20But%20the%20escalation%20guarantee%20is%20technically%20broken%20for%20the%20pathological%20case%20of%20a%20connected-but-subscribe-failing%20client%20without%20a%20disconnection%20callback.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Ftransport%2Fmqtt.py%0ALine%3A%20698-702%0A%0AComment%3A%0A**Unexpected%20subscribe%20exceptions%20bypass%20escalation%20counter**%0A%0A%60_subscribe_missing%60%20only%20catches%20%60HonCodedError%60%20%28which%20wraps%20%60asyncio.TimeoutError%60%29.%20If%20the%20underlying%20%60concurrent.futures.Future%60%20from%20%60self.client.subscribe%28%29%60%20fails%20with%20any%20other%20exception%20%28e.g.%2C%20a%20closed%2Fbad-state%20client%20that%20raises%20directly%29%2C%20it%20escapes%20%60_subscribe_missing%60%20and%20is%20caught%20by%20the%20outer%20%60except%20Exception%60%20in%20the%20watchdog.%20That%20handler%20adds%20backoff%20but%20does%20**not**%20increment%20%60resubscribe_failures%60%2C%20so%20the%20escalation%20to%20a%20full%20rebuild%20never%20fires%20via%20that%20counter%20%E2%80%94%20the%20watchdog%20would%20retry%20indefinitely%20with%20capped%20backoff%20rather%20than%20refreshing%20the%20AWS%20token.%0A%0AIn%20the%20old%20design%2C%20%60attempted_resubscribe%20%3D%20True%60%20ensured%20any%20exception%20from%20the%20re-subscribe%20path%20incremented%20the%20counter.%20The%20new%20design%20relies%20entirely%20on%20the%20%60resubscribe_failures%60%20inline%20path%2C%20which%20is%20only%20reached%20when%20%60_subscribe_missing%60%20returns%20normally%20with%20an%20empty%20set%20%E2%80%94%20not%20when%20it%20raises.%20The%20watchdog%20comment%20%22Only%20the%20REBUILD%20path%20%E2%80%A6%20can%20land%20here%20now%22%20is%20also%20inaccurate%20for%20this%20edge%20case.%0A%0AIn%20practice%2C%20awscrt%20failures%20tend%20to%20trigger%20the%20disconnection%20lifecycle%20callbacks%20first%2C%20so%20%60_connection%60%20would%20flip%20to%20False%20and%20a%20normal%20reconnect%20would%20occur.%20But%20the%20escalation%20guarantee%20is%20technically%20broken%20for%20the%20pathological%20case%20of%20a%20connected-but-subscribe-failing%20client%20without%20a%20disconnection%20callback.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `custom_components/addhon/client/engine/appliance.py`, line 329-331 ([link](https://github.com/tis24dev/addhon/blob/2e146eb32c1d2a302565b6c71602494d707e2f0d/custom_components/addhon/client/engine/appliance.py#L329-L331)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Naive `datetime.now()` for wall-clock TTL freshness check**

   `_last_realtime_local` is stored and compared using naive `datetime.now()` (local wall-clock time). The subtraction in `load_attributes` (`datetime.now() - self._last_realtime_local`) is a local-to-local delta, so it works correctly during normal operation. However, a DST "fall back" transition — where the local clock moves backwards by one hour — can cause the delta to appear larger than it actually is, potentially expiring the 300-second TTL prematurely and briefly allowing a stale REST `DISCONNECTED` to win. `datetime.now(timezone.utc)` avoids this entirely and has no extra cost. Most HA Docker deployments run in UTC so the risk is low, but the fix is trivial.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Fengine%2Fappliance.py%0ALine%3A%20329-331%0A%0AComment%3A%0A**Naive%20%60datetime.now%28%29%60%20for%20wall-clock%20TTL%20freshness%20check**%0A%0A%60_last_realtime_local%60%20is%20stored%20and%20compared%20using%20naive%20%60datetime.now%28%29%60%20%28local%20wall-clock%20time%29.%20The%20subtraction%20in%20%60load_attributes%60%20%28%60datetime.now%28%29%20-%20self._last_realtime_local%60%29%20is%20a%20local-to-local%20delta%2C%20so%20it%20works%20correctly%20during%20normal%20operation.%20However%2C%20a%20DST%20%22fall%20back%22%20transition%20%E2%80%94%20where%20the%20local%20clock%20moves%20backwards%20by%20one%20hour%20%E2%80%94%20can%20cause%20the%20delta%20to%20appear%20larger%20than%20it%20actually%20is%2C%20potentially%20expiring%20the%20300-second%20TTL%20prematurely%20and%20briefly%20allowing%20a%20stale%20REST%20%60DISCONNECTED%60%20to%20win.%20%60datetime.now%28timezone.utc%29%60%20avoids%20this%20entirely%20and%20has%20no%20extra%20cost.%20Most%20HA%20Docker%20deployments%20run%20in%20UTC%20so%20the%20risk%20is%20low%2C%20but%20the%20fix%20is%20trivial.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Fengine%2Fappliance.py%0ALine%3A%20329-331%0A%0AComment%3A%0A**Naive%20%60datetime.now%28%29%60%20for%20wall-clock%20TTL%20freshness%20check**%0A%0A%60_last_realtime_local%60%20is%20stored%20and%20compared%20using%20naive%20%60datetime.now%28%29%60%20%28local%20wall-clock%20time%29.%20The%20subtraction%20in%20%60load_attributes%60%20%28%60datetime.now%28%29%20-%20self._last_realtime_local%60%29%20is%20a%20local-to-local%20delta%2C%20so%20it%20works%20correctly%20during%20normal%20operation.%20However%2C%20a%20DST%20%22fall%20back%22%20transition%20%E2%80%94%20where%20the%20local%20clock%20moves%20backwards%20by%20one%20hour%20%E2%80%94%20can%20cause%20the%20delta%20to%20appear%20larger%20than%20it%20actually%20is%2C%20potentially%20expiring%20the%20300-second%20TTL%20prematurely%20and%20briefly%20allowing%20a%20stale%20REST%20%60DISCONNECTED%60%20to%20win.%20%60datetime.now%28timezone.utc%29%60%20avoids%20this%20entirely%20and%20has%20no%20extra%20cost.%20Most%20HA%20Docker%20deployments%20run%20in%20UTC%20so%20the%20risk%20is%20low%2C%20but%20the%20fix%20is%20trivial.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fclient%2Fengine%2Fappliance.py%0ALine%3A%20329-331%0A%0AComment%3A%0A**Naive%20%60datetime.now%28%29%60%20for%20wall-clock%20TTL%20freshness%20check**%0A%0A%60_last_realtime_local%60%20is%20stored%20and%20compared%20using%20naive%20%60datetime.now%28%29%60%20%28local%20wall-clock%20time%29.%20The%20subtraction%20in%20%60load_attributes%60%20%28%60datetime.now%28%29%20-%20self._last_realtime_local%60%29%20is%20a%20local-to-local%20delta%2C%20so%20it%20works%20correctly%20during%20normal%20operation.%20However%2C%20a%20DST%20%22fall%20back%22%20transition%20%E2%80%94%20where%20the%20local%20clock%20moves%20backwards%20by%20one%20hour%20%E2%80%94%20can%20cause%20the%20delta%20to%20appear%20larger%20than%20it%20actually%20is%2C%20potentially%20expiring%20the%20300-second%20TTL%20prematurely%20and%20briefly%20allowing%20a%20stale%20REST%20%60DISCONNECTED%60%20to%20win.%20%60datetime.now%28timezone.utc%29%60%20avoids%20this%20entirely%20and%20has%20no%20extra%20cost.%20Most%20HA%20Docker%20deployments%20run%20in%20UTC%20so%20the%20risk%20is%20low%2C%20but%20the%20fix%20is%20trivial.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address v5.4.0 review findings (pre..."](https://github.com/tis24dev/addhon/commit/00ce44b5929e3f942b57d233e833132771d87fd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40195975)</sub>

<!-- /greptile_comment -->