### PR TITLE
Release v5.6.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ controls where they have been mapped.
 
 - **AC Unit:** Haier AS35PBPHRA-PRE
 - **Washing Machine:** Haier HW80-B14959TU1IT
+- **Washing Machine:** Candy TCA286TM5-S
 - **Tumble Dryer:** Haier HD100-C367GU1-IT
+- **Tumble Dryer:** Haier HD90-A3959 INT
 - **Refrigerator:** Haier HDPW5620CNPK
 
 Other hOn-compatible Haier appliances should work; feel free to test and report.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.12%2B-41BDF5.svg?logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Last commit](https://img.shields.io/github/last-commit/tis24dev/addhOn?logo=github)](https://github.com/tis24dev/addhOn/commits)
+[![💖 Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-pink?logo=github)](https://github.com/sponsors/tis24dev)
+[![☕ Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-tis24dev-yellow?logo=buymeacoffee)](https://github.com/sponsors/tis24dev)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Last commit](https://img.shields.io/github/last-commit/tis24dev/addhOn?logo=github)](https://github.com/tis24dev/addhOn/commits)
 [![💖 Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-pink?logo=github)](https://github.com/sponsors/tis24dev)
-[![☕ Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-tis24dev-yellow?logo=buymeacoffee)](https://github.com/sponsors/tis24dev)
 
 </div>
 

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.5.0-beta"
+  "version": "5.6.0-beta"
 }

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -29,10 +29,12 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.exceptions import HomeAssistantError
+
 from .base_entity import HonBaseEntity
-from .const import PROGRAM_PENDING_OPTIONS
+from .const import DOMAIN, PROGRAM_PARAM_NAMES, PROGRAM_PENDING_OPTIONS
 from .debug_utils import redact_id
-from .hon_commands import get_command, param_range, param_values
+from .hon_commands import get_command, get_commands, param_range, param_values
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +50,67 @@ _MAX_RANGE_CHOICES = 1000
 def startprogram_command(appliance):
     """The device's ``startProgram`` command, or None if absent."""
     return get_command(appliance, STARTPROGRAM_COMMAND)
+
+
+async def async_send_program(hass, client, appliance, program_code: str) -> None:
+    """Apply ``program_code`` to the ``startProgram`` command and send it, SWAP-AWARE.
+
+    Setting the ``program``/``prCode`` parameter SWAPS the active startProgram command in
+    ``appliance.commands`` (a ``HonParameterProgram`` setter does ``command.category =
+    value`` -> ``appliance.commands["startProgram"] = categories[code]``, replacing the
+    object), so we re-read the now-active command and send THAT, not the stale pre-swap
+    object. Mirrors the proven washer flow (button.py:200-251); used by the fridge program
+    select for an IMMEDIATE send (no buffer/Start-button cycle). The per-program fixed
+    ancillaries (programFamily/zone/holidayMode/quickMode*/remoteActionable/remoteVisible)
+    ride along in the swapped category's own schema and are serialized by ``command.send()``
+    -- we never set them by hand.
+    """
+    if not appliance or not client:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="appliance_or_client_unavailable",
+        )
+
+    def _do():
+        async def _inner():
+            commands = get_commands(appliance)
+            command = commands.get(STARTPROGRAM_COMMAND)
+            if command is None:
+                raise RuntimeError(
+                    f"Command '{STARTPROGRAM_COMMAND}' not found on the device"
+                )
+            params = getattr(command, "parameters", None)
+            params = params if isinstance(params, dict) else {}
+            applied = False
+            for pname in PROGRAM_PARAM_NAMES:
+                if pname in params:
+                    params[pname].value = program_code
+                    applied = True
+                    break
+            if not applied:
+                raise RuntimeError(
+                    f"startProgram has no program parameter {PROGRAM_PARAM_NAMES} "
+                    f"among {sorted(params)}"
+                )
+            # Re-read after the category swap so send() targets the SELECTED program's
+            # command (carrying its fixed ancillaries), not the stale pre-swap object.
+            refreshed = commands.get(STARTPROGRAM_COMMAND)
+            if refreshed is not None and refreshed is not command:
+                _LOGGER.debug(
+                    "ProgramSend debug: startProgram swapped after program apply (%s)",
+                    program_code,
+                )
+                command = refreshed
+            await command.send()
+            _LOGGER.debug(
+                "ProgramSend debug: startProgram '%s' send completed id=%s",
+                program_code,
+                redact_id(getattr(appliance, "id", None)),
+            )
+
+        client.run_command_sync(_inner())
+
+    await hass.async_add_executor_job(_do)
 
 
 def startprogram_option_param(appliance, name: str):

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -81,27 +81,55 @@ async def async_send_program(hass, client, appliance, program_code: str) -> None
                 )
             params = getattr(command, "parameters", None)
             params = params if isinstance(params, dict) else {}
-            applied = False
-            for pname in PROGRAM_PARAM_NAMES:
-                if pname in params:
-                    params[pname].value = program_code
-                    applied = True
-                    break
-            if not applied:
-                raise RuntimeError(
-                    f"startProgram has no program parameter {PROGRAM_PARAM_NAMES} "
-                    f"among {sorted(params)}"
-                )
-            # Re-read after the category swap so send() targets the SELECTED program's
-            # command (carrying its fixed ancillaries), not the stale pre-swap object.
-            refreshed = commands.get(STARTPROGRAM_COMMAND)
-            if refreshed is not None and refreshed is not command:
-                _LOGGER.debug(
-                    "ProgramSend debug: startProgram swapped after program apply (%s)",
-                    program_code,
-                )
-                command = refreshed
-            await command.send()
+            # Snapshot for rollback (mirrors async_send_command). Applying the program
+            # SWAPS appliance.commands[startProgram] to the selected category (a
+            # HonParameterProgram setter does command.category=code; the param's own
+            # __dict__ is untouched). A prCode/enum-typed program param instead mutates its
+            # own value. If send() then fails we must undo BOTH possibilities, otherwise
+            # select.py (which skips the refresh on error) would keep running against a
+            # local command/category the cloud never accepted, until the next coordinator
+            # poll. The command-pointer reset below is the load-bearing undo for the swap;
+            # the param-__dict__ restore covers the value-mutating (prCode) case.
+            original_command = command
+            snapshots: dict = {
+                key: dict(attr.__dict__)
+                for key, attr in params.items()
+                if hasattr(attr, "__dict__")
+            }
+            try:
+                applied = False
+                for pname in PROGRAM_PARAM_NAMES:
+                    if pname in params:
+                        params[pname].value = program_code
+                        applied = True
+                        break
+                if not applied:
+                    raise RuntimeError(
+                        f"startProgram has no program parameter {PROGRAM_PARAM_NAMES} "
+                        f"among {sorted(params)}"
+                    )
+                # Re-read after the category swap so send() targets the SELECTED program's
+                # command (carrying its fixed ancillaries), not the stale pre-swap object.
+                refreshed = commands.get(STARTPROGRAM_COMMAND)
+                if refreshed is not None and refreshed is not command:
+                    _LOGGER.debug(
+                        "ProgramSend debug: startProgram swapped after program apply (%s)",
+                        program_code,
+                    )
+                    command = refreshed
+                await command.send()
+            except Exception:
+                # Restore the pre-swap parameter state (copy __dict__ directly, bypassing
+                # the setters so a value-mutating param does not re-fire its rules) and
+                # reset the swapped command pointer to the original.
+                for key, snap in snapshots.items():
+                    attr = params.get(key)
+                    if attr is None or not hasattr(attr, "__dict__"):
+                        continue
+                    attr.__dict__.clear()
+                    attr.__dict__.update(snap)
+                commands[STARTPROGRAM_COMMAND] = original_command
+                raise
             _LOGGER.debug(
                 "ProgramSend debug: startProgram '%s' send completed id=%s",
                 program_code,

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -12,6 +12,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
 from .const import (
+    APPLIANCE_FR,
+    APPLIANCE_FRE,
+    APPLIANCE_REF,
     APPLIANCE_TD,
     APPLIANCE_WASH_GROUP,
     APPLIANCE_WD,
@@ -28,11 +31,30 @@ from .const import (
     TEMP_LEVEL_LABELS,
 )
 from .debug_utils import redact_id, redact_store
+from .hon_commands import async_send_command
 from .program_options import (
     HonProgramOptionEntity,
+    async_send_program,
     normalize_code,
     option_choices,
 )
+
+# Fridge family (REF/FR/FRE): the writable program/mode select (discussion #40).
+_COOLING_TYPES = (APPLIANCE_REF, APPLIANCE_FR, APPLIANCE_FRE)
+# Synthetic "no program" option -> stopProgram (the global mode reset).
+REF_PROGRAM_OFF = "off"
+# Read-back ONLY: a live device mode flag (0/1) -> the startProgram program code it
+# corresponds to. Used to derive current_option from the device truth (never from
+# startProgram.program, which only carries the recovered default category). The app's own
+# identity map (refrigeration.md section 1): superCool=quickModeZ1, superFreeze=quickModeZ2,
+# holiday=holidayMode, autoSet=intelligenceMode. Double-gated at read time: the code must
+# also be in the device's live program enum.
+_REF_MODE_FLAG_TO_PROGRAM: dict[str, str] = {
+    "quickModeZ1": "super_cool",
+    "quickModeZ2": "super_freeze",
+    "holidayMode": "holiday",
+    "intelligenceMode": "auto_set",
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,6 +158,19 @@ async def async_setup_entry(
             app_type,
             _command_names(appliance),
         )
+        if app_type in _COOLING_TYPES:
+            # Fridge family (#40): one writable program/mode select, sends immediately.
+            if HonRefProgramSelect.supports_appliance(appliance):
+                entities.append(HonRefProgramSelect(coordinator, appliance_id, client))
+                _LOGGER.info("Added REF program select: id=%s", redact_id(appliance_id))
+            else:
+                _LOGGER.debug(
+                    "Select debug: no REF program select for '%s' id=%s; "
+                    "needs startProgram(program enum) + stopProgram",
+                    data.get("name"),
+                    redact_id(appliance_id),
+                )
+            continue
         if app_type not in APPLIANCE_WASH_GROUP:
             _LOGGER.debug("Select debug: appliance id=%s ignored, type=%s", redact_id(appliance_id), app_type)
             continue
@@ -495,3 +530,135 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
                 },
             )
         self._buffer(raw)
+
+
+class HonRefProgramSelect(HonBaseEntity, SelectEntity):
+    """Writable program/mode select for fridges (REF/FR/FRE), discussion #40.
+
+    Fridge "modes" (super cool, super freeze, holiday, plus the iot_* presets) are NOT
+    writable settings booleans: they are ``startProgram`` PROGRAMS, cleared by
+    ``stopProgram`` (a GLOBAL reset that zeroes every mode flag). The app/cloud model is
+    mutually exclusive (one program at a time), so the faithful HA shape is a single
+    select. Options are ``off`` plus the device's LIVE ``startProgram.program`` enum
+    (capability-gated, never hard-coded). Unlike the washer select, selecting here sends
+    IMMEDIATELY (no buffer/Start-button cycle): a program -> ``startProgram(program=X)``,
+    ``off`` -> ``stopProgram``. ``current_option`` is derived from the live device mode
+    FLAGS, NOT from ``startProgram.program`` (which only carries the recovered default
+    category and would otherwise pin a phantom mode forever)."""
+
+    _attr_icon = "mdi:snowflake"
+
+    def __init__(self, coordinator, appliance_id: str, client=None) -> None:
+        super().__init__(coordinator, appliance_id, client)
+        self._attr_unique_id = f"{appliance_id}_ref_program"
+        self._attr_translation_key = "ref_program"
+        # Build the option list from the live program enum read SPECIFICALLY off the
+        # startProgram command -- the same command async_send_program targets -- so the
+        # option SOURCE can never diverge from the SEND target (a fridge could in theory
+        # also expose another program-bearing command; we deliberately ignore it here).
+        self._program_codes: list[str] = []
+        resolved = self._start_program_param(self._appliance)
+        if resolved is not None:
+            command, param_name = resolved
+            self._program_codes = list(
+                HonProgramSelect._program_values(command, param_name).keys()
+            )
+        self._attr_options = [REF_PROGRAM_OFF, *self._program_codes]
+        _LOGGER.debug(
+            "Select debug: initialized REF program '%s' id=%s options=%s",
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
+            self._attr_options,
+        )
+
+    @staticmethod
+    def _start_program_param(appliance):
+        """(startProgram command, program-param name), or None.
+
+        Resolved ONLY on ``startProgram`` (not the broader PROGRAM_SOURCE_COMMANDS walk the
+        washer uses) so the fridge select's option source is always the very command it
+        sends to."""
+        commands = getattr(appliance, "commands", None)
+        commands = commands if isinstance(commands, dict) else {}
+        command = commands.get("startProgram")
+        params = getattr(command, "parameters", None) if command is not None else None
+        if not isinstance(params, dict):
+            return None
+        for param_name in PROGRAM_PARAM_NAMES:
+            if param_name in params:
+                return command, param_name
+        return None
+
+    @classmethod
+    def supports_appliance(cls, appliance) -> bool:
+        """True if the device exposes startProgram with a populated program enum AND a
+        stopProgram command (so the ``off`` reset is real)."""
+        commands = getattr(appliance, "commands", None)
+        commands = commands if isinstance(commands, dict) else {}
+        if "stopProgram" not in commands:
+            _LOGGER.debug(
+                "Select debug: REF select skipped, no stopProgram. commands=%s",
+                _command_names(appliance),
+            )
+            return False
+        resolved = cls._start_program_param(appliance)
+        if resolved is None:
+            _LOGGER.debug(
+                "Select debug: REF select skipped, startProgram has no program param. "
+                "commands=%s",
+                _command_names(appliance),
+            )
+            return False
+        command, param_name = resolved
+        return bool(HonProgramSelect._program_values(command, param_name))
+
+    @property
+    def current_option(self) -> str | None:
+        # Device truth from the mode FLAGS (double-gated: the code must also be a live
+        # program option). No mode set -> off. Deliberately ignores startProgram.program.
+        for flag, code in _REF_MODE_FLAG_TO_PROGRAM.items():
+            if code in self._program_codes and str(self._get_attr(flag)) == "1":
+                _LOGGER.debug(
+                    "Select debug: REF current_option id=%s flag=%s -> %s",
+                    redact_id(self._appliance_id), flag, code,
+                )
+                return code
+        return REF_PROGRAM_OFF
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="program_not_found",
+                translation_placeholders={"program": option},
+            )
+        appliance = self._appliance
+        client = self._hon_client
+        if not appliance or not client:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="appliance_or_client_unavailable",
+            )
+        try:
+            if option == REF_PROGRAM_OFF:
+                _LOGGER.info(
+                    "Select: REF program off -> stopProgram id=%s",
+                    redact_id(self._appliance_id),
+                )
+                await async_send_command(self.hass, client, appliance, "stopProgram", {})
+            else:
+                _LOGGER.info(
+                    "Select: REF program '%s' -> startProgram id=%s",
+                    option, redact_id(self._appliance_id),
+                )
+                await async_send_program(self.hass, client, appliance, option)
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            _LOGGER.error("Select: REF program '%s' error: %s", option, err, exc_info=True)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        await self._async_request_command_refresh()

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -542,9 +542,11 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
     select. Options are ``off`` plus the device's LIVE ``startProgram.program`` enum
     (capability-gated, never hard-coded). Unlike the washer select, selecting here sends
     IMMEDIATELY (no buffer/Start-button cycle): a program -> ``startProgram(program=X)``,
-    ``off`` -> ``stopProgram``. ``current_option`` is derived from the live device mode
-    FLAGS, NOT from ``startProgram.program`` (which only carries the recovered default
-    category and would otherwise pin a phantom mode forever)."""
+    ``off`` -> ``stopProgram``. ``current_option`` is derived from REAL device feedback:
+    first the live mode FLAGS (boost modes), then the cloud-persisted active-program field
+    ``programName``/``prStr``/``prCode`` (covers the iot_* presets, which set no flag) -
+    never optimistic state and never ``startProgram.program`` (the recovered default
+    category, which would otherwise pin a phantom mode forever)."""
 
     _attr_icon = "mdi:snowflake"
 
@@ -612,10 +614,15 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
         command, param_name = resolved
         return bool(HonProgramSelect._program_values(command, param_name))
 
+    # Shadow attributes carrying the ACTIVE program identity (cloud-persisted: what the
+    # official app reads to show the running program, e.g. after an app reinstall). NOT
+    # startProgram.program, which is only the recovered default category.
+    _REF_ACTIVE_PROGRAM_ATTRS = ("programName", "prStr", "prCode")
+
     @property
     def current_option(self) -> str | None:
-        # Device truth from the mode FLAGS (double-gated: the code must also be a live
-        # program option). No mode set -> off. Deliberately ignores startProgram.program.
+        # 1) Boost/special modes from the live device FLAGS (the most reliable signal,
+        #    zeroed by stopProgram). Double-gated: the code must be an offered option.
         for flag, code in _REF_MODE_FLAG_TO_PROGRAM.items():
             if code in self._program_codes and str(self._get_attr(flag)) == "1":
                 _LOGGER.debug(
@@ -623,7 +630,41 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
                     redact_id(self._appliance_id), flag, code,
                 )
                 return code
+        # 2) Any other active program (e.g. the iot_* download presets, which set no
+        #    flag) from the cloud-persisted programName/prStr/prCode. Real device
+        #    feedback, NOT optimistic "remember what was clicked" state.
+        matched = self._active_program_code()
+        if matched is not None:
+            return matched
+        # 3) Nothing active.
         return REF_PROGRAM_OFF
+
+    def _active_program_code(self) -> str | None:
+        """Match the cloud's active-program field to a live option code, or None.
+
+        programName/prStr ship as i18n keys (e.g. ``PROGRAMS.REF.IOT_EXTRA_COLD``), so we
+        compare both the whole token and its last dotted segment, case-insensitively, and
+        accept ONLY an exact match against an offered code (no fuzzy/substring match, to
+        never report the wrong program). This is what reflects the iot_* presets, which
+        set no mode flag. ``startProgram.program`` is deliberately NOT consulted (it is the
+        recovered default category, not the running program)."""
+        by_lower = {code.lower(): code for code in self._program_codes}
+        for attr in self._REF_ACTIVE_PROGRAM_ATTRS:
+            raw = self._get_attr(attr)
+            if raw is None:
+                continue
+            token = str(raw).strip().lower()
+            if not token:
+                continue
+            for candidate in (token, token.rsplit(".", 1)[-1]):
+                code = by_lower.get(candidate)
+                if code is not None:
+                    _LOGGER.debug(
+                        "Select debug: REF current_option id=%s programName=%r -> %s",
+                        redact_id(self._appliance_id), raw, code,
+                    )
+                    return code
+        return None
 
     async def async_select_option(self, option: str) -> None:
         if option not in self._attr_options:

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -962,7 +962,14 @@ class HonMeanWaterConsumption(HonBaseEntity, SensorEntity):
 
     _attr_translation_key = "mean_water_consumption"
     _attr_icon = "mdi:water-sync"
-    _attr_device_class = SensorDeviceClass.WATER
+    # No device_class on purpose: this is an average litres-per-cycle figure that
+    # rises and falls, so it needs state_class MEASUREMENT to record min/mean/max
+    # long-term statistics. WATER and VOLUME allow only total/total_increasing (see
+    # HA sensor const.py DEVICE_CLASS_STATE_CLASSES); the only volume-family classes
+    # that allow MEASUREMENT are VOLUME_STORAGE ("amount currently stored in a
+    # container") and VOLUME_FLOW_RATE (needs flow-rate units, not litres) -- neither
+    # fits a per-cycle average. Dropping the device_class keeps the litre unit and
+    # the statistics while staying semantically honest; the icon is already set above.
     _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -700,6 +700,26 @@
       "program": {
         "name": "Program"
       },
+      "ref_program": {
+        "name": "Program",
+        "state": {
+          "off": "Off",
+          "holiday": "Holiday",
+          "super_cool": "Super cool",
+          "super_freeze": "Super freeze",
+          "auto_set": "Auto set",
+          "quick_cool": "Quick cool",
+          "zero_fresh": "Zero degrees",
+          "fruit_and_veg": "Fruit and veg",
+          "soft_freeze": "Soft freeze",
+          "iot_daily_use": "Daily use",
+          "iot_extra_cold": "Extra cold",
+          "iot_extra_cold_water": "Extra cold (water)",
+          "iot_extra_ice": "Extra ice",
+          "iot_high_efficiency": "High efficiency",
+          "iot_special_food_core": "Special food"
+        }
+      },
       "spin_speed": {
         "name": "Spin speed"
       },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -700,6 +700,26 @@
       "program": {
         "name": "Programma"
       },
+      "ref_program": {
+        "name": "Programma",
+        "state": {
+          "off": "Spento",
+          "holiday": "Vacanza",
+          "super_cool": "Super raffreddamento",
+          "super_freeze": "Super congelamento",
+          "auto_set": "Auto set",
+          "quick_cool": "Raffreddamento rapido",
+          "zero_fresh": "Zero gradi",
+          "fruit_and_veg": "Frutta e verdura",
+          "soft_freeze": "Congelamento leggero",
+          "iot_daily_use": "Uso quotidiano",
+          "iot_extra_cold": "Extra freddo",
+          "iot_extra_cold_water": "Extra freddo (acqua)",
+          "iot_extra_ice": "Extra ghiaccio",
+          "iot_high_efficiency": "Alta efficienza",
+          "iot_special_food_core": "Alimenti speciali"
+        }
+      },
       "spin_speed": {
         "name": "Centrifuga"
       },

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -214,8 +214,9 @@ def _collect_code_keys() -> dict[str, set[str]]:
         | {d.key for d in switch._PROGRAM_OPTION_SWITCHES}
         | {"pause", "debug_logging", "mqtt_realtime_debug"}
     )
