### PR TITLE
Release v5.5.0-beta

### DIFF
--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -17,10 +17,12 @@ from .const import (
     CONF_ENABLE_MQTT_DEBUG,
     DOMAIN,
     PROGRAM_PARAM_NAMES,
+    PROGRAM_PENDING_OPTIONS,
     PROGRAM_PENDING_STORE,
 )
 from .debug_utils import command_names, param_snapshot, redact_id, redact_store
 from .logging_utils import reset_integration_log_level, silence_mqtt_noise
+from .program_options import apply_pending_options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,11 +133,21 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             if self._command_name == "startProgram"
             else None
         )
+        # (a) Snapshot-copy the buffered program OPTIONS (#35): only startProgram carries
+        # them; stopProgram never touches the option buffer. Applied AFTER the program
+        # swap, BELOW. A copy so a concurrent buffer write cannot mutate it mid-send.
+        options_store = self._coordinator_store(PROGRAM_PENDING_OPTIONS)
+        pending_options = (
+            dict(options_store.get(self._appliance_id) or {})
+            if self._command_name == "startProgram"
+            else {}
+        )
         _LOGGER.debug(
-            "Button debug: press '%s' id=%s pending_program=%s store=%s commands=%s",
+            "Button debug: press '%s' id=%s pending_program=%s options=%s store=%s commands=%s",
             self._command_name,
             redact_id(self._appliance_id),
             pending_program,
+            sorted(pending_options),
             redact_store(store),
             command_names(appliance),
         )
@@ -199,6 +211,21 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                         )
                         command = refreshed
                         params = getattr(command, "parameters", {})
+                    # (b) Apply the buffered program options to the POST-SWAP command
+                    # (#35): selecting the program swaps the active startProgram command,
+                    # so the options must land on the new one. apply_pending_options skips
+                    # an option the selected program does not expose (debug). The engine
+                    # setter validates each value; a bad value raises BEFORE send() below,
+                    # so nothing is transmitted and the option buffer is kept for retry
+                    # (the in-memory param mutation is overwritten on the next refresh).
+                    if pending_options:
+                        applied = apply_pending_options(params, pending_options)
+                        _LOGGER.debug(
+                            "Button debug: applied %d/%d program options %s",
+                            len(applied),
+                            len(pending_options),
+                            applied,
+                        )
                     for name, value in self._command_parameters.items():
                         if name in params:
                             previous = getattr(params[name], "value", None)
@@ -234,6 +261,17 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                 _LOGGER.debug(
                     "Button debug: pending program consumed and removed, store=%s",
                     redact_store(store),
+                )
+            # (c) Clear the buffered options on a successful startProgram send (#35).
+            # Gated on the command name, NOT on pending_program: the options must be
+            # cleared even when only options changed and no program was re-selected. On a
+            # failure the buffer is kept (the whole try aborts before here), so a retry
+            # re-sends the same options.
+            if self._command_name == "startProgram":
+                options_store.pop(self._appliance_id, None)
+                _LOGGER.debug(
+                    "Button debug: pending options cleared, store=%s",
+                    redact_store(options_store),
                 )
             _LOGGER.info("Button: command '%s' sent", self._command_name)
             await self._async_request_command_refresh()

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -263,12 +263,21 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                     redact_store(store),
                 )
             # (c) Clear the buffered options on a successful startProgram send (#35).
-            # Gated on the command name, NOT on pending_program: the options must be
-            # cleared even when only options changed and no program was re-selected. On a
-            # failure the buffer is kept (the whole try aborts before here), so a retry
-            # re-sends the same options.
+            # Gated on the command name, NOT on pending_program: options are cleared even
+            # when only options changed and no program was re-selected. Clear ONLY the keys
+            # we actually SENT (the pre-send snapshot) whose current store value still equals
+            # what we sent, so an option the user (re)wrote AFTER the snapshot but before this
+            # clear survives for the next Start (PR #38 / CodeRabbit). Pop the appliance entry
+            # only once empty. On a failure the try aborts before here -> the whole buffer is
+            # kept and a retry re-sends it.
             if self._command_name == "startProgram":
-                options_store.pop(self._appliance_id, None)
+                current = options_store.get(self._appliance_id)
+                if isinstance(current, dict):
+                    for opt_name, opt_value in pending_options.items():
+                        if current.get(opt_name) == opt_value:
+                            current.pop(opt_name, None)
+                    if not current:
+                        options_store.pop(self._appliance_id, None)
                 _LOGGER.debug(
                     "Button debug: pending options cleared, store=%s",
                     redact_store(options_store),

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -87,7 +87,7 @@ DIRTY_LEVEL_LABELS = {"1": "little", "2": "normal", "3": "very"}
 STEAM_LEVEL_LABELS = {"0": "no_steam", "1": "cotton", "2": "delicate", "3": "synthetic"}
 # Unselectable dryLevel sentinels (hasDryLevelValue returns false for ''/'0'/'11'):
 # dropped from the select options so they never appear as a choice.
-DRY_LEVEL_SENTINELS = ("0", "11")
+DRY_LEVEL_SENTINELS = ("", "0", "11")
 
 # Service to change at runtime the log level of the realtime MQTT channel. By
 # default the reconnection-attempt noise is silenced (see logging_utils); this

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -50,6 +50,45 @@ PROGRAM_PARAM_NAMES = ("program", "prCode")
 # to startProgram. The single shared source of truth between select.py and button.py.
 PROGRAM_PENDING_STORE = "pending_programs"
 
+# Key of the volatile store (kept on the coordinator) that holds the writable
+# program OPTIONS (spin/temp/dry level/extra rinses/delayed start/...) chosen on the
+# option entities but not yet started. Shape: {appliance_id: {param: value_str}}.
+# Parallel to PROGRAM_PENDING_STORE: the option entities (switch/select/number) buffer
+# here, and the "Start program" button applies them to the startProgram command and
+# clears them on a successful send (see program_options.py / button.py). Discussion #35.
+PROGRAM_PENDING_OPTIONS = "pending_options"
+
+# --- Program-option label maps (discussion #35) -------------------------------
+# Labels ONLY (machine keys for the select state translations); the legal VALUE set is
+# ALWAYS read from the device's startProgram schema, never hardcoded (a model exposes
+# only a slice -- e.g. the user's dryer shows dryLevel[12,13,14], tempLevel[2,3,4]).
+# Values are the decompiled-app codes. dryLevel semantics are NOT stable across classes
+# (value 1 = EXTRA_DRY on WM/WD but IRON_DRY on TD), so it is TYPE-GATED with two maps.
+DRY_LEVEL_LABELS_WM = {
+    "1": "extra_dry",
+    "2": "cupboard",
+    "3": "iron_dry",
+    "4": "hang_dry",
+    "5": "smart_dry",
+    "6": "wool_dry",
+}  # decomp case 300 (WM/WD)
+DRY_LEVEL_LABELS_TD = {
+    "1": "iron_dry",
+    "2": "hang_dry",
+    "3": "cupboard",
+    "4": "extra_dry",
+    "12": "iron_dry",
+    "13": "ready_to_wear",
+    "14": "cupboard",
+    "15": "extra_dry",
+}  # decomp case 53 (TD)
+TEMP_LEVEL_LABELS = {"1": "minimum", "2": "low", "3": "medium", "4": "high"}
+DIRTY_LEVEL_LABELS = {"1": "little", "2": "normal", "3": "very"}
+STEAM_LEVEL_LABELS = {"0": "no_steam", "1": "cotton", "2": "delicate", "3": "synthetic"}
+# Unselectable dryLevel sentinels (hasDryLevelValue returns false for ''/'0'/'11'):
+# dropped from the select options so they never appear as a choice.
+DRY_LEVEL_SENTINELS = ("0", "11")
+
 # Service to change at runtime the log level of the realtime MQTT channel. By
 # default the reconnection-attempt noise is silenced (see logging_utils); this
 # service re-enables it on demand for debugging. The logger names and the level

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.4.0"
+  "version": "5.5.0-beta"
 }

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -33,7 +33,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -44,7 +44,11 @@ from .const import (
     APPLIANCE_FRE,
     APPLIANCE_OV,
     APPLIANCE_REF,
+    APPLIANCE_TD,
+    APPLIANCE_WASH_GROUP,
     APPLIANCE_WC,
+    APPLIANCE_WD,
+    APPLIANCE_WM,
     DOMAIN,
 )
 from .debug_utils import redact_id
@@ -53,6 +57,10 @@ from .hon_commands import (
     find_settings_param,
     param_range,
     param_values,
+)
+from .program_options import (
+    HonProgramOptionEntity,
+    option_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,6 +138,38 @@ NUMBERS: dict[str, tuple[HonNumberEntityDescription, ...]] = {
     APPLIANCE_WC: _WINE_NUMBERS,
     APPLIANCE_OV: _OVEN_NUMBERS,
 }
+
+
+@dataclass(frozen=True, kw_only=True)
+class HonProgramOptionNumberDescription:
+    """A numeric program option (e.g. delayed start) buffered onto startProgram (#35).
+
+    `param` is the startProgram range parameter; min/max/step are read live from it.
+    `types` gates the appliance families.
+    """
+
+    key: str
+    param: str
+    translation_key: str
+    types: tuple[str, ...]
+    icon: str | None = None
+    unit: str | None = None
+
+
+_WASH_GROUP_TYPES = (APPLIANCE_WM, APPLIANCE_WD, APPLIANCE_TD)
+
+# Candidate program-option numbers, capability-gated by the device schema. delayTime is a
+# true range (0..1410 step 30 on the real models); the bounds are read live.
+_PROGRAM_OPTION_NUMBERS: tuple[HonProgramOptionNumberDescription, ...] = (
+    HonProgramOptionNumberDescription(
+        key="delay_time",
+        param="delayTime",
+        translation_key="delay_time",
+        types=_WASH_GROUP_TYPES,
+        icon="mdi:timer-outline",
+        unit=UnitOfTime.MINUTES,
+    ),
+)
 
 
 def _is_enum_param(param) -> bool:
@@ -259,14 +299,28 @@ async def async_setup_entry(
                 )
             )
             created.append(description.key)
+        # Writable program-option numbers (#35): delayed start etc., capability-gated on
+        # the wash group's live startProgram schema.
+        opt_created: list[str] = []
+        if app_type in APPLIANCE_WASH_GROUP:
+            for option in _PROGRAM_OPTION_NUMBERS:
+                if app_type not in option.types:
+                    continue
+                if not HonProgramOptionNumber.supports(appliance, option.param):
+                    continue
+                entities.append(
+                    HonProgramOptionNumber(coordinator, appliance_id, option, client)
+                )
+                opt_created.append(option.key)
         _LOGGER.debug(
-            "Number debug: '%s' (type=%s, id=%s) -> %d/%d numbers %s",
+            "Number debug: '%s' (type=%s, id=%s) -> %d/%d numbers %s; option numbers %s",
             data.get("name", "Haier"),
             app_type,
             redact_id(appliance_id),
             len(created),
             len(NUMBERS.get(app_type, ())),
             created,
+            opt_created,
         )
     async_add_entities(entities)
 
@@ -395,3 +449,92 @@ class HonNumber(HonBaseEntity, NumberEntity):
                 translation_key="command_error",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+
+def _clean_number(value: float) -> str:
+    """'30' not '30.0'; keep the decimals for a non-integer."""
+    return str(int(value)) if float(value).is_integer() else str(value)
+
+
+class HonProgramOptionNumber(HonProgramOptionEntity, NumberEntity):
+    """Numeric program option (delayed start) buffered onto the startProgram command;
+    applied + sent on the "Start program" button (no immediate send)."""
+
+    entity_description: HonProgramOptionNumberDescription
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        coordinator,
+        appliance_id: str,
+        description: HonProgramOptionNumberDescription,
+        client=None,
+    ) -> None:
+        super().__init__(coordinator, appliance_id, description.param, client)
+        self._desc = description
+        self._attr_translation_key = description.translation_key
+        self._attr_unique_id = f"{appliance_id}_opt_{description.key}"
+        if description.icon:
+            self._attr_icon = description.icon
+        if description.unit:
+            self._attr_native_unit_of_measurement = description.unit
+        # Fallback for a device that errored on its first load. The live bounds are read
+        # off the cached param (resolved once by the mixin -- see _live_range); engine
+        # rules can still move min/max/step, so they are read fresh. delayTime is 0..1410
+        # step 30 on the real models.
+        self._fallback_range = option_range(self._option_param) or (0.0, 1410.0, 30.0)
+        _LOGGER.debug(
+            "Number debug: init option number '%s' id=%s param=%s range=%s",
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
+            description.param,
+            self._live_range,
+        )
+
+    @property
+    def _live_range(self) -> tuple[float, float, float]:
+        # Read live min/max/step off the cached param (cheap: no per-read available_settings
+        # re-resolution across program categories). Falls back if the param is unavailable.
+        rng = option_range(self._option_param) if self._option_param is not None else None
+        return rng or self._fallback_range
+
+    @property
+    def native_min_value(self) -> float:
+        return self._live_range[0]
+
+    @property
+    def native_max_value(self) -> float:
+        return self._live_range[1]
+
+    @property
+    def native_step(self) -> float:
+        return self._live_range[2]
+
+    @property
+    def native_value(self) -> float | None:
+        raw = self._current_raw()
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        lo, hi, step = self._live_range
+        # Reject out-of-range / off-grid up front (clean message); the engine range setter
+        # would otherwise raise an opaque error only at "Start program".
+        on_grid = step > 0 and abs((value - lo) / step - round((value - lo) / step)) < 1e-6
+        if not (lo <= value <= hi) or not on_grid:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_setpoint",
+                translation_placeholders={
+                    "value": _clean_number(value),
+                    "allowed": (
+                        f"min {_clean_number(lo)} max {_clean_number(hi)} "
+                        f"step {_clean_number(step)}"
+                    ),
+                },
+            )
+        self._buffer(_clean_number(value))

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -493,9 +493,15 @@ class HonProgramOptionNumber(HonProgramOptionEntity, NumberEntity):
 
     @property
     def _live_range(self) -> tuple[float, float, float]:
-        # Read live min/max/step off the cached param (cheap: no per-read available_settings
-        # re-resolution across program categories). Falls back if the param is unavailable.
-        rng = option_range(self._option_param) if self._option_param is not None else None
+        # Read live min/max/step from the ACTIVE startProgram command first, so the range
+        # tracks the SELECTED program (the cached _option_param is the merged superset across
+        # categories, which would validate too permissively after a program swap -- PR #38).
+        # Both are cheap single-object reads (no available_settings). Fall back to the cached
+        # merged param, then to the static fallback range.
+        active = self._active_option_param()
+        rng = option_range(active) if active is not None else None
+        if rng is None and self._option_param is not None:
+            rng = option_range(self._option_param)
         return rng or self._fallback_range
 
     @property

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -131,10 +131,14 @@ def option_choices(param, drop: tuple[str, ...] = ()) -> list[str]:
     rng = option_range(param)
     if rng is not None:
         lo, hi, step = rng
+        if step <= 0:
+            return []
         out: list[str] = []
         current = lo
         count = 0
-        while current <= hi + step / 2 and count < _MAX_RANGE_CHOICES:
+        # Tight upper bound (+1e-9 only for float-accumulation drift, NOT step/2): a step
+        # that overshoots the max (e.g. 0..10 step 20) must NOT emit a value beyond hi.
+        while current <= hi + 1e-9 and count < _MAX_RANGE_CHOICES:
             token = _num_str(current)
             if token not in drop and token not in out:
                 out.append(token)
@@ -156,8 +160,14 @@ def is_settable_option(param, drop: tuple[str, ...] = ()) -> bool:
         return False
     rng = option_range(param)
     if rng is not None:
+        lo, hi, step = rng
+        if step <= 0:
+            return False
         if not drop:
-            return rng[1] > rng[0]
+            # >= 2 reachable values: lo AND lo+step must both fall within [lo, hi]. A range
+            # whose step overshoots the max (e.g. 0..10 step 20) has ONE real value -> not a
+            # control (max > min alone would wrongly accept it).
+            return lo + step <= hi + 1e-9
         return len(option_choices(param, drop)) >= 2
     return len(option_value_set(param, drop)) >= 2
 

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -1,0 +1,266 @@
+"""Writable program-option controls for the washing group (WM/WD/TD), discussion #35.
+
+The washer/dryer expose start/stop/pause + a program select, but no way to tune the
+program (spin speed, temperature, dry level, extra rinses, delayed start, ...). Those
+options are PARAMETERS of the ``startProgram`` command, not a separate service: the app
+picks a program, overlays the chosen option values and sends ONE ``startProgram`` bundle.
+
+This module is the shared core for that feature:
+
+- the GATE: a curated candidate catalog (the decompiled-app / andre0512 superset) is
+  filtered by the device's runtime ``startProgram`` schema with a ">= 2 reachable values /
+  not fixed" rule. So an entity is created only when the param is genuinely settable on
+  THIS model -- improving on andre0512's static per-type list, which renders a wall of
+  "No disponible" controls for the params that are fixed on the user's unit. Schema =
+  values; the const label maps supply labels only.
+- the BUFFER + apply-on-start: option entities write to a pending-options store on the
+  coordinator (parallel to PROGRAM_PENDING_STORE) and DO NOT send. The "Start program"
+  button applies the buffered options to the post-swap ``startProgram`` command and sends
+  once (see button.py). This mirrors the existing program buffer/apply-on-start pattern.
+- the shared mixin ``HonProgramOptionEntity`` (pending read/write, live-or-pending read,
+  capability gate) reused by the switch/select/number option entities.
+
+CRITICAL gate detail: check ``option_range`` FIRST and never call ``.values`` on a
+``HonParameterRange`` to count it -- the range ``.values`` enumerates min..max and a
+malformed range can loop. A ``HonParameterFixed`` (or a single-value enum) fails the gate,
+so the entity is never created (auto-removes the fixed toggles on the user's models).
+"""
+from __future__ import annotations
+
+import logging
+
+from .base_entity import HonBaseEntity
+from .const import PROGRAM_PENDING_OPTIONS
+from .debug_utils import redact_id
+from .hon_commands import get_command, param_range, param_values
+
+_LOGGER = logging.getLogger(__name__)
+
+# The single runtime command that carries the program + its options. Selecting a program
+# swaps the active category (program.py / commands.py), but the command name is stable.
+STARTPROGRAM_COMMAND = "startProgram"
+
+# Safety cap when materializing the reachable values of a range parameter: a malformed
+# range (huge max / tiny step) must never loop unbounded while building a select's options.
+_MAX_RANGE_CHOICES = 1000
+
+
+def startprogram_command(appliance):
+    """The device's ``startProgram`` command, or None if absent."""
+    return get_command(appliance, STARTPROGRAM_COMMAND)
+
+
+def startprogram_option_param(appliance, name: str):
+    """Resolve option parameter ``name`` across the ``startProgram`` program categories.
+
+    Prefers ``HonCommand.available_settings`` (the richest, non-fixed variant of the
+    param across program categories -- stable across program swaps), falling back to the
+    active command's ``parameters`` (and to None) so it also works with the lightweight
+    fake commands used by the tests."""
+    command = startprogram_command(appliance)
+    if command is None:
+        return None
+    settings = getattr(command, "available_settings", None)
+    if isinstance(settings, dict) and name in settings:
+        return settings[name]
+    params = getattr(command, "parameters", None)
+    if isinstance(params, dict):
+        return params.get(name)
+    return None
+
+
+def option_range(param) -> tuple[float, float, float] | None:
+    """(min, max, step) of a range parameter, or None if it is not a range.
+
+    Thin wrapper over ``hon_commands.param_range`` (duck-types on min/max/step); kept as a
+    named helper so the gate reads as the design-of-record."""
+    return param_range(param)
+
+
+def _num_str(value) -> str:
+    """Format a numeric value as a clean string: '12' not '12.0', '22.5' kept."""
+    number = float(value)
+    return str(int(number)) if number.is_integer() else str(number)
+
+
+def normalize_code(value) -> str | None:
+    """Normalize a raw device/schema value to its canonical option code.
+
+    Collapses a numeric value to a clean integer/float string ("13.0"/"13"/13 -> "13",
+    "360.0" -> "360"), accepting a decimal comma ("4,5" -> "4.5"); a non-numeric value
+    (an enum key like "iot_smart") passes through as ``str(value)``; None stays None.
+    Used so a device reading and a schema-derived code compare/serialize consistently
+    (the range/enum setters reject "13.0" against an enum/range that expects "13")."""
+    if value is None:
+        return None
+    try:
+        return _num_str(str(value).replace(",", "."))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def option_value_set(param, drop: tuple[str, ...] = ()) -> list[str]:
+    """Distinct ENUM values (clean string codes) of ``param`` minus ``drop``; [] for a range.
+
+    Range is detected FIRST (via ``option_range``) and returns [] -- this never touches
+    the range ``.values`` (which would enumerate min..max). For an enum (or a fixed param,
+    whose base ``.values`` is the single fixed value) it returns the distinct, normalized
+    values (so "12.0"/"12" collapse and a sentinel in ``drop`` matches the clean form)."""
+    if param is None:
+        return []
+    if option_range(param) is not None:
+        return []
+    out: list[str] = []
+    for value in param_values(param):
+        code = normalize_code(value)
+        if code is None or code in drop or code in out:
+            continue
+        out.append(code)
+    return out
+
+
+def option_choices(param, drop: tuple[str, ...] = ()) -> list[str]:
+    """Selectable values (clean strings) of an option param, enum OR range, minus ``drop``.
+
+    For an enum: its distinct values. For a range: the reachable values min..max step
+    (so a range-typed categorical like the dryer's dryLevel[12,13,14] still yields a
+    select's options). Range is checked FIRST and bounded by ``_MAX_RANGE_CHOICES`` so a
+    malformed range can never loop unbounded."""
+    if param is None:
+        return []
+    rng = option_range(param)
+    if rng is not None:
+        lo, hi, step = rng
+        out: list[str] = []
+        current = lo
+        count = 0
+        while current <= hi + step / 2 and count < _MAX_RANGE_CHOICES:
+            token = _num_str(current)
+            if token not in drop and token not in out:
+                out.append(token)
+            current += step
+            count += 1
+        return out
+    return option_value_set(param, drop)
+
+
+def is_settable_option(param, drop: tuple[str, ...] = ()) -> bool:
+    """True if ``param`` is genuinely settable on this model (>= 2 reachable / not fixed).
+
+    ``option_range`` is checked FIRST (never ``.values`` on a range). For a range with no
+    sentinels to drop this is the cheap ``max > min``; with sentinels it counts the
+    reachable NON-sentinel members (so a sentinel-dominated dryLevel range gates OFF).
+    An enum needs >= 2 distinct non-sentinel values. A fixed param (or a 1-value enum, or
+    a sentinel-only range/enum, or None) -> False -> the entity is never created."""
+    if param is None:
+        return False
+    rng = option_range(param)
+    if rng is not None:
+        if not drop:
+            return rng[1] > rng[0]
+        return len(option_choices(param, drop)) >= 2
+    return len(option_value_set(param, drop)) >= 2
+
+
+def apply_pending_options(params: dict, options: dict) -> list[str]:
+    """Apply buffered option values to a command's parameters (the apply-on-start step).
+
+    For each ``(name, value)`` in ``options``: if ``name`` is a parameter of ``params``,
+    set ``params[name].value = value`` (the engine setter validates it); skip-with-debug
+    if the param is absent for the SELECTED program (a different program may not expose it).
+    MUST be called on the POST-SWAP command (see button.py): selecting the program swaps
+    the active startProgram command, and the options have to land on the new one.
+
+    Returns the list of names actually applied."""
+    applied: list[str] = []
+    if not isinstance(params, dict):
+        return applied
+    for name, value in options.items():
+        param = params.get(name)
+        if param is None:
+            _LOGGER.debug(
+                "apply_pending_options: option '%s' absent in the selected program "
+                "command; skipped",
+                name,
+            )
+            continue
+        param.value = value
+        applied.append(name)
+        _LOGGER.debug("apply_pending_options: applied option '%s'=%s", name, value)
+    return applied
+
+
+class HonProgramOptionEntity(HonBaseEntity):
+    """Shared mixin for the writable program-option entities (switch/select/number).
+
+    Read = pending (the buffered, not-yet-started choice) else the live device value.
+    Write = to the coordinator pending-options store ONLY (no send); the real send happens
+    in button.py on "Start program". ``available`` is the base connection+present check with
+    NO ``remoteCtrValid`` gate (consistent with start/pause: a refused write surfaces as a
+    command_error, the control is not hidden). Subclasses pass the hOn ``param_name`` they
+    buffer/read up to ``__init__``."""
+
+    def __init__(self, coordinator, appliance_id: str, param_name: str, client=None) -> None:
+        super().__init__(coordinator, appliance_id, client)
+        self._param = param_name
+        # Resolve the startProgram option parameter ONCE. ``available_settings`` merges the
+        # parameter across ALL program categories and measures each range by its ``.values``
+        # (which enumerates min..max) -- expensive on a 100-program washer. Caching the
+        # resolved param here keeps the per-read available/value/range access off that hot
+        # path (the live min/max/step are still read fresh off this cached object).
+        self._option_param = startprogram_option_param(self._appliance, param_name)
+
+    def _options_store(self) -> dict:
+        """The top-level pending-options store {appliance_id: {param: value}}."""
+        return self._coordinator_store(PROGRAM_PENDING_OPTIONS)
+
+    def _pending(self) -> dict:
+        """The buffered option map for THIS appliance ({param: value}), or {}."""
+        per = self._options_store().get(self._appliance_id)
+        return per if isinstance(per, dict) else {}
+
+    def _buffer(self, value: str) -> None:
+        """Store the chosen value WITHOUT sending; the start button applies it later."""
+        store = self._options_store()
+        per = store.get(self._appliance_id)
+        if not isinstance(per, dict):
+            per = {}
+            store[self._appliance_id] = per
+        per[self._param] = value
+        _LOGGER.debug(
+            "ProgramOption debug: buffered '%s'=%s id=%s param=%s",
+            redact_id(getattr(self, "_attr_unique_id", None), self._appliance_id)
+            or self.__class__.__name__,
+            value,
+            redact_id(self._appliance_id),
+            self._param,
+        )
+        self.async_write_ha_state()
+
+    def _current_raw(self):
+        """Pending value if buffered, else the live device value.
+
+        Reads ``_get_attr(param)`` (the direct attribute the device reports) and then
+        ``_get_attr("startProgram." + param)`` (startProgram is not shadow-synced into
+        attributes, unlike ``settings``)."""
+        pending = self._pending().get(self._param)
+        if pending is not None:
+            return pending
+        raw = self._get_attr(self._param)
+        if raw is not None:
+            return raw
+        return self._get_attr(f"{STARTPROGRAM_COMMAND}.{self._param}")
+
+    @property
+    def available(self) -> bool:
+        # Base connection+present check, NO remoteCtrValid gate (see class docstring).
+        return super().available
+
+    @classmethod
+    def supports(cls, appliance, param_name: str, drop: tuple[str, ...] = ()) -> bool:
+        """Capability gate: the device declares ``param_name`` in startProgram AND it is
+        genuinely settable (>= 2 reachable values / not fixed)."""
+        param = startprogram_option_param(appliance, param_name)
+        if param is None:
+            return False
+        return is_settable_option(param, drop)

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -251,6 +251,20 @@ class HonProgramOptionEntity(HonBaseEntity):
             return raw
         return self._get_attr(f"{STARTPROGRAM_COMMAND}.{self._param}")
 