-    # Program select (fixed key) + the program-option selects (#35).
-    used["select"] = {"program"} | {
+    # Program select (fixed key) + the REF program/mode select (#40) + the
+    # program-option selects (#35).
+    used["select"] = {"program", "ref_program"} | {
         d.translation_key for d in select._PROGRAM_OPTION_SELECTS
     }
     used["button"] = {"start_program", "stop_program", "force_refresh", "reset_debug"}

--- a/tests/test_ref_program_select.py
+++ b/tests/test_ref_program_select.py
@@ -1,0 +1,394 @@
+"""Tests for the fridge (REF/FR/FRE) writable program/mode select, discussion #40.
+
+The fridge modes (super cool, super freeze, holiday, iot_* presets) are startProgram
+PROGRAMS, not writable booleans, cleared by a GLOBAL stopProgram. This select exposes
+``off`` + the live ``startProgram.program`` enum and sends IMMEDIATELY: a program ->
+``startProgram(program=X)`` (swap-aware), ``off`` -> ``stopProgram``. ``current_option`` is
+read from the live device mode FLAGS, never from ``startProgram.program``.
+
+Reuses the HA stub harness installed by test_program_select.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Importing this installs the homeassistant stubs and gives us the fakes.
+from test_program_select import (  # noqa: E402
+    FakeClient,
+    FakeCoordinator,
+    FakeEntry,
+    FakeHass,
+    Param,
+    RecordingCommand,
+)
+
+# roberglezz's real fridge (HCW58F18EWMP) program enum, live order.
+ROB_PROGRAMS = [
+    "holiday",
+    "iot_daily_use",
+    "iot_extra_cold",
+    "iot_extra_ice",
+    "iot_high_efficiency",
+    "iot_special_food_core",
+    "super_cool",
+    "super_freeze",
+]
+
+
+def _ref(commands: dict, attributes: dict | None = None, app_id: str = "ref-1") -> dict:
+    return {
+        app_id: {
+            "type": "REF",
+            "name": "Fridge",
+            "appliance": types.SimpleNamespace(commands=commands),
+            "attributes": attributes or {},
+            "settings": {},
+        }
+    }
+
+
+def _ref_commands(programs=None, with_stop=True) -> dict:
+    commands = {
+        # The fridge's setParameters command (no program param): must be ignored as a
+        # program source, exactly like a real REF.
+        "settings": RecordingCommand({"tempSelZ1": Param("3", values=["1", "2", "3"])}),
+        "startProgram": RecordingCommand(
+            {"program": Param(values=list(programs if programs is not None else ROB_PROGRAMS))}
+        ),
+    }
+    if with_stop:
+        commands["stopProgram"] = RecordingCommand(
+            {
+                "quickModeZ1": Param("0", values=["0"]),
+                "quickModeZ2": Param("0", values=["0"]),
+                "holidayMode": Param("0", values=["0"]),
+            }
+        )
+    return commands
+
+
+class RefProgramSelectSetupTest(unittest.IsolatedAsyncioTestCase):
+    async def _setup(self, data) -> list:
+        from custom_components.addhon.const import DOMAIN
+        from custom_components.addhon import select
+
+        coordinator = FakeCoordinator(data)
+        hass = FakeHass(
+            {DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}}
+        )
+        added: list = []
+        await select.async_setup_entry(hass, FakeEntry(), added.extend)
+        return added
+
+    async def test_created_for_ref_with_program_and_stopprogram(self) -> None:
+        added = await self._setup(_ref(_ref_commands()))
+        self.assertEqual(1, len(added))
+        self.assertEqual("ref_program", added[0]._attr_translation_key)
+
+    async def test_options_are_off_first_plus_live_enum(self) -> None:
+        # off is always the first option; the rest is exactly the live enum SET. (Runtime
+        # HonParameterProgram.values sorts, so we assert the set, not the input order.)
+        added = await self._setup(_ref(_ref_commands()))
+        options = added[0]._attr_options
+        self.assertEqual("off", options[0])
+        self.assertEqual(set(ROB_PROGRAMS), set(options[1:]))
+
+    async def test_options_follow_a_different_live_enum(self) -> None:
+        # Built from the live enum, NOT hard-coded: a different model -> different options.
+        added = await self._setup(_ref(_ref_commands(programs=["super_cool", "auto_set"])))
+        options = added[0]._attr_options
+        self.assertEqual("off", options[0])
+        self.assertEqual({"super_cool", "auto_set"}, set(options[1:]))
+
+    async def test_not_created_without_stopprogram(self) -> None:
+        added = await self._setup(_ref(_ref_commands(with_stop=False)))
+        self.assertEqual([], added)
+
+    async def test_not_created_without_program_enum(self) -> None:
+        commands = {
+            "startProgram": RecordingCommand({"program": Param(values=[])}),
+            "stopProgram": RecordingCommand({"holidayMode": Param("0", values=["0"])}),
+        }
+        added = await self._setup(_ref(commands))
+        self.assertEqual([], added)
+
+    async def test_fr_and_fre_types_supported(self) -> None:
+        for app_type in ("FR", "FRE"):
+            data = _ref(_ref_commands())
+            data["ref-1"]["type"] = app_type
+            added = await self._setup(data)
+            self.assertEqual(1, len(added), f"type {app_type} should get a select")
+
+
+class RefProgramSelectBehaviourTest(unittest.IsolatedAsyncioTestCase):
+    def _entity(self, commands, attributes=None):
+        from custom_components.addhon.select import HonRefProgramSelect
+
+        coordinator = FakeCoordinator(_ref(commands, attributes))
+        entity = HonRefProgramSelect(coordinator, "ref-1", FakeClient())
+        entity.hass = FakeHass()
+        return entity, coordinator
+
+    async def test_select_program_sends_startprogram(self) -> None:
+        commands = _ref_commands()
+        entity, coordinator = self._entity(commands)
+
+        await entity.async_select_option("super_cool")
+
+        start = commands["startProgram"]
+        self.assertEqual("super_cool", start.parameters["program"].value)
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual(0, commands["stopProgram"].send_calls)
+        self.assertEqual(1, coordinator.refreshes)
+
+    async def test_select_off_sends_stopprogram_only(self) -> None:
+        commands = _ref_commands()
+        entity, coordinator = self._entity(commands)
+
+        await entity.async_select_option("off")
+
+        self.assertEqual(1, commands["stopProgram"].send_calls)
+        # startProgram untouched.
+        self.assertEqual(0, commands["startProgram"].send_calls)
+        self.assertIsNone(commands["startProgram"].parameters["program"].value)
+        self.assertEqual(1, coordinator.refreshes)
+
+    async def test_off_sends_stopprogram_with_no_overrides(self) -> None:
+        # Production must call async_send_command for stopProgram with an EMPTY params dict:
+        # the device's own schema-fixed "0" flags do the global reset, and we must NOT
+        # inject overrides (which would hit the "missing param" raise). Spying the real call
+        # makes this mutation-proof against a regression that passed e.g. {"onOffStatus":"0"}.
+        from custom_components.addhon import select as select_mod
+
+        calls: list = []
+
+        async def _spy(hass, client, appliance, command_name, params, **kwargs):
+            calls.append((command_name, dict(params)))
+
+        original = select_mod.async_send_command
+        select_mod.async_send_command = _spy
+        try:
+            entity, _ = self._entity(_ref_commands())
+            await entity.async_select_option("off")
+        finally:
+            select_mod.async_send_command = original
+
+        self.assertEqual([("stopProgram", {})], calls)
+
+    async def test_select_program_is_swap_aware(self) -> None:
+        # Setting program swaps the active startProgram command; we must send the NEW one.
+        from custom_components.addhon.select import HonRefProgramSelect
+
+        appliance = types.SimpleNamespace(commands={})
+        new_cmd = RecordingCommand({"program": Param("holiday")})
+
+        class ProgramSwapParam:
+            def __init__(self, values) -> None:
+                self._value = None
+                self.values = values
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd
+
+        old_cmd = RecordingCommand({"program": ProgramSwapParam(["holiday", "super_cool"])})
+        appliance.commands["startProgram"] = old_cmd
+        appliance.commands["stopProgram"] = RecordingCommand(
+            {"holidayMode": Param("0", values=["0"])}
+        )
+
+        coordinator = FakeCoordinator(
+            {
+                "ref-1": {
+                    "type": "REF",
+                    "name": "Fridge",
+                    "appliance": appliance,
+                    "attributes": {},
+                    "settings": {},
+                }
+            }
+        )
+        entity = HonRefProgramSelect(coordinator, "ref-1", FakeClient())
+        entity.hass = FakeHass()
+
+        await entity.async_select_option("holiday")
+
+        self.assertEqual("holiday", old_cmd.parameters["program"].value)
+        self.assertEqual(1, new_cmd.send_calls)  # swapped command sent
+        self.assertEqual(0, old_cmd.send_calls)  # stale one NOT sent
+
+    async def test_invalid_option_raises(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        entity, coordinator = self._entity(_ref_commands())
+        commands = coordinator.data["ref-1"]["appliance"].commands
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_select_option("nonexistent_mode")
+        self.assertEqual("program_not_found", ctx.exception.translation_key)
+        self.assertEqual("nonexistent_mode", ctx.exception.translation_placeholders["program"])
+        # An invalid option must not send nor refresh.
+        self.assertEqual(0, commands["startProgram"].send_calls)
+        self.assertEqual(0, commands["stopProgram"].send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+
+    async def test_send_failure_wraps_command_error_and_skips_refresh(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.select import HonRefProgramSelect
+
+        class FailingClient:
+            def run_command_sync(self, coro) -> None:
+                coro.close()  # avoid "never awaited" warning
+                raise RuntimeError("cloud rejected")
+
+        coordinator = FakeCoordinator(_ref(_ref_commands()))
+        entity = HonRefProgramSelect(coordinator, "ref-1", FailingClient())
+        entity.hass = FakeHass()
+
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_select_option("super_cool")
+        self.assertEqual("command_error", ctx.exception.translation_key)
+        self.assertIn("cloud rejected", ctx.exception.translation_placeholders["error"])
+        # Refresh must NOT run after a failed send.
+        self.assertEqual(0, coordinator.refreshes)
+
+    async def test_unavailable_when_client_missing(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.select import HonRefProgramSelect
+
+        coordinator = FakeCoordinator(_ref(_ref_commands()))
+        entity = HonRefProgramSelect(coordinator, "ref-1", client=None)
+        entity.hass = FakeHass()
+
+        # Spy both send helpers: the guard must fire at the select layer, BEFORE either
+        # helper is reached (the helpers raise the same key as a backstop, so without this
+        # we could not tell the select-level check is what fired).
+        from custom_components.addhon import select as select_mod
+
+        send_calls: list = []
+
+        async def _spy_cmd(*a, **k):
+            send_calls.append("cmd")
+
+        async def _spy_prog(*a, **k):
+            send_calls.append("prog")
+
+        orig_cmd, orig_prog = select_mod.async_send_command, select_mod.async_send_program
+        select_mod.async_send_command = _spy_cmd
+        select_mod.async_send_program = _spy_prog
+        try:
+            with self.assertRaises(HomeAssistantError) as ctx:
+                await entity.async_select_option("super_cool")
+        finally:
+            select_mod.async_send_command = orig_cmd
+            select_mod.async_send_program = orig_prog
+        self.assertEqual("appliance_or_client_unavailable", ctx.exception.translation_key)
+        self.assertEqual([], send_calls)  # neither send helper was reached
+        self.assertEqual(0, coordinator.refreshes)
+
+    async def test_setup_log_redacts_appliance_id(self) -> None:
+        # No-id-leak policy: the "Added REF program select" INFO log must redact the id
+        # (here the appliance is keyed under a MAC, the exact identity that must not leak).
+        from custom_components.addhon.const import DOMAIN
+        from custom_components.addhon import select as select_mod
+
+        mac = "AA:BB:CC:DD:EE:FF"
+        data = _ref(_ref_commands(), app_id=mac)
+        coordinator = FakeCoordinator(data)
+        hass = FakeHass(
+            {DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}}
+        )
+        added: list = []
+        with self.assertLogs(select_mod._LOGGER.name, level="INFO") as logs:
+            await select_mod.async_setup_entry(hass, FakeEntry(), added.extend)
+        blob = "\n".join(logs.output)
+        self.assertEqual(1, len(added))
+        self.assertTrue(any("Added REF program select" in ln for ln in logs.output))
+        self.assertNotIn(mac, blob)
+        self.assertNotIn("AA:BB", blob)
+
+    async def test_current_option_off_when_flags_zero(self) -> None:
+        # The read-back TRAP: startProgram.program defaults to "holiday" while the fridge is
+        # idle (all flags 0). current_option must ignore it and return off.
+        commands = _ref_commands()
+        attributes = {
+            "quickModeZ1": 0,
+            "quickModeZ2": 0,
+            "holidayMode": 0,
+            "startProgram.program": "holiday",
+            "programName": "No Program",
+        }
+        entity, _ = self._entity(commands, attributes)
+        self.assertEqual("off", entity.current_option)
+
+    async def test_current_option_reads_active_flag(self) -> None:
+        cases = {
+            "quickModeZ1": "super_cool",
+            "quickModeZ2": "super_freeze",
+            "holidayMode": "holiday",
+        }
+        for flag, expected in cases.items():
+            entity, _ = self._entity(_ref_commands(), {flag: "1"})
+            self.assertEqual(expected, entity.current_option, f"{flag} -> {expected}")
+
+    async def test_current_option_gated_by_live_enum(self) -> None:
+        # intelligenceMode=1 but this model's enum has no auto_set -> not reported -> off.
+        entity, _ = self._entity(_ref_commands(), {"intelligenceMode": "1"})
+        self.assertEqual("off", entity.current_option)
+
+    async def test_current_option_auto_set_when_in_enum(self) -> None:
+        commands = _ref_commands(programs=["holiday", "auto_set", "super_cool"])
+        entity, _ = self._entity(commands, {"intelligenceMode": "1"})
+        self.assertEqual("auto_set", entity.current_option)
+
+    async def test_iot_preset_reads_back_off(self) -> None:
+        # iot_* presets set no mode flag, so after applying they read back as off (the
+        # documented limitation; their effect shows on the temperature numbers instead).
+        commands = _ref_commands()
+        entity, _ = self._entity(commands)
+        await entity.async_select_option("iot_extra_cold")
+        self.assertEqual("iot_extra_cold", commands["startProgram"].parameters["program"].value)
+        # No flag set -> current_option is off.
+        self.assertEqual("off", entity.current_option)
+
+
+class RefProgramStateTranslationTest(unittest.TestCase):
+    """The ref_program state map must label every code the select can show: the read-back
+    codes (what current_option returns) AND a real model's full program enum. A missing
+    label only degrades to a raw key in the UI (no crash), but this guards intent."""
+
+    def _state_keys(self, lang: str) -> set[str]:
+        import json
+
+        path = REPO_ROOT / "custom_components" / "addhon" / "translations" / f"{lang}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return set(data["entity"]["select"]["ref_program"]["state"].keys())
+
+    def test_state_covers_readback_and_real_enum(self) -> None:
+        from custom_components.addhon.select import _REF_MODE_FLAG_TO_PROGRAM, REF_PROGRAM_OFF
+
+        required = {REF_PROGRAM_OFF, *_REF_MODE_FLAG_TO_PROGRAM.values(), *ROB_PROGRAMS}
+        for lang in ("en", "it"):
+            keys = self._state_keys(lang)
+            missing = required - keys
+            self.assertFalse(missing, f"[{lang}] ref_program.state missing labels: {sorted(missing)}")
+
+    def test_state_keys_identical_en_it(self) -> None:
+        self.assertEqual(self._state_keys("en"), self._state_keys("it"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ref_program_select.py
+++ b/tests/test_ref_program_select.py
@@ -414,15 +414,51 @@ class RefProgramSelectBehaviourTest(unittest.IsolatedAsyncioTestCase):
         entity, _ = self._entity(commands, {"intelligenceMode": "1"})
         self.assertEqual("auto_set", entity.current_option)
 
-    async def test_iot_preset_reads_back_off(self) -> None:
-        # iot_* presets set no mode flag, so after applying they read back as off (the
-        # documented limitation; their effect shows on the temperature numbers instead).
+    async def test_select_iot_preset_sends_program(self) -> None:
         commands = _ref_commands()
         entity, _ = self._entity(commands)
         await entity.async_select_option("iot_extra_cold")
-        self.assertEqual("iot_extra_cold", commands["startProgram"].parameters["program"].value)
-        # No flag set -> current_option is off.
+        self.assertEqual(
+            "iot_extra_cold", commands["startProgram"].parameters["program"].value
+        )
+
+    async def test_current_option_reads_iot_preset_from_programname(self) -> None:
+        # iot_* presets set NO mode flag, but the cloud persists the active program in
+        # programName (often as an i18n key); current_option reflects it from that real
+        # feedback, both as a bare code and as a dotted i18n key.
+        for raw in ("iot_extra_cold", "PROGRAMS.REF.IOT_EXTRA_COLD"):
+            entity, _ = self._entity(_ref_commands(), {"programName": raw})
+            self.assertEqual("iot_extra_cold", entity.current_option, raw)
+
+    async def test_current_option_programname_via_prstr_and_case(self) -> None:
+        # prStr is an accepted source too; matching is case-insensitive.
+        entity, _ = self._entity(_ref_commands(), {"prStr": "Super_Cool"})
+        self.assertEqual("super_cool", entity.current_option)
+
+    async def test_current_option_off_without_feedback(self) -> None:
+        # No flag and an idle programName -> off (nothing active).
+        entity, _ = self._entity(_ref_commands(), {"programName": "No Program"})
         self.assertEqual("off", entity.current_option)
+
+    async def test_current_option_numeric_prcode_is_harmless(self) -> None:
+        # prCode is consulted but is an int needing a device map we do not have; a numeric
+        # value must never false-match a snake_case code -> off (safe, not a wrong program).
+        for raw in (3, "5", 0):
+            entity, _ = self._entity(_ref_commands(), {"prCode": raw})
+            self.assertEqual("off", entity.current_option, raw)
+
+    async def test_current_option_programname_no_fuzzy_match(self) -> None:
+        # A program name that is not EXACTLY an offered code must not be force-matched.
+        entity, _ = self._entity(_ref_commands(), {"programName": "extra_cold"})
+        self.assertEqual("off", entity.current_option)
+
+    async def test_flag_wins_over_programname(self) -> None:
+        # A live flag takes precedence (boost modes are the most reliable signal).
+        entity, _ = self._entity(
+            _ref_commands(),
+            {"quickModeZ1": "1", "programName": "PROGRAMS.REF.IOT_DAILY_USE"},
+        )
+        self.assertEqual("super_cool", entity.current_option)
 
 
 class RefProgramStateTranslationTest(unittest.TestCase):

--- a/tests/test_ref_program_select.py
+++ b/tests/test_ref_program_select.py
@@ -231,6 +231,66 @@ class RefProgramSelectBehaviourTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, new_cmd.send_calls)  # swapped command sent
         self.assertEqual(0, old_cmd.send_calls)  # stale one NOT sent
 
+    async def test_send_failure_rolls_back_swap_and_program(self) -> None:
+        # If startProgram.send() fails AFTER the category swap, async_send_program must
+        # restore the pre-swap command object AND the program param value, so no unsent
+        # local mutation leaks into later interactions.
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.select import HonRefProgramSelect
+
+        appliance = types.SimpleNamespace(commands={})
+
+        class FailingCommand(RecordingCommand):
+            async def send(self) -> None:
+                self.send_calls += 1
+                raise RuntimeError("cloud rejected")
+
+        new_cmd = FailingCommand({"program": Param("super_cool")})
+
+        class ProgramSwapParam:
+            def __init__(self, values) -> None:
+                self._value = "ORIG"
+                self.values = values
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd  # category swap
+
+        swap_param = ProgramSwapParam(["super_cool", "holiday"])
+        old_cmd = RecordingCommand({"program": swap_param})
+        appliance.commands["startProgram"] = old_cmd
+        appliance.commands["stopProgram"] = RecordingCommand(
+            {"holidayMode": Param("0", values=["0"])}
+        )
+
+        coordinator = FakeCoordinator(
+            {
+                "ref-1": {
+                    "type": "REF",
+                    "name": "Fridge",
+                    "appliance": appliance,
+                    "attributes": {},
+                    "settings": {},
+                }
+            }
+        )
+        entity = HonRefProgramSelect(coordinator, "ref-1", FakeClient())
+        entity.hass = FakeHass()
+
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_select_option("super_cool")
+        self.assertEqual("command_error", ctx.exception.translation_key)
+        self.assertEqual(1, new_cmd.send_calls)  # send was attempted
+        # Rollback: the swap was undone and the staged program value reverted.
+        self.assertIs(old_cmd, appliance.commands["startProgram"])
+        self.assertEqual("ORIG", swap_param.value)
+        self.assertEqual(0, coordinator.refreshes)  # no refresh on failed send
+
     async def test_invalid_option_raises(self) -> None:
         from homeassistant.exceptions import HomeAssistantError
 


### PR DESCRIPTION
Automated release PR for `v5.6.0-beta`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new fridge/cooling program selector with live program options and an off state.
  * Expanded language support for the new selector in English and Italian.
  * Updated the project header with sponsor and donation badges.

* **Bug Fixes**
  * Improved device command handling so program changes are sent reliably and reflect the latest available options.

* **Documentation**
  * Added more real-hardware examples to the supported devices list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- release-tag: v5.6.0-beta -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v5.6.0-beta release with a new fridge program selector. The main changes are:

- New REF/FR/FRE program select with immediate start and stop commands.
- Swap-aware program sending and rollback handling.
- English and Italian labels for the new select states.
- Tests for fridge program options, send behavior, and translations.
- Version, README, and sensor metadata updates.

<h3>Confidence Score: 4/5</h3>

This is close, but the fridge preset state issue should be fixed before merging.

- REF presets can still read back as `off` after a successful selection.
- The new read-back path depends on string feedback that real REF schemas may not provide.
- The send and rollback path itself looks contained.

custom_components/addhon/select.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/select.py | Adds the REF program select, but preset read-back can still fall through to `off` when refreshed feedback has no matchable string program code. |
| custom_components/addhon/program_options.py | Adds swap-aware program sending with rollback for fridge program changes. |
| tests/test_ref_program_select.py | Adds coverage for the new REF select, including options, sends, rollback, and translated state labels. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fselect.py%3A653%0A**Preset%20Still%20Reads%20Off**%0A%0AThis%20fallback%20still%20misses%20REF%20presets%20when%20the%20refreshed%20device%20state%20does%20not%20contain%20a%20string%20program%20code.%20For%20real%20REF%20schemas%20where%20%60programName%60%20is%20computed%20as%20%60No%20Program%60%2C%20%60prStr%60%20is%20absent%2C%20and%20%60prCode%60%20is%20numeric%2C%20selecting%20an%20offered%20preset%20such%20as%20%60iot_extra_cold%60%20can%20send%20successfully%20and%20refresh%2C%20but%20%60_active_program_code%28%29%60%20cannot%20match%20any%20of%20these%20fields%20back%20to%20the%20offered%20option.%20The%20entity%20then%20falls%20through%20to%20%60off%60%2C%20so%20Home%20Assistant%20can%20still%20report%20the%20preset%20as%20not%20applied%20after%20a%20successful%20selection.%0A%0A&repo=tis24dev%2Faddhon&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fselect.py%3A653%0A**Preset%20Still%20Reads%20Off**%0A%0AThis%20fallback%20still%20misses%20REF%20presets%20when%20the%20refreshed%20device%20state%20does%20not%20contain%20a%20string%20program%20code.%20For%20real%20REF%20schemas%20where%20%60programName%60%20is%20computed%20as%20%60No%20Program%60%2C%20%60prStr%60%20is%20absent%2C%20and%20%60prCode%60%20is%20numeric%2C%20selecting%20an%20offered%20preset%20such%20as%20%60iot_extra_cold%60%20can%20send%20successfully%20and%20refresh%2C%20but%20%60_active_program_code%28%29%60%20cannot%20match%20any%20of%20these%20fields%20back%20to%20the%20offered%20option.%20The%20entity%20then%20falls%20through%20to%20%60off%60%2C%20so%20Home%20Assistant%20can%20still%20report%20the%20preset%20as%20not%20applied%20after%20a%20successful%20selection.%0A%0A&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acustom_components%2Faddhon%2Fselect.py%3A653%0A**Preset%20Still%20Reads%20Off**%0A%0AThis%20fallback%20still%20misses%20REF%20presets%20when%20the%20refreshed%20device%20state%20does%20not%20contain%20a%20string%20program%20code.%20For%20real%20REF%20schemas%20where%20%60programName%60%20is%20computed%20as%20%60No%20Program%60%2C%20%60prStr%60%20is%20absent%2C%20and%20%60prCode%60%20is%20numeric%2C%20selecting%20an%20offered%20preset%20such%20as%20%60iot_extra_cold%60%20can%20send%20successfully%20and%20refresh%2C%20but%20%60_active_program_code%28%29%60%20cannot%20match%20any%20of%20these%20fields%20back%20to%20the%20offered%20option.%20The%20entity%20then%20falls%20through%20to%20%60off%60%2C%20so%20Home%20Assistant%20can%20still%20report%20the%20preset%20as%20not%20applied%20after%20a%20successful%20selection.%0A%0A&repo=tis24dev%2Faddhon&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Reflect active fridge program from cloud..."](https://github.com/tis24dev/addhon/commit/f11df49d989a7e502a95f29227865fd5fc2a675c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40494095)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->