+    def _active_option_param(self):
+        """Resolve this param off the ACTIVE startProgram command's parameters only.
+
+        Program-accurate (and cheap) vs the cached ``_option_param`` (the merged-across-
+        categories superset): selecting a program SWAPS the active ``startProgram`` command,
+        so a per-program range/value must come from the current command, not the merged
+        cache (PR #38 / Greptile P2). Never calls ``available_settings`` (no range
+        enumeration). Returns None if the command/param is absent."""
+        command = startprogram_command(self._appliance)
+        params = getattr(command, "parameters", None) if command is not None else None
+        if isinstance(params, dict):
+            return params.get(self._param)
+        return None
+
     @property
     def available(self) -> bool:
         # Base connection+present check, NO remoteCtrValid gate (see class docstring).

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -1,6 +1,7 @@
-"""Haier hOn select - washer program selection."""
+"""Haier hOn select - washer program selection + writable program options."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 
 from homeassistant.components.select import SelectEntity
@@ -11,14 +12,88 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
 from .const import (
+    APPLIANCE_TD,
     APPLIANCE_WASH_GROUP,
+    APPLIANCE_WD,
+    APPLIANCE_WM,
+    DIRTY_LEVEL_LABELS,
     DOMAIN,
+    DRY_LEVEL_LABELS_TD,
+    DRY_LEVEL_LABELS_WM,
+    DRY_LEVEL_SENTINELS,
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_STORE,
+    STEAM_LEVEL_LABELS,
+    TEMP_LEVEL_LABELS,
 )
 from .debug_utils import redact_id, redact_store
+from .program_options import (
+    HonProgramOptionEntity,
+    normalize_code,
+    option_choices,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HonProgramOptionSelectDescription:
+    """A categorical program option rendered as a select (#35).
+
+    `label_map` maps raw schema values -> machine keys for the select state translations
+    (None = render the raw values, used for the numeric spin/temp enums). `drop` removes
+    unselectable sentinels. `types` gates the appliance families; dryLevel is TYPE-GATED
+    (WM/WD vs TD) because value 1 means EXTRA_DRY on WM/WD but IRON_DRY on TD, so the two
+    descriptions share the `dry_level` translation_key but carry disjoint label maps.
+    """
+
+    key: str                 # base of the unique_id suffix (opt_<key>)
+    param: str
+    translation_key: str
+    types: tuple[str, ...]
+    label_map: dict[str, str] | None = None
+    drop: tuple[str, ...] = ()
+    icon: str | None = None
+
+
+_WASH_TYPES = (APPLIANCE_WM, APPLIANCE_WD)
+_DRY_TYPES = (APPLIANCE_TD,)
+
+# Candidate program-option selects, capability-gated by the device schema. spin/temp are
+# numeric enums on the real washers -> selects with raw numeric labels (no state block).
+# dryLevel/tempLevel/dirtyLevel/steamLevel are label-mapped (state translations).
+_PROGRAM_OPTION_SELECTS: tuple[HonProgramOptionSelectDescription, ...] = (
+    HonProgramOptionSelectDescription(
+        key="spin_speed", param="spinSpeed", translation_key="spin_speed",
+        types=_WASH_TYPES, icon="mdi:speedometer",
+    ),
+    HonProgramOptionSelectDescription(
+        key="wash_temp", param="temp", translation_key="wash_temp",
+        types=_WASH_TYPES, icon="mdi:thermometer",
+    ),
+    HonProgramOptionSelectDescription(
+        key="dry_level", param="dryLevel", translation_key="dry_level",
+        types=_WASH_TYPES, label_map=DRY_LEVEL_LABELS_WM, drop=DRY_LEVEL_SENTINELS,
+        icon="mdi:tumble-dryer",
+    ),
+    HonProgramOptionSelectDescription(
+        key="dry_level", param="dryLevel", translation_key="dry_level",
+        types=_DRY_TYPES, label_map=DRY_LEVEL_LABELS_TD, drop=DRY_LEVEL_SENTINELS,
+        icon="mdi:tumble-dryer",
+    ),
+    HonProgramOptionSelectDescription(
+        key="temp_level", param="tempLevel", translation_key="temp_level",
+        types=_DRY_TYPES, label_map=TEMP_LEVEL_LABELS, icon="mdi:thermometer",
+    ),
+    HonProgramOptionSelectDescription(
+        key="dirty_level", param="dirtyLevel", translation_key="dirty_level",
+        types=_WASH_TYPES, label_map=DIRTY_LEVEL_LABELS, icon="mdi:liquid-spot",
+    ),
+    HonProgramOptionSelectDescription(
+        key="steam_level", param="steamLevel", translation_key="steam_level",
+        types=_WASH_TYPES, label_map=STEAM_LEVEL_LABELS, icon="mdi:weather-fog",
+    ),
+)
 
 # "Safe" commands (they do not start a cycle) to read/write the program from.
 PROGRAM_SELECT_COMMANDS = ("settings", "setProgram", "setProgramme", "programSettings")
@@ -74,6 +149,27 @@ async def async_setup_entry(
                 redact_id(appliance_id),
                 PROGRAM_PARAM_NAMES,
             )
+        # Writable program-option selects (#35): capability-gated on the live schema.
+        created_opts: list[str] = []
+        for desc in _PROGRAM_OPTION_SELECTS:
+            if app_type not in desc.types:
+                continue
+            if not HonProgramOptionSelect.supports(appliance, desc.param, desc.drop):
+                continue
+            entities.append(HonProgramOptionSelect(coordinator, appliance_id, desc, client))
+            created_opts.append(desc.key)
+        if created_opts:
+            _LOGGER.info(
+                "Added %d program-option selects: id=%s",
+                len(created_opts),
+                redact_id(appliance_id),
+            )
+        _LOGGER.debug(
+            "Select debug: option selects for id=%s type=%s -> %s",
+            redact_id(appliance_id),
+            app_type,
+            created_opts,
+        )
     async_add_entities(entities)
 
 
@@ -311,3 +407,61 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         )
         _LOGGER.debug("Select debug: after selection store=%s", redact_store(store))
         self.async_write_ha_state()
+
+
+class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
+    """Categorical program option (dry level, spin speed, soil level, ...) buffered onto
+    the startProgram command; applied + sent on the "Start program" button."""
+
+    def __init__(
+        self,
+        coordinator,
+        appliance_id: str,
+        description: HonProgramOptionSelectDescription,
+        client=None,
+    ) -> None:
+        super().__init__(coordinator, appliance_id, description.param, client)
+        self._desc = description
+        self._attr_translation_key = description.translation_key
+        self._attr_unique_id = f"{appliance_id}_opt_{description.key}"
+        if description.icon:
+            self._attr_icon = description.icon
+        label_map = description.label_map or {}
+        # The param is resolved + cached once by the mixin; materialize its codes here.
+        choices = (
+            option_choices(self._option_param, description.drop)
+            if self._option_param is not None
+            else []
+        )
+        # raw schema value -> displayed option key (label map, raw value as fallback).
+        self._raw_to_key: dict[str, str] = {raw: label_map.get(raw, raw) for raw in choices}
+        self._key_to_raw: dict[str, str] = {key: raw for raw, key in self._raw_to_key.items()}
+        # Preserve order, dedupe (two raw codes can share a label on some models).
+        self._attr_options = list(dict.fromkeys(self._raw_to_key.values()))
+        _LOGGER.debug(
+            "Select debug: init option select '%s' id=%s param=%s options=%s",
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
+            description.param,
+            self._attr_options,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        raw = self._current_raw()
+        if raw is None:
+            return None
+        return self._raw_to_key.get(normalize_code(raw))
+
+    async def async_select_option(self, option: str) -> None:
+        raw = self._key_to_raw.get(option)
+        if raw is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_setpoint",
+                translation_placeholders={
+                    "value": option,
+                    "allowed": ", ".join(self._attr_options),
+                },
+            )
+        self._buffer(raw)

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -450,11 +450,24 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
             if self._option_param is not None
             else []
         )
-        # raw schema value -> displayed option key (label map, raw value as fallback).
-        self._raw_to_key: dict[str, str] = {raw: label_map.get(raw, raw) for raw in choices}
+        # raw schema value -> base label (label map, raw value as fallback).
+        base_keys = {raw: label_map.get(raw, raw) for raw in choices}
+        # Collision-aware disambiguation (PR #38 / Greptile P2): when two EXPOSED raw codes
+        # share a label (DRY_LEVEL_LABELS_TD maps e.g. 1 & 12 both to "iron_dry"), suffixing
+        # ONLY the colliding ones with their raw code keeps every code selectable and keeps
+        # the reverse map injective (otherwise one raw would be unreachable). Non-colliding
+        # labels are untouched, so the common case keeps its translatable `state.<key>`; a
+        # suffixed colliding key has no translation and renders literally (rare-model-only).
+        label_counts: dict[str, int] = {}
+        for label in base_keys.values():
+            label_counts[label] = label_counts.get(label, 0) + 1
+        self._raw_to_key: dict[str, str] = {
+            raw: (f"{label} ({raw})" if label_counts[label] > 1 else label)
+            for raw, label in base_keys.items()
+        }
         self._key_to_raw: dict[str, str] = {key: raw for raw, key in self._raw_to_key.items()}
-        # Preserve order, dedupe (two raw codes can share a label on some models).
-        self._attr_options = list(dict.fromkeys(self._raw_to_key.values()))
+        # One distinct option per exposed raw code (keys are now unique; order preserved).
+        self._attr_options = list(self._raw_to_key.values())
         _LOGGER.debug(
             "Select debug: init option select '%s' id=%s param=%s options=%s",
             redact_id(self._attr_unique_id, appliance_id),

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -22,6 +22,7 @@ from .const import (
     DRY_LEVEL_LABELS_WM,
     DRY_LEVEL_SENTINELS,
     PROGRAM_PARAM_NAMES,
+    PROGRAM_PENDING_OPTIONS,
     PROGRAM_PENDING_STORE,
     STEAM_LEVEL_LABELS,
     TEMP_LEVEL_LABELS,
@@ -394,6 +395,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         # with the "Avvia programma" button, which reads this pending program and
         # applies it to the startProgram command.
         store = self._coordinator_store(PROGRAM_PENDING_STORE)
+        previous_code = store.get(self._appliance_id)
         _LOGGER.debug(
             "Select debug: before selection option=%s code=%s store=%s",
             option,
@@ -401,10 +403,25 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
             redact_store(store),
         )
         store[self._appliance_id] = code
+        # Changing the program invalidates any buffered program OPTIONS: they were chosen
+        # for the previous program and must not silently carry into the new one at Start
+        # (PR #38 / Greptile P1). Clear them ONLY on an actual program change, so
+        # re-selecting the SAME program keeps the user's buffered options.
+        cleared = (
+            self._coordinator_store(PROGRAM_PENDING_OPTIONS).pop(self._appliance_id, None)
+            if previous_code != code
+            else None
+        )
         _LOGGER.info(
             "Select: program '%s' (code=%s) set; start it with 'Avvia programma'",
             option, code,
         )
+        if cleared:
+            _LOGGER.debug(
+                "Select debug: program change id=%s cleared pending options=%s",
+                redact_id(self._appliance_id),
+                sorted(cleared) if isinstance(cleared, dict) else None,
+            )
         _LOGGER.debug("Select debug: after selection store=%s", redact_store(store))
         self.async_write_ha_state()
 

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -15,13 +15,21 @@ from .ac_command import async_send_settings, settings_param
 from .base_entity import HonAccountEntity, HonBaseEntity
 from .const import (
     APPLIANCE_AC,
+    APPLIANCE_TD,
     APPLIANCE_WASH_GROUP,
+    APPLIANCE_WD,
+    APPLIANCE_WM,
     CONF_ENABLE_DEBUG,
     CONF_ENABLE_MQTT_DEBUG,
     DOMAIN,
     WM_ATTR_STATUS,
 )
 from .debug_utils import redact_id
+from .program_options import (
+    HonProgramOptionEntity,
+    normalize_code,
+    option_choices,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,6 +66,43 @@ _AC_SWITCHES: tuple[HonAcSwitchDescription, ...] = (
     HonAcSwitchDescription(key="fresh_air", param="freshAirStatus", icon="mdi:air-filter"),
     HonAcSwitchDescription(key="half_degree", param="halfDegreeSettingStatus", icon="mdi:thermometer-lines"),
     HonAcSwitchDescription(key="energy_saving", param="energySavingStatus", icon="mdi:meter-electric"),
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HonProgramOptionSwitchDescription:
+    """Boolean program-option switch buffered onto the startProgram command (#35).
+
+    `param` is the startProgram parameter name (read + write). `types` gates which
+    appliance families the option applies to. on/off tokens are derived from the device
+    schema at runtime (handles 0/1 AND value-pair ranges like antiCreaseTime[0,360]).
+    """
+
+    key: str            # translation_key + base of the unique_id suffix
+    param: str
+    types: tuple[str, ...]
+    icon: str | None = None
+
+
+# Candidate program-option switches (decomp/andre0512 superset), capability-gated by the
+# device's startProgram schema (a param that is fixed / single-value on the model creates
+# NO entity, so no "No disponible" clutter). WM/WD vs TD families are kept distinct
+# (anticrease is the WM/WD opt-toggle; antiCreaseTime is the TD timed variant).
+_WASH_TYPES = (APPLIANCE_WM, APPLIANCE_WD)
+_DRY_TYPES = (APPLIANCE_TD,)
+_PROGRAM_OPTION_SWITCHES: tuple[HonProgramOptionSwitchDescription, ...] = (
+    HonProgramOptionSwitchDescription(key="extra_rinse_1", param="extraRinse1", types=_WASH_TYPES, icon="mdi:water-plus"),
+    HonProgramOptionSwitchDescription(key="extra_rinse_2", param="extraRinse2", types=_WASH_TYPES, icon="mdi:water-plus"),
+    HonProgramOptionSwitchDescription(key="extra_rinse_3", param="extraRinse3", types=_WASH_TYPES, icon="mdi:water-plus"),
+    HonProgramOptionSwitchDescription(key="acquaplus", param="acquaplus", types=_WASH_TYPES, icon="mdi:water"),
+    HonProgramOptionSwitchDescription(key="prewash", param="prewash", types=_WASH_TYPES, icon="mdi:water-sync"),
+    HonProgramOptionSwitchDescription(key="hygiene", param="hygiene", types=_WASH_TYPES, icon="mdi:bacteria"),
+    HonProgramOptionSwitchDescription(key="anticrease", param="anticrease", types=_WASH_TYPES, icon="mdi:tshirt-crew"),
+    HonProgramOptionSwitchDescription(key="good_night", param="goodNight", types=_WASH_TYPES, icon="mdi:weather-night"),
+    HonProgramOptionSwitchDescription(key="sterilization", param="sterilizationStatus", types=_DRY_TYPES, icon="mdi:bacteria-outline"),
+    HonProgramOptionSwitchDescription(key="tumbling", param="tumblingStatus", types=_DRY_TYPES, icon="mdi:tumble-dryer"),
+    HonProgramOptionSwitchDescription(key="permanent_press", param="permanentPressStatus", types=_DRY_TYPES, icon="mdi:tshirt-crew-outline"),
+    HonProgramOptionSwitchDescription(key="anti_crease_time", param="antiCreaseTime", types=_DRY_TYPES, icon="mdi:tshirt-crew"),
 )
 
 
@@ -108,6 +153,28 @@ async def async_setup_entry(
                         "Switch debug: pause switch not created for id=%s; pause/resume missing",
                         redact_id(appliance_id),
                     )
+            # Writable program-option switches (#35): created only for the params this
+            # model genuinely exposes as settable in its startProgram schema.
+            created_opts: list[str] = []
+            for desc in _PROGRAM_OPTION_SWITCHES:
+                if app_type not in desc.types:
+                    continue
+                if not HonProgramOptionSwitch.supports(appliance, desc.param):
+                    continue
+                entities.append(HonProgramOptionSwitch(coordinator, appliance_id, desc, client))
+                created_opts.append(desc.key)
+            if created_opts:
+                _LOGGER.info(
+                    "Added %d program-option switches: id=%s",
+                    len(created_opts),
+                    redact_id(appliance_id),
+                )
+            _LOGGER.debug(
+                "Switch debug: option switches for id=%s type=%s -> %s",
+                redact_id(appliance_id),
+                app_type,
+                created_opts,
+            )
         elif app_type == APPLIANCE_AC:
             created: list[str] = []
             for desc in _AC_SWITCHES:
@@ -284,6 +351,52 @@ class HonAcSwitch(HonBaseEntity, SwitchEntity):
                 translation_key="command_error",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+
+class HonProgramOptionSwitch(HonProgramOptionEntity, SwitchEntity):
+    """Boolean program option (extra rinse, prewash, sterilization, ...) buffered onto
+    the startProgram command; the real send happens on the "Start program" button."""
+
+    def __init__(
+        self,
+        coordinator,
+        appliance_id: str,
+        description: HonProgramOptionSwitchDescription,
+        client=None,
+    ) -> None:
+        super().__init__(coordinator, appliance_id, description.param, client)
+        self._desc = description
+        self._attr_translation_key = description.key
+        self._attr_unique_id = f"{appliance_id}_opt_{description.key}"
+        if description.icon:
+            self._attr_icon = description.icon
+        # Resolve on/off tokens from the device schema (the param is resolved + cached once
+        # by the mixin): off = "0" (or the lowest value), on = the first value that is not
+        # off. Handles plain 0/1 AND value-pair ranges such as antiCreaseTime[0,360].
+        choices = option_choices(self._option_param) if self._option_param is not None else []
+        self._off = "0" if "0" in choices else (choices[0] if choices else "0")
+        self._on = next((c for c in choices if c != self._off), "1")
+        _LOGGER.debug(
+            "Switch debug: init option switch '%s' id=%s param=%s off=%s on=%s",
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
+            description.param,
+            self._off,
+            self._on,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        raw = self._current_raw()
+        if raw is None:
+            return None
+        return normalize_code(raw) != self._off
+
+    async def async_turn_on(self, **kwargs) -> None:
+        self._buffer(self._on)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        self._buffer(self._off)
 
 
 class HonDebugSwitch(HonAccountEntity, SwitchEntity):

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -655,7 +655,7 @@
         "name": "Keep fresh"
       },
       "anti_crease_time": {
-        "name": "Anti-crease"
+        "name": "Anti-crease time"
       },
       "pause": {
         "name": "Pause"

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -621,6 +621,42 @@
       "energy_saving": {
         "name": "Energy saving"
       },
+      "extra_rinse_1": {
+        "name": "Extra rinse 1"
+      },
+      "extra_rinse_2": {
+        "name": "Extra rinse 2"
+      },
+      "extra_rinse_3": {
+        "name": "Extra rinse 3"
+      },
+      "acquaplus": {
+        "name": "Acqua Plus"
+      },
+      "prewash": {
+        "name": "Prewash"
+      },
+      "hygiene": {
+        "name": "Extra hygiene"
+      },
+      "anticrease": {
+        "name": "Anti-crease"
+      },
+      "good_night": {
+        "name": "Good night"
+      },
+      "sterilization": {
+        "name": "Sterilization"
+      },
+      "tumbling": {
+        "name": "Tumbling"
+      },
+      "permanent_press": {
+        "name": "Keep fresh"
+      },
+      "anti_crease_time": {
+        "name": "Anti-crease"
+      },
       "pause": {
         "name": "Pause"
       },
@@ -655,11 +691,58 @@
       },
       "target_temp_oven": {
         "name": "Oven temperature"
+      },
+      "delay_time": {
+        "name": "Delayed start"
       }
     },
     "select": {
       "program": {
         "name": "Program"
+      },
+      "spin_speed": {
+        "name": "Spin speed"
+      },
+      "wash_temp": {
+        "name": "Temperature"
+      },
+      "dry_level": {
+        "name": "Dry level",
+        "state": {
+          "extra_dry": "Extra dry",
+          "cupboard": "Cupboard dry",
+          "iron_dry": "Iron dry",
+          "hang_dry": "Hang dry",
+          "smart_dry": "Smart dry",
+          "wool_dry": "Wool dry",
+          "ready_to_wear": "Ready to wear"
+        }
+      },
+      "temp_level": {
+        "name": "Temperature level",
+        "state": {
+          "minimum": "Minimum",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High"
+        }
+      },
+      "dirty_level": {
+        "name": "Soil level",
+        "state": {
+          "little": "Light",
+          "normal": "Normal",
+          "very": "Heavy"
+        }
+      },
+      "steam_level": {
+        "name": "Steam level",
+        "state": {
+          "no_steam": "No steam",
+          "cotton": "Cotton",
+          "delicate": "Delicate",
+          "synthetic": "Synthetic"
+        }
       }
     },
     "button": {

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -621,6 +621,42 @@
       "energy_saving": {
         "name": "Risparmio Energetico"
       },
+      "extra_rinse_1": {
+        "name": "Extra risciacquo 1"
+      },
+      "extra_rinse_2": {
+        "name": "Extra risciacquo 2"
+      },
+      "extra_rinse_3": {
+        "name": "Extra risciacquo 3"
+      },
+      "acquaplus": {
+        "name": "Acqua Plus"
+      },
+      "prewash": {
+        "name": "Prelavaggio"
+      },
+      "hygiene": {
+        "name": "Igiene extra"
+      },
+      "anticrease": {
+        "name": "Antipiega"
+      },
+      "good_night": {
+        "name": "Buonanotte"
+      },
+      "sterilization": {
+        "name": "Sterilizzazione"
+      },
+      "tumbling": {
+        "name": "Rotazione antipiega"
+      },
+      "permanent_press": {
+        "name": "Mantieni fresco"
+      },
+      "anti_crease_time": {
+        "name": "Antipiega"
+      },
       "pause": {
         "name": "Pausa"
       },
@@ -655,11 +691,58 @@
       },
       "target_temp_oven": {
         "name": "Temperatura Forno"
+      },
+      "delay_time": {
+        "name": "Partenza ritardata"
       }
     },
     "select": {
       "program": {
         "name": "Programma"
+      },
+      "spin_speed": {
+        "name": "Centrifuga"
+      },
+      "wash_temp": {
+        "name": "Temperatura"
+      },
+      "dry_level": {
+        "name": "Livello di asciugatura",
+        "state": {
+          "extra_dry": "Extra asciutto",
+          "cupboard": "Pronto armadio",
+          "iron_dry": "Pronto stiro",
+          "hang_dry": "Pronto stendi",
+          "smart_dry": "Asciugatura smart",
+          "wool_dry": "Asciugatura lana",
+          "ready_to_wear": "Pronto indossa"
+        }
+      },
+      "temp_level": {
+        "name": "Livello temperatura",
+        "state": {
+          "minimum": "Minima",
+          "low": "Bassa",
+          "medium": "Media",
+          "high": "Alta"
+        }
+      },
+      "dirty_level": {
+        "name": "Livello di sporco",
+        "state": {
+          "little": "Leggero",
+          "normal": "Normale",
+          "very": "Intenso"
+        }
+      },
+      "steam_level": {
+        "name": "Livello vapore",
+        "state": {
+          "no_steam": "Senza vapore",
+          "cotton": "Cotone",
+          "delicate": "Delicati",
+          "synthetic": "Sintetici"
+        }
       }
     },
     "button": {

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -655,7 +655,7 @@
         "name": "Mantieni fresco"
       },
       "anti_crease_time": {
-        "name": "Antipiega"
+        "name": "Tempo antipiega"
       },
       "pause": {
         "name": "Pausa"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,83 @@ def _install_homeassistant_error() -> None:
     exc.HomeAssistantError = HomeAssistantError
 
 
+def _ensure_module(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_shared_entity_stubs() -> None:
+    """Install the COMPLETE Home Assistant stubs the entity stack binds at import time.
+
+    `custom_components/addhon/base_entity.py` does `class HonBaseEntity(CoordinatorEntity)`
+    at import, so whatever `CoordinatorEntity` is in sys.modules the FIRST time base_entity
+    is imported becomes the permanent base for the run. Several test modules install an
+    INCOMPLETE `CoordinatorEntity` (no `async_write_ha_state` / `available` / `hass`) with a
+    first-wins `getattr(...)` idiom; in a partial collection order one of those can win and
+    poison every entity instantiated afterwards. Likewise some `const` stubs omit symbols
+    the platforms import at module load (e.g. `UnitOfTime`). pytest imports this conftest
+    before ANY test module, so installing a COMPLETE `CoordinatorEntity` + the full `const`
+    symbol set here makes those per-file first-wins `getattr`/`hasattr` calls reuse the
+    complete shared stubs -- the suite stops depending on collection order. Everything is
+    getattr/hasattr-guarded so an already-present (or real) symbol is never clobbered."""
+    helpers = _ensure_module("homeassistant.helpers")
+    sys.modules["homeassistant"].helpers = helpers
+
+    uc = _ensure_module("homeassistant.helpers.update_coordinator")
+    helpers.update_coordinator = uc
+
+    class CoordinatorEntity:
+        """Complete mirror of HA's CoordinatorEntity (the base HonBaseEntity subclasses)."""
+
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+            self.hass = getattr(coordinator, "hass", None)
+
+        @property
+        def available(self) -> bool:
+            return getattr(self.coordinator, "last_update_success", True)
+
+        def async_write_ha_state(self) -> None:
+            self.state_writes = getattr(self, "state_writes", 0) + 1
+
+    uc.CoordinatorEntity = getattr(uc, "CoordinatorEntity", CoordinatorEntity)
+    uc.DataUpdateCoordinator = getattr(
+        uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {})
+    )
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+
+    const = _ensure_module("homeassistant.const")
+    sys.modules["homeassistant"].const = const
+    if not hasattr(const, "UnitOfTemperature"):
+        const.UnitOfTemperature = type("UnitOfTemperature", (), {"CELSIUS": "°C"})
+    if not hasattr(const, "UnitOfTime"):
+        const.UnitOfTime = type("UnitOfTime", (), {"MINUTES": "min", "SECONDS": "s"})
+    if not hasattr(const, "UnitOfEnergy"):
+        const.UnitOfEnergy = type("UnitOfEnergy", (), {"KILO_WATT_HOUR": "kWh"})
+    if not hasattr(const, "UnitOfVolume"):
+        const.UnitOfVolume = type("UnitOfVolume", (), {"LITERS": "L"})
+    if not hasattr(const, "UnitOfMass"):
+        const.UnitOfMass = type("UnitOfMass", (), {"GRAMS": "g", "KILOGRAMS": "kg"})
+    if not hasattr(const, "EntityCategory"):
+        const.EntityCategory = type(
+            "EntityCategory", (), {"CONFIG": "config", "DIAGNOSTIC": "diagnostic"}
+        )
+
+    # base_entity's other import-time HA deps (never order-sensitive today, seeded here so
+    # the same class of bug can't resurface for a future entity-only subset).
+    entity = _ensure_module("homeassistant.helpers.entity")
+    helpers.entity = entity
+    entity.DeviceInfo = getattr(entity, "DeviceInfo", dict)
+    dr = _ensure_module("homeassistant.helpers.device_registry")
+    helpers.device_registry = dr
+    dr.DeviceEntryType = getattr(
+        dr, "DeviceEntryType", type("DeviceEntryType", (), {"SERVICE": "service"})
+    )
+
+
 def _ensure_yarl() -> None:
     """The CI test env installs only pytest (no yarl). config_flow now imports the
     transport auth (which does `from yarl import URL`), so importing config_flow -- and
@@ -74,4 +151,5 @@ def _ensure_yarl() -> None:
 
 
 _install_homeassistant_error()
+_install_shared_entity_stubs()
 _ensure_yarl()

--- a/tests/fixtures/td_haier_hd90/startprogram_params.json
+++ b/tests/fixtures/td_haier_hd90/startprogram_params.json
@@ -1,0 +1,236 @@
+{
+  "_comment": "Real startProgram command parameter SCHEMA of erpayo device (model HD90-A3959 INT), from the redacted config-entry diagnostics dump (discussion #35, 2026-06-25). Reconstructed into raw engine attribute form (typology + enumValues/min/max/step) so the gate can be run against real HonParameter objects. Haier tumble dryer, settable on this unit: dryLevel[12,13,14] + tempLevel[2,3,4] + delayTime + antiCreaseTime[0,360] + sterilizationStatus + tumblingStatus (range). dryTimeMM fixed. No identity, schema only.",
+  "model": "HD90-A3959 INT",
+  "type": "TD",
+  "source": "config_entry diagnostics (.data.appliances[].commands.startProgram), redacted",
+  "captured": "2026-06-25",
+  "startprogram_params": {
+    "airWashMode": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "program": {
+      "typology": "enum",
+      "enumValues": [
+        "Algodón",
+        "Ropa mixta",
+        "Sintéticos",
+        "Sábanas",
+        "hqd_baby_care",
+        "hqd_bath_towel",
+        "hqd_bed_sheets",
+        "hqd_bulky",
+        "hqd_casual",
+        "hqd_cold_wind_timing",
+        "hqd_cotton",
+        "hqd_curtain",
+        "hqd_delicate",
+        "hqd_duvet",
+        "hqd_feather",
+        "hqd_hot_wind_timing",
+        "hqd_hygienic",
+        "hqd_i_refresh",
+        "hqd_jacket",
+        "hqd_jeans",
+        "hqd_mix",
+        "hqd_night_dry",
+        "hqd_outdoor",
+        "hqd_precious_cure",
+        "hqd_quick_30",
+        "hqd_quick_dry",
+        "hqd_quilt",
+        "hqd_refresh",
+        "hqd_shirt",
+        "hqd_shoes",
+        "hqd_silk",
+        "hqd_sports",
+        "hqd_synthetics",
+        "hqd_timer",
+        "hqd_towel",
+        "hqd_underwear",
+        "hqd_wool",
+        "hqd_working_suit",
+        "iot_dry_baby",
+        "iot_dry_backpacks",
+        "iot_dry_bathrobe",
+        "iot_dry_bed_linen",
+        "iot_dry_cotton",
+        "iot_dry_cuddly_toys",
+        "iot_dry_curtains",
+        "iot_dry_delicates",
+        "iot_dry_denim_jeans",
+        "iot_dry_down_jacket",
+        "iot_dry_duvet",
+        "iot_dry_gym_fit",
+        "iot_dry_lingerie",
+        "iot_dry_mixed",
+        "iot_dry_pet_accessories",
+        "iot_dry_pet_hair_removal",
+        "iot_dry_rapid_30",
+        "iot_dry_rapid_59",
+        "iot_dry_shirts",
+        "iot_dry_swimsuits_and_bikinis",
+        "iot_dry_synthetics",
+        "iot_dry_tablecloths",
+        "iot_dry_technical_fabrics",
+        "iot_dry_tennis_tie_break",
+        "iot_dry_wool"
+      ],
+      "defaultValue": "iot_dry_baby"
+    },
+    "airwashSprayTime": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "anionStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "antiCreaseTime": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 360.0,
+      "incrementValue": 360.0,
+      "defaultValue": 0
+    },
+    "buzzerDisabled": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "cloudProgId": {
+      "typology": "fixed",
+      "fixedValue": "255"
+    },
+    "cloudProgSrc": {
+      "typology": "fixed",
+      "fixedValue": "2"
+    },
+    "delayTime": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1410.0,
+      "incrementValue": 30.0,
+      "defaultValue": 0
+    },
+    "delicateStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "dryLevel": {
+      "typology": "range",
+      "minimumValue": 12.0,
+      "maximumValue": 14.0,
+      "incrementValue": 1.0,
+      "defaultValue": 14
+    },
+    "dryMode": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "dryTimeMM": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "fastDryStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "ironRemindStatus": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "lockStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "mitesRemovalStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "onOffStatus": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "operationName": {
+      "typology": "fixed",
+      "fixedValue": "grDryCloudProg"
+    },
+    "pause": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "prCode": {
+      "typology": "fixed",
+      "fixedValue": "63"
+    },
+    "programClass": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "sterilizationStatus": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    },
+    "tempLevel": {
+      "typology": "range",
+      "minimumValue": 2.0,
+      "maximumValue": 4.0,
+      "incrementValue": 1.0,
+      "defaultValue": 3
+    },
+    "texture": {
+      "typology": "fixed",
+      "fixedValue": "64"
+    },
+    "energyLabel": {
+      "typology": "range",
+      "minimumValue": 1.0,
+      "maximumValue": 5.0,
+      "incrementValue": 1.0,
+      "defaultValue": 2
+    },
+    "programCluster": {
+      "typology": "fixed",
+      "fixedValue": "specialCare"
+    },
+    "programFamily": {
+      "typology": "enum",
+      "enumValues": [
+        "guided",
+        "auto",
+        "guided_auto"
+      ],
+      "defaultValue": "guided_auto"
+    },
+    "programType": {
+      "typology": "fixed",
+      "fixedValue": "D"
+    },
+    "prPosition": {
+      "typology": "fixed",
+      "fixedValue": "8"
+    },
+    "remoteActionable": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "remoteVisible": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "suggestedLoadD": {
+      "typology": "fixed",
+      "fixedValue": 4.5
+    },
+    "tumblingStatus": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    }
+  }
+}

--- a/tests/fixtures/wm_candy_tca286/startprogram_params.json
+++ b/tests/fixtures/wm_candy_tca286/startprogram_params.json
@@ -1,0 +1,281 @@
+{
+  "_comment": "Real startProgram command parameter SCHEMA of erpayo device (model TCA286TM5-S), from the redacted config-entry diagnostics dump (discussion #35, 2026-06-25). Reconstructed into raw engine attribute form (typology + enumValues/min/max/step) so the gate can be run against real HonParameter objects. Candy washing machine, settable on this unit: spinSpeed/temp (enum) + delayTime + extraRinse1/2/3 + acquaplus (range). prewash/hygiene/anticrease/goodNight/dirtyLevel fixed. No identity, schema only.",
+  "model": "TCA286TM5-S",
+  "type": "WM",
+  "source": "config_entry diagnostics (.data.appliances[].commands.startProgram), redacted",
+  "captured": "2026-06-25",
+  "startprogram_params": {
+    "checkUpStatus": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "program": {
+      "typology": "enum",
+      "enumValues": [
+        "autoclean",
+        "cottons",
+        "delicati_59",
+        "drain_spin",
+        "eco_40_60_new_energy_label",
+        "handwash_wool",
+        "hygiene_60",
+        "hygiene_plus_59",
+        "intensive_40",
+        "iot_checkup",
+        "iot_wash_100_custom_wash",
+        "iot_wash_anti_mites",
+        "iot_wash_ariel_clean_cycle",
+        "iot_wash_ariel_cold_cycle",
+        "iot_wash_ariel_fresh_cycle",
+        "iot_wash_baby_sanitizer",
+        "iot_wash_backpacks",
+        "iot_wash_bathrobe",
+        "iot_wash_bed_linen",
+        "iot_wash_bleaching",
+        "iot_wash_blood_stains",
+        "iot_wash_cashmere",
+        "iot_wash_chocolate_stains",
+        "iot_wash_cold_wash",
+        "iot_wash_colored",
+        "iot_wash_colored_anti_stain",
+        "iot_wash_colored_delicate",
+        "iot_wash_coloured",
+        "iot_wash_coloured_bed_linen",
+        "iot_wash_coloured_curtains",
+        "iot_wash_coloured_shirts",
+        "iot_wash_cotton",
+        "iot_wash_cuddly_toys",
+        "iot_wash_curtains",
+        "iot_wash_dark",
+        "iot_wash_darks_and_coloured_44",
+        "iot_wash_darks_and_coloured_59",
+        "iot_wash_darks_and_coloured_xl",
+        "iot_wash_dash_clean_cycle",
+        "iot_wash_dash_cold_cycle",
+        "iot_wash_dash_fresh_cycle",
+        "iot_wash_delicate",
+        "iot_wash_delicate_antiallergy",
+        "iot_wash_delicate_colors",
+        "iot_wash_delicate_dark",
+        "iot_wash_delicate_tablecloths",
+        "iot_wash_delicate_whites",
+        "iot_wash_denim_jeans",
+        "iot_wash_diving_suits",
+        "iot_wash_down_jackets",
+        "iot_wash_fruit_stains",
+        "iot_wash_gym_fit",
+        "iot_wash_handwash",
+        "iot_wash_handwash_colored",
+        "iot_wash_handwash_dark",
+        "iot_wash_lingerie",
+        "iot_wash_masks_refresh",
+        "iot_wash_masks_sanification",
+        "iot_wash_mats",
+        "iot_wash_men_s_trousers",
+        "iot_wash_mix_and_coloured_44",
+        "iot_wash_mix_and_coloured_59",
+        "iot_wash_mix_and_coloured_xl",
+        "iot_wash_mixed",
+        "iot_wash_new_clothes",
+        "iot_wash_perfect_white",
+        "iot_wash_pets",
+        "iot_wash_pets_hair_removal",
+        "iot_wash_pets_odours_stains_removal",
+        "iot_wash_playsuits",
+        "iot_wash_quick_drum_cleaner",
+        "iot_wash_rapid_14",
+        "iot_wash_rapid_30",
+        "iot_wash_rapid_44",
+        "iot_wash_rapid_59",
+        "iot_wash_refresh_14_min",
+        "iot_wash_resistant_colored",
+        "iot_wash_resistant_dark",
+        "iot_wash_resistant_whites",
+        "iot_wash_rinse",
+        "iot_wash_shirts",
+        "iot_wash_silk",
+        "iot_wash_ski_suit",
+        "iot_wash_spin",
+        "iot_wash_sport",
+        "iot_wash_sport_anti_odor",
+        "iot_wash_stains_remover",
+        "iot_wash_super_saving",
+        "iot_wash_swimsuits_and_bikinis",
+        "iot_wash_synthetic",
+        "iot_wash_tablecloths",
+        "iot_wash_technical_fabrics",
+        "iot_wash_technical_jackets",
+        "iot_wash_trainers",
+        "iot_wash_whites",
+        "iot_wash_whites_44",
+        "iot_wash_whites_59",
+        "iot_wash_whites_xl",
+        "iot_wash_wine_stains",
+        "iot_wash_wool",
+        "jeans_60",
+        "mix_and_colour_59",
+        "perfect_cotton_59",
+        "rapid_14_min",
+        "rapid_30_min",
+        "rapid_44_min",
+        "rinse",
+        "silent_night",
+        "single_item",
+        "special_49",
+        "sport_plus_39",
+        "synthetic_and_coloured",
+        "tumbling"
+      ],
+      "defaultValue": "special_49"
+    },
+    "delayTime": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1410.0,
+      "incrementValue": 30.0,
+      "defaultValue": 240
+    },
+    "dirtyLevel": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "lang": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 25.0,
+      "incrementValue": 1.0,
+      "defaultValue": 1
+    },
+    "onOffStatus": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "operationName": {
+      "typology": "fixed",
+      "fixedValue": "grCHGWash"
+    },
+    "prewash": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "hygiene": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "anticrease": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "goodNight": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    },
+    "extraRinse1": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    },
+    "extraRinse2": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    },
+    "extraRinse3": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    },
+    "acquaplus": {
+      "typology": "range",
+      "minimumValue": 0.0,
+      "maximumValue": 1.0,
+      "incrementValue": 1.0,
+      "defaultValue": 0
+    },
+    "prCode": {
+      "typology": "fixed",
+      "fixedValue": "12"
+    },
+    "prPosition": {
+      "typology": "fixed",
+      "fixedValue": "5"
+    },
+    "prStr": {
+      "typology": "fixed",
+      "fixedValue": "PROGRAMS.WM_WD.MIX_AND_COLOUR_59"
+    },
+    "spinSpeed": {
+      "typology": "enum",
+      "enumValues": [
+        "0",
+        "400",
+        "800",
+        "1000",
+        "1200"
+      ],
+      "defaultValue": "1200"
+    },
+    "temp": {
+      "typology": "enum",
+      "enumValues": [
+        "0",
+        "20",
+        "30",
+        "40"
+      ],
+      "defaultValue": "40"
+    },
+    "energyLabel": {
+      "typology": "range",
+      "minimumValue": 3.0,
+      "maximumValue": 5.0,
+      "incrementValue": 1.0,
+      "defaultValue": 4
+    },
+    "liquidDetergentDose": {
+      "typology": "fixed",
+      "fixedValue": "2"
+    },
+    "powderDetergentDose": {
+      "typology": "fixed",
+      "fixedValue": "2"
+    },
+    "programCluster": {
+      "typology": "fixed",
+      "fixedValue": "quick"
+    },
+    "programFamily": {
+      "typology": "enum",
+      "enumValues": [
+        "dashboard"
+      ],
+      "defaultValue": "dashboard"
+    },
+    "programType": {
+      "typology": "fixed",
+      "fixedValue": "W+D"
+    },
+    "remoteActionable": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "remoteVisible": {
+      "typology": "fixed",
+      "fixedValue": "1"
+    },
+    "suggestedLoadW": {
+      "typology": "fixed",
+      "fixedValue": "4"
+    },
+    "tempContribution": {
+      "typology": "fixed",
+      "fixedValue": "0"
+    }
+  }
+}

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -181,7 +181,7 @@ def _tk(description) -> str:
 
 
 def _collect_code_keys() -> dict[str, set[str]]:
-    from custom_components.addhon import binary_sensor, number, sensor, switch
+    from custom_components.addhon import binary_sensor, number, select, sensor, switch
 
     used: dict[str, set[str]] = {}
 
@@ -206,13 +206,18 @@ def _collect_code_keys() -> dict[str, set[str]]:
     used["binary_sensor"].add("update_ok")
     used["number"] = {
         _tk(d) for descs in number.NUMBERS.values() for d in descs
+    } | {d.translation_key for d in number._PROGRAM_OPTION_NUMBERS}
+    # HonAcSwitch names from description.key; the pause + debug switches use fixed keys;
+    # the program-option switches (#35) come from their description key.
+    used["switch"] = (
+        {d.key for d in switch._AC_SWITCHES}
+        | {d.key for d in switch._PROGRAM_OPTION_SWITCHES}
+        | {"pause", "debug_logging", "mqtt_realtime_debug"}
+    )
+    # Program select (fixed key) + the program-option selects (#35).
+    used["select"] = {"program"} | {
+        d.translation_key for d in select._PROGRAM_OPTION_SELECTS
     }
-    # HonAcSwitch names from description.key; the pause + debug switches use fixed keys.
-    used["switch"] = {d.key for d in switch._AC_SWITCHES} | {
-        "pause", "debug_logging", "mqtt_realtime_debug"
-    }
-    # Fixed-key entities (no description table).
-    used["select"] = {"program"}
     used["button"] = {"start_program", "stop_program", "force_refresh", "reset_debug"}
     return used
 
@@ -426,6 +431,43 @@ class SensorStateTranslationTest(unittest.TestCase):
                     )
                 else:
                     seen[tk] = opts
+
+
+def _collect_select_state_keys() -> dict[str, set[str]]:
+    """Per select translation_key, the union of label-map values across the program-option
+    select descriptions (the machine keys that need a `state` translation). dryLevel is
+    type-gated (WM/WD + TD) and shares the `dry_level` key, so the union covers both maps."""
+    from custom_components.addhon import select
+
+    by_tk: dict[str, set[str]] = {}
+    for d in select._PROGRAM_OPTION_SELECTS:
+        label_map = getattr(d, "label_map", None)
+        if not label_map:
+            continue
+        by_tk.setdefault(d.translation_key, set()).update(label_map.values())
+    return by_tk
+
+
+class SelectStateTranslationTest(unittest.TestCase):
+    """Every label-mapped program-option select's machine keys must have a matching
+    `entity.select.<tk>.state.<key>` label in BOTH languages, with no extras. Without it
+    a mapped state would render as a raw machine key in the UI (#35). The numeric-label
+    selects (spin/temp) have no label map and are intentionally skipped here."""
+
+    def test_label_mapped_select_state_matches_translations(self) -> None:
+        by_tk = _collect_select_state_keys()
+        self.assertTrue(by_tk, "no label-mapped select options were collected")
+        for lang in ("en", "it"):
+            data = json.loads((COMPONENT / "translations" / f"{lang}.json").read_text(encoding="utf-8"))
+            select_block = data.get("entity", {}).get("select", {})
+            for tk, keys in by_tk.items():
+                state = set(select_block.get(tk, {}).get("state", {}))
+                self.assertEqual(
+                    keys,
+                    state,
+                    f"[{lang}] entity.select.{tk}.state keys {sorted(state)} != "
+                    f"label-map keys used in code {sorted(keys)}",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -58,6 +58,7 @@ _FILES = {
     "switch.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "button.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "number.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
+    "program_options.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "binary_sensor.py": (_ENTITY_NAMES, _ENTITY_ATTRS),
     "climate.py": (_ENTITY_NAMES, _ENTITY_ATTRS),

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -305,6 +305,38 @@ class GateTest(unittest.TestCase):
         self.assertEqual("iot_smart", normalize_code("iot_smart"))
         self.assertIsNone(normalize_code(None))
 
+    def test_uneven_range_does_not_overshoot_max(self) -> None:
+        # FIX #6: a step that overshoots the max must NOT emit a value beyond it
+        # (0..10 step 20 -> ["0"], never ["0","20"]), and such a single-reachable-value
+        # range is NOT a settable control (max>min alone would wrongly accept it).
+        from custom_components.addhon.program_options import (
+            is_settable_option,
+            option_choices,
+        )
+
+        self.assertEqual(["0"], option_choices(RangeParam(0, 10, 20)))
+        self.assertFalse(is_settable_option(RangeParam(0, 10, 20)))
+        # A clean two-value uneven range is fine.
+        self.assertEqual(["0", "20"], option_choices(RangeParam(0, 20, 20)))
+        self.assertTrue(is_settable_option(RangeParam(0, 20, 20)))
+
+    def test_empty_string_drylevel_sentinel_dropped(self) -> None:
+        # FIX #5: '' is an unselectable dryLevel sentinel (hasDryLevelValue == false),
+        # so it must be dropped from the options and not count toward the gate.
+        from custom_components.addhon.const import DRY_LEVEL_SENTINELS
+        from custom_components.addhon.program_options import (
+            is_settable_option,
+            option_choices,
+        )
+
+        self.assertIn("", DRY_LEVEL_SENTINELS)
+        self.assertEqual(
+            ["12", "13"],
+            option_choices(SetParam(["", "12", "13"]), DRY_LEVEL_SENTINELS),
+        )
+        # '' + one real value -> only one selectable -> not a control.
+        self.assertFalse(is_settable_option(SetParam(["", "12"]), DRY_LEVEL_SENTINELS))
+
 
 class BufferWriteTest(unittest.IsolatedAsyncioTestCase):
     def _attach(self, entity) -> None:

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -1,0 +1,659 @@
+"""Behavioural tests for the writable program options (discussion #35).
+
+Covers the design-of-record:
+- the GATE (>= 2 reachable values / not fixed; range checked before enum; dryLevel
+  sentinel-only -> off);
+- BUFFER write: an option entity writes the coordinator store and sends NOTHING;
+- READ precedence: pending value else live device value, None when absent;
+- APPLY-on-start: the buffered options land on the POST-SWAP startProgram command, are
+  sent once, and both pending stores are cleared on success;
+- an option absent from the selected program is skipped (no error);
+- stopProgram ignores the option buffer;
+- CAPABILITY gate: a fixed/single-value param creates NO entity (anti-"No disponible");
+- TYPE gate: dryLevel uses the WM/WD label map vs the TD one.
+
+Stdlib unittest + inline Home Assistant stubs (the platforms pull the entity stack).
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ha = _mod("homeassistant")
+
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+
+    exc = _mod("homeassistant.exceptions")
+    base_err = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base_err
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {}))
+
+    helpers = _mod("homeassistant.helpers")
+    entity = _mod("homeassistant.helpers.entity")
+    entity.DeviceInfo = getattr(entity, "DeviceInfo", dict)
+    dr = _mod("homeassistant.helpers.device_registry")
+    dr.DeviceEntryType = getattr(dr, "DeviceEntryType", type("DeviceEntryType", (), {"SERVICE": "service"}))
+    ep = _mod("homeassistant.helpers.entity_platform")
+    ep.AddEntitiesCallback = getattr(ep, "AddEntitiesCallback", object)
+    er = _mod("homeassistant.helpers.entity_registry")
+    er.async_get = getattr(er, "async_get", lambda hass: None)
+    er.async_entries_for_config_entry = getattr(
+        er, "async_entries_for_config_entry", lambda registry, entry_id: []
+    )
+    uc = _mod("homeassistant.helpers.update_coordinator")
+
+    class CoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+            self.hass = getattr(coordinator, "hass", None)
+
+        def async_write_ha_state(self) -> None:
+            self.state_writes = getattr(self, "state_writes", 0) + 1
+
+    uc.CoordinatorEntity = getattr(uc, "CoordinatorEntity", CoordinatorEntity)
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+
+    const = _mod("homeassistant.const")
+    for unit_cls in ("UnitOfTemperature", "UnitOfTime"):
+        if not hasattr(const, unit_cls):
+            setattr(const, unit_cls, type(unit_cls, (), {"CELSIUS": "C", "MINUTES": "min", "SECONDS": "s"}))
+    const.EntityCategory = getattr(
+        const, "EntityCategory", type("EntityCategory", (), {"CONFIG": "config", "DIAGNOSTIC": "diagnostic"})
+    )
+
+    components = _mod("homeassistant.components")
+    _mod("homeassistant.components.switch").SwitchEntity = type("SwitchEntity", (), {})
+    _mod("homeassistant.components.select").SelectEntity = type("SelectEntity", (), {})
+    _mod("homeassistant.components.button").ButtonEntity = type("ButtonEntity", (), {})
+    number_mod = _mod("homeassistant.components.number")
+    import dataclasses
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class NumberEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+        native_unit_of_measurement: str | None = None
+        mode: object | None = None
+
+    number_mod.NumberEntityDescription = getattr(number_mod, "NumberEntityDescription", NumberEntityDescription)
+    number_mod.NumberEntity = getattr(number_mod, "NumberEntity", type("NumberEntity", (), {}))
+    number_mod.NumberDeviceClass = getattr(number_mod, "NumberDeviceClass", type("NumberDeviceClass", (), {"TEMPERATURE": "temperature"}))
+    number_mod.NumberMode = getattr(number_mod, "NumberMode", type("NumberMode", (), {"AUTO": "auto", "BOX": "box", "SLIDER": "slider"}))
+
+    ha.config_entries = ce
+    ha.core = core
+    ha.exceptions = exc
+    ha.helpers = helpers
+    ha.const = const
+    ha.components = components
+    helpers.entity = entity
+    helpers.entity_platform = ep
+    helpers.entity_registry = er
+    helpers.update_coordinator = uc
+    helpers.device_registry = dr
+
+
+_install_stubs()
+
+
+class FakeClient:
+    def run_command_sync(self, coro) -> None:
+        asyncio.run(coro)
+
+
+class FakeCoordinator:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+        self.hass = None
+        self.refreshes = 0
+        self.last_update_success = True
+        self.last_exception = None
+
+    async def async_refresh(self) -> None:
+        self.refreshes += 1
+
+    async def async_request_refresh(self) -> None:
+        self.refreshes += 1
+
+
+class FakeHass:
+    def __init__(self, data: dict | None = None) -> None:
+        self.data = data or {}
+
+    async def async_add_executor_job(self, func, *args):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(func, *args).result(timeout=5)
+
+
+class Param:
+    """A settable command parameter (value assignment recorded)."""
+
+    def __init__(self, value=None, values=None) -> None:
+        self.value = value
+        self.values = values
+
+
+class RecordingCommand:
+    def __init__(self, parameters=None) -> None:
+        self.parameters = parameters or {}
+        self.send_calls = 0
+
+    async def send(self) -> None:
+        self.send_calls += 1
+
+
+class RangeParam:
+    """Duck-types HonParameterRange (min/max/step) for the gate + option_choices."""
+
+    def __init__(self, mn: float, mx: float, step: float, value=None) -> None:
+        self.min = mn
+        self.max = mx
+        self.step = step
+        self.value = value if value is not None else mn
+
+    @property
+    def values(self) -> list[str]:
+        out: list[str] = []
+        i = self.min
+        while i <= self.max:
+            out.append(str(i))
+            i += self.step
+        return out
+
+
+class SetParam:
+    """Duck-types HonParameterEnum/Fixed (values only, no range)."""
+
+    def __init__(self, values, value=None) -> None:
+        self._values = list(values)
+        self.value = value if value is not None else (self._values[0] if self._values else None)
+
+    @property
+    def values(self) -> list[str]:
+        return list(self._values)
+
+
+class FakeEntry:
+    def __init__(self, entry_id: str = "entry-1") -> None:
+        self.entry_id = entry_id
+
+
+def _washer(commands: dict, attributes: dict | None = None, app_type: str = "WM") -> dict:
+    return {
+        "washer-1": {
+            "type": app_type,
+            "name": "Washer",
+            "appliance": types.SimpleNamespace(commands=commands),
+            "attributes": attributes or {},
+            "settings": {},
+        }
+    }
+
+
+class GateTest(unittest.TestCase):
+    def test_range_two_or_more_is_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        self.assertTrue(is_settable_option(RangeParam(0, 1, 1)))
+        self.assertTrue(is_settable_option(RangeParam(12, 14, 1)))
+        self.assertTrue(is_settable_option(RangeParam(0, 360, 360)))
+
+    def test_range_single_value_not_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        # max == min -> only one reachable value -> off.
+        self.assertFalse(is_settable_option(RangeParam(5, 5, 1)))
+
+    def test_enum_two_or_more_is_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        self.assertTrue(is_settable_option(SetParam(["0", "400", "800"])))
+
+    def test_enum_single_value_not_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        self.assertFalse(is_settable_option(SetParam(["0"])))
+
+    def test_fixed_param_not_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        # A fixed param duck-types as a single-value set (and no range).
+        self.assertFalse(is_settable_option(SetParam(["0"])))
+
+    def test_drylevel_sentinel_only_not_settable(self) -> None:
+        from custom_components.addhon.const import DRY_LEVEL_SENTINELS
+        from custom_components.addhon.program_options import is_settable_option
+
+        # An enum exposing only the unselectable sentinels -> nothing to pick -> off.
+        self.assertFalse(is_settable_option(SetParam(["0", "11"]), DRY_LEVEL_SENTINELS))
+
+    def test_option_value_set_empty_for_range(self) -> None:
+        # CRITICAL: a range must never be counted via .values (it enumerates min..max).
+        from custom_components.addhon.program_options import option_value_set
+
+        self.assertEqual(option_value_set(RangeParam(0, 1410, 30)), [])
+
+    def test_option_choices_materializes_range(self) -> None:
+        from custom_components.addhon.program_options import option_choices
+
+        self.assertEqual(option_choices(RangeParam(12, 14, 1)), ["12", "13", "14"])
+        self.assertEqual(option_choices(RangeParam(0, 360, 360)), ["0", "360"])
+
+    def test_option_choices_drops_sentinels(self) -> None:
+        from custom_components.addhon.const import DRY_LEVEL_SENTINELS
+        from custom_components.addhon.program_options import option_choices
+
+        self.assertEqual(
+            option_choices(SetParam(["0", "1", "2", "11"]), DRY_LEVEL_SENTINELS),
+            ["1", "2"],
+        )
+
+    def test_range_with_sentinels_counts_non_sentinel_members(self) -> None:
+        # The correctness graft: when `drop` is non-empty a RANGE is gated on its NON-
+        # sentinel reachable members (>= 2), not the cheap max>min -- so a sentinel-only
+        # range gates OFF even though max>min. Range is still measured WITHOUT .values.
+        from custom_components.addhon.const import DRY_LEVEL_SENTINELS
+        from custom_components.addhon.program_options import is_settable_option
+
+        # 0..11 step 11 -> {0, 11}, both sentinels -> 0 real values -> off (max>min is True!).
+        self.assertFalse(is_settable_option(RangeParam(0, 11, 11), DRY_LEVEL_SENTINELS))
+        # 12..14 step 1 -> {12, 13, 14}, no sentinels -> settable.
+        self.assertTrue(is_settable_option(RangeParam(12, 14, 1), DRY_LEVEL_SENTINELS))
+        # 0..13 step 1 minus {0, 11} -> 12 real members -> settable.
+        self.assertTrue(is_settable_option(RangeParam(0, 13, 1), DRY_LEVEL_SENTINELS))
+
+    def test_none_param_not_settable(self) -> None:
+        from custom_components.addhon.program_options import is_settable_option
+
+        self.assertFalse(is_settable_option(None))
+
+    def test_normalize_code_cleans_numeric_repr(self) -> None:
+        # The token normalizer: float/int/str numerics collapse to a clean code so a
+        # device reading ("13.0", 360) matches the schema codes; non-numeric passes through.
+        from custom_components.addhon.program_options import normalize_code
+
+        self.assertEqual("13", normalize_code("13.0"))
+        self.assertEqual("360", normalize_code(360))
+        self.assertEqual("0", normalize_code("0"))
+        self.assertEqual("iot_smart", normalize_code("iot_smart"))
+        self.assertIsNone(normalize_code(None))
+
+
+class BufferWriteTest(unittest.IsolatedAsyncioTestCase):
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    async def test_switch_buffers_without_sending(self) -> None:
+        from custom_components.addhon import switch
+
+        start = RecordingCommand({"extraRinse1": RangeParam(0, 1, 1)})
+        coordinator = FakeCoordinator(
+            _washer({"startProgram": start}, attributes={"extraRinse1": "0"})
+        )
+        desc = switch.HonProgramOptionSwitchDescription(
+            key="extra_rinse_1", param="extraRinse1", types=("WM", "WD")
+        )
+        entity = switch.HonProgramOptionSwitch(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        self.assertFalse(entity.is_on)  # live value "0"
+        await entity.async_turn_on()
+
+        # Buffered only: no command sent, no refresh.
+        self.assertEqual({"washer-1": {"extraRinse1": "1"}}, coordinator.pending_options)
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+        self.assertTrue(entity.is_on)  # pending now wins
+
+    async def test_select_buffers_raw_value(self) -> None:
+        from custom_components.addhon import select
+
+        start = RecordingCommand({"spinSpeed": SetParam(["0", "400", "800", "1000", "1200"])})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        desc = select.HonProgramOptionSelectDescription(
+            key="spin_speed", param="spinSpeed", translation_key="spin_speed", types=("WM", "WD")
+        )
+        entity = select.HonProgramOptionSelect(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        self.assertEqual(["0", "400", "800", "1000", "1200"], entity._attr_options)
+        await entity.async_select_option("800")
+
+        self.assertEqual({"washer-1": {"spinSpeed": "800"}}, coordinator.pending_options)
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual("800", entity.current_option)
+
+    async def test_number_buffers_and_rejects_off_grid(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon import number
+
+        start = RecordingCommand({"delayTime": RangeParam(0, 1410, 30)})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        desc = number.HonProgramOptionNumberDescription(
+            key="delay_time", param="delayTime", translation_key="delay_time",
+            types=("WM", "WD", "TD"),
+        )
+        entity = number.HonProgramOptionNumber(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        self.assertEqual(0, entity.native_min_value)
+        self.assertEqual(1410, entity.native_max_value)
+        self.assertEqual(30, entity.native_step)
+
+        await entity.async_set_native_value(240)
+        self.assertEqual({"washer-1": {"delayTime": "240"}}, coordinator.pending_options)
+        self.assertEqual(0, start.send_calls)
+
+        # Off-grid value rejected up front (clean error, no buffer change).
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_native_value(45)
+        self.assertEqual("invalid_setpoint", ctx.exception.translation_key)
+
+    async def test_anti_crease_time_switch_uses_schema_values(self) -> None:
+        # antiCreaseTime is a 0/360 range: on must be the schema's "360", not a hardcoded
+        # "1". The on/off tokens are derived from the device schema (TD dryer).
+        from custom_components.addhon import switch
+
+        start = RecordingCommand({"antiCreaseTime": RangeParam(0, 360, 360)})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}, app_type="TD"))
+        desc = switch.HonProgramOptionSwitchDescription(
+            key="anti_crease_time", param="antiCreaseTime", types=("TD",)
+        )
+        entity = switch.HonProgramOptionSwitch(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        await entity.async_turn_on()
+        self.assertEqual({"washer-1": {"antiCreaseTime": "360"}}, coordinator.pending_options)
+        self.assertTrue(entity.is_on)
+        await entity.async_turn_off()
+        self.assertEqual("0", coordinator.pending_options["washer-1"]["antiCreaseTime"])
+        self.assertFalse(entity.is_on)
+        self.assertEqual(0, start.send_calls)
+
+
+class ReadPrecedenceTest(unittest.IsolatedAsyncioTestCase):
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    def _make(self, attributes):
+        from custom_components.addhon import switch
+
+        start = RecordingCommand({"extraRinse1": RangeParam(0, 1, 1)})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}, attributes=attributes))
+        desc = switch.HonProgramOptionSwitchDescription(
+            key="extra_rinse_1", param="extraRinse1", types=("WM", "WD")
+        )
+        entity = switch.HonProgramOptionSwitch(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+        return entity, coordinator
+
+    async def test_live_value_when_no_pending(self) -> None:
+        entity, _ = self._make({"extraRinse1": "1"})
+        self.assertTrue(entity.is_on)
+
+    async def test_pending_overrides_live(self) -> None:
+        entity, coordinator = self._make({"extraRinse1": "1"})
+        coordinator.pending_options = {"washer-1": {"extraRinse1": "0"}}
+        self.assertFalse(entity.is_on)
+
+    async def test_none_when_absent(self) -> None:
+        entity, _ = self._make({})
+        self.assertIsNone(entity.is_on)
+
+
+class ApplyOnStartTest(unittest.IsolatedAsyncioTestCase):
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    def _swap_appliance(self, new_cmd):
+        """Build a startProgram whose 'program' setter swaps the active command (like
+        HonParameterProgram), returning (appliance, old_cmd)."""
+        appliance = types.SimpleNamespace(commands={})
+
+        class ProgramSwapParam:
+            def __init__(self) -> None:
+                self._value = None
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd  # category swap
+
+        old_cmd = RecordingCommand({"program": ProgramSwapParam()})
+        appliance.commands["startProgram"] = old_cmd
+        return appliance, old_cmd
+
+    async def test_options_land_on_post_swap_command_and_clear(self) -> None:
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        new_cmd = RecordingCommand({"spinSpeed": Param("0"), "prStr": Param("X")})
+        appliance, old_cmd = self._swap_appliance(new_cmd)
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": "2"}
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200"}}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+            command_parameters={"prStr": "Y"},
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        # The selected (swapped) command was sent once; option landed on the NEW command.
+        self.assertEqual(1, new_cmd.send_calls)
+        self.assertEqual(0, old_cmd.send_calls)
+        self.assertEqual("1200", new_cmd.parameters["spinSpeed"].value)
+        self.assertEqual("Y", new_cmd.parameters["prStr"].value)  # fixed params too
+        # Both buffers cleared on success.
+        self.assertEqual({}, coordinator.pending_programs)
+        self.assertEqual({}, coordinator.pending_options)
+        self.assertEqual(1, coordinator.refreshes)
+
+    async def test_options_cleared_even_without_program_reselection(self) -> None:
+        # Only options changed (no pending program): the active command is sent and the
+        # option buffer is still cleared (gated on the command name, not pending_program).
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        start = RecordingCommand({"spinSpeed": Param("0")})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1000"}}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual("1000", start.parameters["spinSpeed"].value)
+        self.assertEqual({}, coordinator.pending_options)
+
+    async def test_option_absent_for_selected_program_is_skipped(self) -> None:
+        # The buffered option is not a parameter of the selected program's command: it is
+        # skipped (debug), the command still starts, no error.
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        start = RecordingCommand({"onOffStatus": Param("1")})  # no spinSpeed param here
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200"}}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual({}, coordinator.pending_options)
+
+    async def test_stop_ignores_options(self) -> None:
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        stop = RecordingCommand({"onOffStatus": Param("1")})
+        coordinator = FakeCoordinator(_washer({"stopProgram": stop}))
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200"}}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="stopProgram", unique_suffix="stop_program",
+            translation_key="stop_program", icon="mdi:stop-circle",
+            command_parameters={"onOffStatus": "0"},
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        self.assertEqual(1, stop.send_calls)
+        # The stop must neither consume nor apply the option buffer.
+        self.assertEqual({"washer-1": {"spinSpeed": "1200"}}, coordinator.pending_options)
+        self.assertEqual("0", stop.parameters["onOffStatus"].value)
+
+    async def test_failed_start_keeps_options(self) -> None:
+        # On a send failure the option buffer is KEPT (the clear is past the send, inside
+        # the try): the user can retry without re-entering the options.
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        class FailingCommand(RecordingCommand):
+            async def send(self) -> None:
+                raise RuntimeError("cloud rejected")
+
+        start = FailingCommand({"spinSpeed": Param("0")})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "800"}}
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        with self.assertRaises(HomeAssistantError):
+            await button.async_press()
+        self.assertEqual({"washer-1": {"spinSpeed": "800"}}, coordinator.pending_options)
+
+
+class CapabilityGateSetupTest(unittest.IsolatedAsyncioTestCase):
+    async def test_fixed_param_creates_no_select(self) -> None:
+        # The anti-"No disponible" assertion: a fixed/single-value option creates NO
+        # entity, while a genuinely settable one does.
+        from custom_components.addhon import select
+        from custom_components.addhon.const import DOMAIN
+
+        start = RecordingCommand({
+            "program": Param(values={"1": "Cotone", "2": "Sintetici"}),
+            "spinSpeed": SetParam(["0", "400", "800"]),  # settable -> entity
+            "dirtyLevel": SetParam(["0"]),               # fixed/single -> NO entity
+        })
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}})
+        added: list = []
+
+        await select.async_setup_entry(hass, FakeEntry(), added.extend)
+
+        added = [e for e in added if not getattr(e, "_addhon_account", False)]
+        tks = {getattr(e, "_attr_translation_key", None) for e in added}
+        self.assertIn("spin_speed", tks)
+        self.assertNotIn("dirty_level", tks)
+        self.assertIn("program", tks)  # the program select is unaffected
+
+    async def test_no_option_switch_for_fixed_param(self) -> None:
+        from custom_components.addhon import switch
+        from custom_components.addhon.const import DOMAIN
+
+        start = RecordingCommand({
+            "acquaplus": RangeParam(0, 1, 1),  # settable -> switch
+            "prewash": SetParam(["0"]),        # fixed -> NO switch
+        })
+        commands = {
+            "startProgram": start,
+            "pauseProgram": RecordingCommand(),
+            "resumeProgram": RecordingCommand(),
+        }
+        coordinator = FakeCoordinator(_washer(commands))
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}})
+        added: list = []
+
+        await switch.async_setup_entry(hass, FakeEntry(), added.extend)
+
+        added = [e for e in added if not getattr(e, "_addhon_account", False)]
+        tks = {getattr(e, "_attr_translation_key", None) for e in added}
+        self.assertIn("acquaplus", tks)
+        self.assertNotIn("prewash", tks)
+        self.assertIn("pause", tks)
+
+
+class TypeGateDryLevelTest(unittest.IsolatedAsyncioTestCase):
+    async def _dry_level_select(self, app_type, param):
+        from custom_components.addhon import select
+        from custom_components.addhon.const import DOMAIN
+
+        start = RecordingCommand({
+            "program": Param(values={"1": "A", "2": "B"}),
+            "dryLevel": param,
+        })
+        coordinator = FakeCoordinator(_washer({"startProgram": start}, app_type=app_type))
+        hass = FakeHass({DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}})
+        added: list = []
+        await select.async_setup_entry(hass, FakeEntry(), added.extend)
+        added = [e for e in added if getattr(e, "_attr_translation_key", None) == "dry_level"]
+        self.assertEqual(1, len(added))
+        return added[0]
+
+    async def test_wm_uses_wm_label_map(self) -> None:
+        entity = await self._dry_level_select("WM", RangeParam(1, 3, 1))
+        # WM/WD case 300: 1=extra_dry, 2=cupboard, 3=iron_dry.
+        self.assertEqual(["extra_dry", "cupboard", "iron_dry"], entity._attr_options)
+
+    async def test_td_uses_td_label_map(self) -> None:
+        entity = await self._dry_level_select("TD", RangeParam(12, 14, 1))
+        # TD case 53: 12=iron_dry, 13=ready_to_wear, 14=cupboard.
+        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -655,6 +655,75 @@ class TypeGateDryLevelTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
 
 
+class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
+    """PR#38 FIX#4 (Greptile P2): a TD dryLevel can expose two raw codes that share a
+    label (DRY_LEVEL_LABELS_TD: 1&12->iron_dry, 3&14->cupboard, 4&15->extra_dry). When
+    BOTH members are exposed the select must keep them as two DISTINCT options and
+    round-trip each raw, not collapse them onto one key (which would drop a code from
+    _attr_options and make _key_to_raw buffer the wrong raw)."""
+
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    def _td_dry_level(self, param):
+        from custom_components.addhon import select
+
+        # The real type-gated TD dry_level description (label_map=DRY_LEVEL_LABELS_TD).
+        desc = next(
+            d for d in select._PROGRAM_OPTION_SELECTS
+            if d.key == "dry_level" and "TD" in d.types
+        )
+        coordinator = FakeCoordinator(
+            _washer({"startProgram": RecordingCommand({"dryLevel": param})}, app_type="TD")
+        )
+        entity = select.HonProgramOptionSelect(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+        return entity, coordinator
+
+    async def test_colliding_codes_stay_distinct_and_round_trip(self) -> None:
+        # 4 and 15 both map to "extra_dry" on TD; both must survive as DISTINCT options.
+        # Mutation-proof: without FIX#4 _attr_options collapses to ["extra_dry"] (len 1)
+        # and _key_to_raw is {"extra_dry": "15"} -> the first two assertions fail and the
+        # raw "4" is unreachable / buffers as "15".
+        entity, coordinator = self._td_dry_level(SetParam(["4", "15"]))
+
+        self.assertEqual(2, len(entity._attr_options))
+        self.assertEqual(len(entity._attr_options), len(set(entity._attr_options)))
+        # Every raw code is reachable through the option keys (injective round-trip map).
+        self.assertEqual({"4", "15"}, set(entity._key_to_raw.values()))
+
+        for option in entity._attr_options:
+            await entity.async_select_option(option)
+            # Each option buffers its OWN distinct raw, not a collapsed sibling.
+            self.assertEqual(
+                entity._key_to_raw[option],
+                coordinator.pending_options["washer-1"]["dryLevel"],
+            )
+            # current_option read-back round-trips to the very option just selected.
+            self.assertEqual(option, entity.current_option)
+
+    async def test_iron_dry_pair_round_trips_each_raw(self) -> None:
+        # 1 and 12 both map to "iron_dry": a live device reading of each raw must read
+        # back as a distinct option (no aliasing of 1 onto 12 or vice versa).
+        entity, coordinator = self._td_dry_level(SetParam(["1", "12"]))
+
+        self.assertEqual(2, len(set(entity._attr_options)))
+        opt_1 = entity._raw_to_key["1"]
+        opt_12 = entity._raw_to_key["12"]
+        self.assertNotEqual(opt_1, opt_12)
+        # Live read (no pending): each raw resolves to its own distinct option.
+        coordinator.data["washer-1"]["attributes"] = {"dryLevel": "1"}
+        self.assertEqual(opt_1, entity.current_option)
+        coordinator.data["washer-1"]["attributes"] = {"dryLevel": "12"}
+        self.assertEqual(opt_12, entity.current_option)
+
+    async def test_no_collision_keeps_translatable_keys_unchanged(self) -> None:
+        # Regression guard: erpayo's TD range [12,13,14] has NO label collision, so the
+        # options stay the plain translatable keys (state.<key>), unsuffixed.
+        entity, _ = self._td_dry_level(RangeParam(12, 14, 1))
+        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
+
+
 class ProgramDependencyTest(unittest.IsolatedAsyncioTestCase):
     """PR#38 reviewer findings: stale options across programs (#1) and a cached
     range that outlives the program after a swap (#3)."""

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -655,5 +655,173 @@ class TypeGateDryLevelTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
 
 
+class ProgramDependencyTest(unittest.IsolatedAsyncioTestCase):
+    """PR#38 reviewer findings: stale options across programs (#1) and a cached
+    range that outlives the program after a swap (#3)."""
+
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    async def test_changing_program_clears_pending_options(self) -> None:
+        # FIX#1 (Greptile P1): selecting a DIFFERENT program clears THIS appliance's
+        # buffered options (they were chosen for the previous program), and selecting
+        # never sends a command.
+        from custom_components.addhon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        # Options chosen in the context of the CURRENT program.
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200"}}
+
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        await entity.async_select_option("Sintetici")
+
+        # The new program is recorded; selecting does NOT start the appliance.
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+        # The stale options from the previous program are gone (entry dropped).
+        self.assertNotIn("washer-1", coordinator.pending_options)
+        self.assertEqual({}, coordinator.pending_options)
+
+    async def test_reselecting_same_program_keeps_pending_options(self) -> None:
+        # FIX#1 guard: re-selecting the SAME program is not a change, so the buffered
+        # options (chosen for that very program) are PRESERVED, not wiped.
+        from custom_components.addhon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        coordinator.pending_programs = {"washer-1": "2"}  # already on Sintetici
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200"}}
+
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        await entity.async_select_option("Sintetici")  # the SAME program
+
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+        self.assertEqual({"washer-1": {"spinSpeed": "1200"}}, coordinator.pending_options)
+        self.assertEqual(0, start.send_calls)
+
+    async def test_number_range_follows_active_program_after_swap(self) -> None:
+        # FIX#3 (Greptile P2): after a program swap the number's range must follow the
+        # ACTIVE program, NOT the merged superset cached at __init__. Mutation-proof: if
+        # _live_range read the cached merged param, native_max_value would be 1410 and the
+        # 240 write would be accepted -- both assertions below would then fail.
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon import number
+
+        # Two program categories with DIFFERENT delayTime ranges. The merged param the
+        # mixin caches at __init__ is the wide one (the initial active command).
+        wide = RecordingCommand({"delayTime": RangeParam(0, 1410, 30)})
+        narrow = RecordingCommand({"delayTime": RangeParam(0, 180, 30)})
+        appliance = types.SimpleNamespace(commands={"startProgram": wide})
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        desc = number.HonProgramOptionNumberDescription(
+            key="delay_time", param="delayTime", translation_key="delay_time",
+            types=("WM", "WD", "TD"),
+        )
+        entity = number.HonProgramOptionNumber(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        # Initially the active command is the wide category.
+        self.assertEqual(1410, entity.native_max_value)
+
+        # Program swap: the active startProgram command becomes the narrow category.
+        appliance.commands["startProgram"] = narrow
+        self.assertEqual(180, entity.native_max_value)
+        self.assertEqual(0, entity.native_min_value)
+        self.assertEqual(30, entity.native_step)
+
+        # A value valid for the merged superset (240) but NOT the active program is rejected.
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_native_value(240)
+        self.assertEqual("invalid_setpoint", ctx.exception.translation_key)
+
+        # A value valid for the ACTIVE program is buffered.
+        await entity.async_set_native_value(150)
+        self.assertEqual("150", coordinator.pending_options["washer-1"]["delayTime"])
+        self.assertEqual(0, narrow.send_calls)
+
+    async def test_number_range_falls_back_to_cached_param_when_active_absent(self) -> None:
+        # FIX#3 fallback: if the active command no longer exposes the param, the range
+        # falls back to the cached merged param read LIVE, never to a fabricated default.
+        from custom_components.addhon import number
+
+        cached_param = RangeParam(0, 1410, 30)
+        wide = RecordingCommand({"delayTime": cached_param})
+        appliance = types.SimpleNamespace(commands={"startProgram": wide})
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        desc = number.HonProgramOptionNumberDescription(
+            key="delay_time", param="delayTime", translation_key="delay_time",
+            types=("WM", "WD", "TD"),
+        )
+        entity = number.HonProgramOptionNumber(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+
+        # Mutate the cached merged param AFTER __init__ so its LIVE range (600) differs from
+        # the _fallback_range snapshot captured at __init__ (1410): this isolates the
+        # cached-param branch of _live_range from the static fallback (without this, both
+        # paths would coincidentally return 1410 and the branch would be untested).
+        cached_param.max = 600
+        # The active command swaps to one WITHOUT delayTime -> _live_range must read the
+        # cached merged param LIVE (600), not the __init__ snapshot (1410) nor a default.
+        appliance.commands["startProgram"] = RecordingCommand({"onOffStatus": Param("1")})
+        self.assertEqual(600, entity.native_max_value)
+
+
+class OptionClearSurvivesNewerWriteTest(unittest.IsolatedAsyncioTestCase):
+    """PR#38 FIX#2 (CodeRabbit Major): the post-send clear must drop only the
+    actually-sent option values, leaving a newer/changed (unsent) write intact."""
+
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    async def test_newer_write_after_snapshot_survives_clear(self) -> None:
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        start = RecordingCommand({"spinSpeed": Param("0"), "temp": Param("0")})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        # Snapshot (taken before the executor job) will be {spinSpeed:1200, temp:40}.
+        coordinator.pending_options = {"washer-1": {"spinSpeed": "1200", "temp": "40"}}
+
+        # Simulate a NEW option write landing AFTER the snapshot but BEFORE the clear:
+        # hook send() to add a brand-new key and to CHANGE one of the sent values.
+        orig_send = start.send
+
+        async def send_then_buffer_new() -> None:
+            await orig_send()
+            store = coordinator.pending_options["washer-1"]
+            store["delayTime"] = "240"   # brand-new, never sent
+            store["spinSpeed"] = "800"   # changed AFTER we sent "1200"
+
+        start.send = send_then_buffer_new
+
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        self._attach(button)
+
+        await button.async_press()
+
+        # temp was sent ("40") and unchanged -> cleared. spinSpeed changed after the send
+        # ("800") -> kept. delayTime is new/unsent -> kept. The entry is NOT popped.
+        self.assertEqual(
+            {"washer-1": {"spinSpeed": "800", "delayTime": "240"}},
+            coordinator.pending_options,
+        )
+        self.assertEqual(1, start.send_calls)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -109,6 +109,18 @@ class TranslationsContentTest(unittest.TestCase):
     def test_en_it_have_identical_structure(self) -> None:
         self.assertEqual(_dotted_keys(self.data["en"]), _dotted_keys(self.data["it"]))
 
+    def test_anti_crease_time_distinct_from_anticrease(self) -> None:
+        # PR #38 (#7): a WD merges the WM+TD option catalogs, so both the anticrease
+        # toggle and the antiCreaseTime control can appear; their labels must differ or
+        # the UI shows two indistinguishable "Anti-crease" switches.
+        for lang in LANGS:
+            switches = self.data[lang]["entity"]["switch"]
+            self.assertNotEqual(
+                switches["anticrease"]["name"],
+                switches["anti_crease_time"]["name"],
+                f"{lang}: anti_crease_time must have a label distinct from anticrease",
+            )
+
     def test_no_dead_pyhon_references(self) -> None:
         """#17 regression guard: the strangler fully removed pyhOn (native client in
         hon_client.py), so no user-facing translation string may mention it again.

--- a/tests/test_wash_option_params.py
+++ b/tests/test_wash_option_params.py
@@ -76,8 +76,20 @@ def _install_stubs() -> None:
     class CoordinatorEntity:
         def __init__(self, coordinator) -> None:
             self.coordinator = coordinator
+            self.hass = getattr(coordinator, "hass", None)
 
-    uc.CoordinatorEntity = getattr(uc, "CoordinatorEntity", CoordinatorEntity)
+        def async_write_ha_state(self) -> None:
+            self.state_writes = getattr(self, "state_writes", 0) + 1
+
+        @property
+        def available(self) -> bool:
+            return self.coordinator.last_update_success
+
+    # FORCE-ASSIGN (not getattr): this module imports the addhon entities below, binding
+    # HonBaseEntity to whatever CoordinatorEntity is installed now. If collected first it
+    # must bind a COMPLETE base (hass + async_write_ha_state + available, mirroring
+    # test_ac_write_path) so it never poisons the entity tests that DO instantiate.
+    uc.CoordinatorEntity = CoordinatorEntity
     uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
     uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
 

--- a/tests/test_wash_option_params.py
+++ b/tests/test_wash_option_params.py
@@ -1,0 +1,299 @@
+"""Validate the #35 program-option catalogs against erpayo's REAL device schemas.
+
+The per-type entity tests validate entity `key`s (slugs) but not the `param`
+(the Haier startProgram parameter name a control reads/writes) nor that the
+schema-driven GATE produces exactly the settable set we expect on a real model. A
+wrong `param` makes a capability-gated control silently never created, and a gate
+bug would either resurrect erpayo's fixed "No disponible" toggles or drop a
+genuinely settable one - no key-based test catches either.
+
+This guards both against erpayo's two real machines (fixtures built from his
+redacted config-entry diagnostics, discussion #35):
+  - WM Candy TCA286TM5-S  -> tests/fixtures/wm_candy_tca286/
+  - TD Haier HD90-A3959    -> tests/fixtures/td_haier_hd90/
+The catalog is a SUPERSET (decompiled hOn / andre0512): not every candidate param
+exists on every model (steamLevel/permanentPress are absent here). So we assert
+the GATE result (the genuinely-settable set) matches erpayo's known set, prove the
+fixed-on-his-unit toggles gate OFF (the anti-"No disponible" assertion), and pin
+the (key -> param) maps against drift.
+
+Stdlib unittest with inline Home Assistant stubs (the platform modules pull the
+HA stack); the engine + gate run for real against reconstructed HonParameters.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+_WM_FIXTURE = REPO / "tests" / "fixtures" / "wm_candy_tca286" / "startprogram_params.json"
+_TD_FIXTURE = REPO / "tests" / "fixtures" / "td_haier_hd90" / "startprogram_params.json"
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ha = _mod("homeassistant")
+
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+
+    exc = _mod("homeassistant.exceptions")
+    base_err = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base_err
+    exc.ConfigEntryNotReady = getattr(exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base_err,), {}))
+    exc.ConfigEntryAuthFailed = getattr(exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base_err,), {}))
+
+    helpers = _mod("homeassistant.helpers")
+    entity = _mod("homeassistant.helpers.entity")
+    entity.DeviceInfo = getattr(entity, "DeviceInfo", dict)
+    dr = _mod("homeassistant.helpers.device_registry")
+    dr.DeviceEntryType = getattr(dr, "DeviceEntryType", type("DeviceEntryType", (), {"SERVICE": "service"}))
+    ep = _mod("homeassistant.helpers.entity_platform")
+    ep.AddEntitiesCallback = getattr(ep, "AddEntitiesCallback", object)
+    er = _mod("homeassistant.helpers.entity_registry")
+    er.async_get = getattr(er, "async_get", lambda hass: None)
+    er.async_entries_for_config_entry = getattr(
+        er, "async_entries_for_config_entry", lambda registry, entry_id: []
+    )
+    uc = _mod("homeassistant.helpers.update_coordinator")
+
+    class CoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+
+    uc.CoordinatorEntity = getattr(uc, "CoordinatorEntity", CoordinatorEntity)
+    uc.DataUpdateCoordinator = getattr(uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {}))
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+
+    const = _mod("homeassistant.const")
+    for unit_cls in ("UnitOfTemperature", "UnitOfEnergy", "UnitOfTime", "UnitOfVolume", "UnitOfMass"):
+        if not hasattr(const, unit_cls):
+            setattr(const, unit_cls, type(unit_cls, (), {
+                "CELSIUS": "C", "KILO_WATT_HOUR": "kWh", "MINUTES": "min", "LITERS": "L",
+                "GRAMS": "g", "KILOGRAMS": "kg", "SECONDS": "s",
+            }))
+    const.EntityCategory = getattr(
+        const, "EntityCategory", type("EntityCategory", (), {"CONFIG": "config", "DIAGNOSTIC": "diagnostic"})
+    )
+
+    components = _mod("homeassistant.components")
+    _mod("homeassistant.components.switch").SwitchEntity = type("SwitchEntity", (), {})
+    _mod("homeassistant.components.select").SelectEntity = type("SelectEntity", (), {})
+
+    number_mod = _mod("homeassistant.components.number")
+    import dataclasses
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class NumberEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+        native_unit_of_measurement: str | None = None
+        mode: object | None = None
+
+    number_mod.NumberEntityDescription = getattr(number_mod, "NumberEntityDescription", NumberEntityDescription)
+    number_mod.NumberEntity = getattr(number_mod, "NumberEntity", type("NumberEntity", (), {}))
+    number_mod.NumberDeviceClass = getattr(number_mod, "NumberDeviceClass", type("NumberDeviceClass", (), {"TEMPERATURE": "temperature"}))
+    number_mod.NumberMode = getattr(number_mod, "NumberMode", type("NumberMode", (), {"AUTO": "auto", "BOX": "box", "SLIDER": "slider"}))
+
+    ha.config_entries = ce
+    ha.core = core
+    ha.exceptions = exc
+    ha.helpers = helpers
+    ha.const = const
+    ha.components = components
+    helpers.entity = entity
+    helpers.entity_platform = ep
+    helpers.entity_registry = er
+    helpers.update_coordinator = uc
+    helpers.device_registry = dr
+    components.number = number_mod
+
+
+_install_stubs()
+
+from custom_components.addhon import number, select, switch  # noqa: E402
+from custom_components.addhon.client.engine.commands import HonCommand  # noqa: E402
+from custom_components.addhon.const import (  # noqa: E402
+    APPLIANCE_TD,
+    APPLIANCE_WD,
+    APPLIANCE_WM,
+)
+from custom_components.addhon.program_options import (  # noqa: E402
+    is_settable_option,
+    startprogram_option_param,
+)
+
+# erpayo's genuinely-settable program-option params per model (discussion #35).
+_KNOWN_SETTABLE = {
+    APPLIANCE_WM: {
+        "spinSpeed", "temp", "delayTime",
+        "extraRinse1", "extraRinse2", "extraRinse3", "acquaplus",
+    },
+    APPLIANCE_TD: {
+        "dryLevel", "tempLevel", "delayTime",
+        "antiCreaseTime", "sterilizationStatus", "tumblingStatus",
+    },
+}
+
+
+def _build_appliance(fixture_path: Path):
+    """Reconstruct a startProgram HonCommand from a fixture schema."""
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    params = data["startprogram_params"]
+    appliance = types.SimpleNamespace(zone="", commands={})
+    command = HonCommand("startProgram", {"parameters": params}, appliance, None, "")
+    appliance.commands["startProgram"] = command
+    return appliance, set(params)
+
+
+def _catalog_entries(app_type: str):
+    """(param, drop) for every catalog control applicable to app_type."""
+    for d in switch._PROGRAM_OPTION_SWITCHES:
+        if app_type in d.types:
+            yield d.param, frozenset()
+    for d in select._PROGRAM_OPTION_SELECTS:
+        if app_type in d.types:
+            yield d.param, d.drop
+    for d in number._PROGRAM_OPTION_NUMBERS:
+        if app_type in d.types:
+            yield d.param, frozenset()
+
+
+class GateMatchesRealDeviceTest(unittest.TestCase):
+    """The schema-driven gate must yield EXACTLY erpayo's settable set on each model."""
+
+    def _settable_from_catalog(self, fixture_path: Path, app_type: str) -> set[str]:
+        appliance, _ = _build_appliance(fixture_path)
+        settable: set[str] = set()
+        for param, drop in _catalog_entries(app_type):
+            if is_settable_option(startprogram_option_param(appliance, param), drop):
+                settable.add(param)
+        return settable
+
+    def test_wm_settable_set_matches(self) -> None:
+        self.assertEqual(
+            self._settable_from_catalog(_WM_FIXTURE, APPLIANCE_WM),
+            _KNOWN_SETTABLE[APPLIANCE_WM],
+        )
+
+    def test_td_settable_set_matches(self) -> None:
+        self.assertEqual(
+            self._settable_from_catalog(_TD_FIXTURE, APPLIANCE_TD),
+            _KNOWN_SETTABLE[APPLIANCE_TD],
+        )
+
+    def test_known_settable_params_exist_in_schema(self) -> None:
+        # The params we rely on must be present (a rename in the catalog would
+        # otherwise silently drop the control).
+        for fixture, app_type in ((_WM_FIXTURE, APPLIANCE_WM), (_TD_FIXTURE, APPLIANCE_TD)):
+            _, present = _build_appliance(fixture)
+            missing = _KNOWN_SETTABLE[app_type] - present
+            self.assertEqual(missing, set(), f"{app_type}: settable params absent from schema: {sorted(missing)}")
+
+    def test_fixed_toggles_gate_off(self) -> None:
+        # The anti-"No disponible" assertion: erpayo's WM prewash/hygiene/anticrease/
+        # goodNight/dirtyLevel are FIXED on his unit, so the gate must NOT create them.
+        appliance, present = _build_appliance(_WM_FIXTURE)
+        for param in ("prewash", "hygiene", "anticrease", "goodNight", "dirtyLevel"):
+            self.assertIn(param, present, f"{param} should be in the WM fixture")
+            self.assertFalse(
+                is_settable_option(startprogram_option_param(appliance, param)),
+                f"{param} is fixed on erpayo's WM and must gate OFF (no 'No disponible' control)",
+            )
+        # TD: dryTimeMM is fixed [0] on his dryer.
+        appliance, present = _build_appliance(_TD_FIXTURE)
+        self.assertIn("dryTimeMM", present)
+        self.assertFalse(is_settable_option(startprogram_option_param(appliance, "dryTimeMM")))
+
+    def test_junk_params_excluded_by_allowlist(self) -> None:
+        # 'lang' passes the >= 2 gate (range 0..25) but is junk; the allowlist excludes
+        # it by omission -> it must never be a catalog param.
+        all_params = {p for d in switch._PROGRAM_OPTION_SWITCHES for p in (d.param,)}
+        all_params |= {d.param for d in select._PROGRAM_OPTION_SELECTS}
+        all_params |= {d.param for d in number._PROGRAM_OPTION_NUMBERS}
+        for junk in ("lang", "energyLabel", "programFamily", "programCluster"):
+            self.assertNotIn(junk, all_params, f"junk param '{junk}' must not be in the catalog")
+
+
+class CatalogPinTest(unittest.TestCase):
+    """Drift guard: the (key -> param) maps are pinned to the values verified against
+    erpayo's real WM+TD + the decompiled hOn app (discussion #35). Any change must be
+    re-verified against a real device (see GateMatchesRealDeviceTest)."""
+
+    _PINNED_SWITCHES = {
+        "extra_rinse_1": "extraRinse1",
+        "extra_rinse_2": "extraRinse2",
+        "extra_rinse_3": "extraRinse3",
+        "acquaplus": "acquaplus",
+        "prewash": "prewash",
+        "hygiene": "hygiene",
+        "anticrease": "anticrease",
+        "good_night": "goodNight",
+        "sterilization": "sterilizationStatus",
+        "tumbling": "tumblingStatus",
+        "permanent_press": "permanentPressStatus",
+        "anti_crease_time": "antiCreaseTime",
+    }
+    _PINNED_SELECTS = {
+        # (key, param) pairs: dry_level appears twice (type-gated WM/WD vs TD).
+        ("dry_level", "dryLevel"),
+        ("dirty_level", "dirtyLevel"),
+        ("steam_level", "steamLevel"),
+        ("temp_level", "tempLevel"),
+        ("spin_speed", "spinSpeed"),
+        ("wash_temp", "temp"),
+    }
+    _PINNED_NUMBERS = {"delay_time": "delayTime"}
+
+    def test_switch_catalog_pinned(self) -> None:
+        actual = {d.key: d.param for d in switch._PROGRAM_OPTION_SWITCHES}
+        self.assertEqual(actual, self._PINNED_SWITCHES)
+
+    def test_select_catalog_pinned(self) -> None:
+        actual = {(d.key, d.param) for d in select._PROGRAM_OPTION_SELECTS}
+        self.assertEqual(actual, self._PINNED_SELECTS)
+
+    def test_number_catalog_pinned(self) -> None:
+        actual = {d.key: d.param for d in number._PROGRAM_OPTION_NUMBERS}
+        self.assertEqual(actual, self._PINNED_NUMBERS)
+
+    def test_dry_level_type_gated(self) -> None:
+        # The two dry_level descriptions must have DISJOINT types and DISTINCT label
+        # maps (value "1" = EXTRA_DRY on WM/WD vs IRON_DRY on TD).
+        dry = [d for d in select._PROGRAM_OPTION_SELECTS if d.key == "dry_level"]
+        self.assertEqual(len(dry), 2)
+        types_a, types_b = set(dry[0].types), set(dry[1].types)
+        self.assertEqual(types_a & types_b, set(), "dry_level types must be disjoint")
+        self.assertEqual(types_a | types_b, {APPLIANCE_WM, APPLIANCE_WD, APPLIANCE_TD})
+        self.assertNotEqual(dry[0].label_map, dry[1].label_map)
+        self.assertNotEqual(dry[0].label_map["1"], dry[1].label_map["1"])
+
+    def test_catalog_keys_and_params_unique_within_type(self) -> None:
+        # No two controls of the same appliance type may share a param (would write
+        # the same option twice) or a unique_id suffix collision.
+        for app_type in (APPLIANCE_WM, APPLIANCE_WD, APPLIANCE_TD):
+            params = [p for p, _ in _catalog_entries(app_type)]
+            self.assertEqual(len(params), len(set(params)), f"{app_type}: duplicate catalog param")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wash_option_params.py
+++ b/tests/test_wash_option_params.py
@@ -300,11 +300,25 @@ class CatalogPinTest(unittest.TestCase):
         self.assertNotEqual(dry[0].label_map["1"], dry[1].label_map["1"])
 
     def test_catalog_keys_and_params_unique_within_type(self) -> None:
-        # No two controls of the same appliance type may share a param (would write
-        # the same option twice) or a unique_id suffix collision.
+        # No two controls of the same appliance type may share a param (would write the
+        # same option twice). And within a PLATFORM no two may share a key: the entity
+        # unique_id is f"{appliance_id}_opt_{key}" scoped per platform, so a same-key
+        # collision in one platform clashes (cross-platform reuse is fine -- different
+        # entity domains). This is the unique_id-suffix guard the comment promised.
         for app_type in (APPLIANCE_WM, APPLIANCE_WD, APPLIANCE_TD):
             params = [p for p, _ in _catalog_entries(app_type)]
             self.assertEqual(len(params), len(set(params)), f"{app_type}: duplicate catalog param")
+            for platform, catalog in (
+                ("switch", switch._PROGRAM_OPTION_SWITCHES),
+                ("select", select._PROGRAM_OPTION_SELECTS),
+                ("number", number._PROGRAM_OPTION_NUMBERS),
+            ):
+                keys = [d.key for d in catalog if app_type in d.types]
+                self.assertEqual(
+                    len(keys),
+                    len(set(keys)),
+                    f"{app_type}/{platform}: duplicate catalog key (unique_id collision)",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.5.0-beta`.

<!-- release-tag: v5.5.0-beta -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added writable washer/dryer “program option” controls (select, switch, and numeric delay/option values) for supported models.
  * Changes are buffered and automatically applied when you start the selected program.
* **Bug Fixes**
  * Improved validation and error handling for option values (prevents off-grid/invalid selections).
  * Pending options are now applied reliably and only cleared after a successful start.
* **Documentation**
  * Updated English and Italian translations for the new program-option controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds buffered washer and dryer program options for the v5.5.0 beta release. The main changes are:

- New select, switch, and number entities for supported start-program options.
- Shared option buffering and apply-on-start helpers.
- Pending option clearing when the selected program changes.
- Duplicate dry-level label handling for dryer schemas.
- English and Italian translations for the new entities.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/button.py | Applies pending options to the active start command and clears sent values after a successful start. |
| custom_components/addhon/select.py | Adds program-option selects and clears buffered options when the selected program changes. |
| custom_components/addhon/number.py | Adds delayed-start option support with live range validation. |
| custom_components/addhon/program_options.py | Introduces shared helpers for option discovery, normalization, buffering, and application. |
| custom_components/addhon/switch.py | Adds schema-gated switch entities for boolean program options. |

<sub>Reviews (3): Last reviewed commit: ["test(#35): PR #38 #8 — assert catalog ke..."](https://github.com/tis24dev/addhon/commit/1ba04835c5bf9aeb0fb98e6bb0713f10024fe0ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40376319)</sub>

<!-- /greptile_comment -->