### PR TITLE
Release v5.7.0

### DIFF
--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -177,22 +177,30 @@ AC_FAN_MAP = {
 AC_FAN_MAP_REVERSE = {v: k for k, v in AC_FAN_MAP.items()}
 
 # --- AC fan-direction position selects (discussion #37) -----------------------
-# windDirectionVertical / windDirectionHorizontal are PER-MODEL position ENUMS
-# (2,4,5,6,7 = fixed louver angles, vertical 8 = SWING/oscillation; horizontal 0 =
-# neutral). The official app collapses every fixed angle to a single "fixed" caption
-# (getVerticalFanDirectionLabel, decomp.txt:2533064-2533104; horizontal label fn
-# decomp.txt:2532971-2532976), so it cannot supply a per-angle label; we mint our own
-# STABLE per-value keys, keeping the one named semantic the app exposes: vertical 8 =
-# swing (decomp.txt:2533095). These are LABEL maps ONLY (raw firmware value -> machine
-# key for the select state translations); the LEGAL value set is ALWAYS read live from
-# the per-model enum, never hard-coded (AS68PDAHRA vertical=[2,4,5,6,7,8] but
-# AS35RBAHRA-3=[2,4,5,6,8] -- no 7; AS68PDAHRA horizontal is typology=fixed [0] = no
-# control). The maps are a SUPERSET: only keys whose raw value is in the live enum
-# become options, and a live value absent from the map falls back to its raw number
-# (forward-safe, mirrors HonProgramOptionSelect). Values 1/3 (HEALTH_AIR_FLOW,
-# decomp.txt:2533101) are intentionally absent: not in the vertical setter enum on any
-# observed model. Vertical and horizontal use SEPARATE translation_keys so the
-# overlapping numbers 4/5/6/7 live in disjoint state blocks and never collide.
+# windDirectionVertical / windDirectionHorizontal are PER-MODEL position ENUMS. The two
+# axes are SYMMETRIC: each is a set of fixed louver positions plus exactly ONE oscillation
+# value. The app's own label fns (verified against the decompiled control flow):
+#   VERTICAL  (getVerticalFanDirectionLabel, decomp.txt:2533064-2533104):
+#       8         -> VERTICAL_SWING ; 2,4,5,6,7 -> VERTICAL_FIXED (angles)
+#       1,3       -> HEALTH_AIR_FLOW (not in the setter enum on any observed model)
+#   HORIZONTAL (getHorizontalFanDirectionLabel, decomp.txt:2532971-2532976):
+#       7         -> HORIZONTAL_SWING ; any other (0,3,4,5,6) -> HORIZONTAL_FIXED
+# So the single swing value is 8 on the vertical axis and 7 on the horizontal axis; every
+# OTHER value is a fixed position. (decomp control flow: horizontal pre-loads FIXED and
+# only the val===7 fall-through assigns SWING; default/stopProgram horizontal = 0 = a
+# fixed neutral position, i.e. NOT swinging.) The app collapses every fixed angle to a
+# single "fixed" caption and cannot supply per-angle labels, so we mint our own STABLE
+# per-value keys, keeping the one named semantic the app exposes per axis (the swing
+# value). These are LABEL maps ONLY (raw firmware value -> machine key for the select
+# state translations); the LEGAL value set is ALWAYS read live from the per-model enum,
+# never hard-coded (AS68PDAHRA vertical=[2,4,5,6,7,8] but AS35RBAHRA-3=[2,4,5,6,8] -- no 7;
+# AS68PDAHRA horizontal is typology=fixed [0] = no control). The maps are a SUPERSET: only
+# keys whose raw value is in the live enum become options, and a live value absent from the
+# map falls back to its raw number (forward-safe, mirrors HonProgramOptionSelect; firmware
+# may also report a horizontal value outside the setter enum, e.g. 2 @decomp shadow
+# fixture, which then reads as unknown rather than a false map). Vertical and horizontal use
+# SEPARATE translation_keys so the overlapping numbers 4/5/6/7 -- and each axis' own "swing"
+# key -- live in disjoint state blocks and never collide.
 FAN_DIR_V_LABELS = {
     "2": "position_2",
     "4": "position_4",
@@ -207,7 +215,7 @@ FAN_DIR_H_LABELS = {
     "4": "position_4",
     "5": "position_5",
     "6": "position_6",
-    "7": "position_7",
+    "7": "swing",
 }
 
 # --- Washing machine attributes -----------------------------------------------

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -176,6 +176,40 @@ AC_FAN_MAP = {
 }
 AC_FAN_MAP_REVERSE = {v: k for k, v in AC_FAN_MAP.items()}
 
+# --- AC fan-direction position selects (discussion #37) -----------------------
+# windDirectionVertical / windDirectionHorizontal are PER-MODEL position ENUMS
+# (2,4,5,6,7 = fixed louver angles, vertical 8 = SWING/oscillation; horizontal 0 =
+# neutral). The official app collapses every fixed angle to a single "fixed" caption
+# (getVerticalFanDirectionLabel, decomp.txt:2533064-2533104; horizontal label fn
+# decomp.txt:2532971-2532976), so it cannot supply a per-angle label; we mint our own
+# STABLE per-value keys, keeping the one named semantic the app exposes: vertical 8 =
+# swing (decomp.txt:2533095). These are LABEL maps ONLY (raw firmware value -> machine
+# key for the select state translations); the LEGAL value set is ALWAYS read live from
+# the per-model enum, never hard-coded (AS68PDAHRA vertical=[2,4,5,6,7,8] but
+# AS35RBAHRA-3=[2,4,5,6,8] -- no 7; AS68PDAHRA horizontal is typology=fixed [0] = no
+# control). The maps are a SUPERSET: only keys whose raw value is in the live enum
+# become options, and a live value absent from the map falls back to its raw number
+# (forward-safe, mirrors HonProgramOptionSelect). Values 1/3 (HEALTH_AIR_FLOW,
+# decomp.txt:2533101) are intentionally absent: not in the vertical setter enum on any
+# observed model. Vertical and horizontal use SEPARATE translation_keys so the
+# overlapping numbers 4/5/6/7 live in disjoint state blocks and never collide.
+FAN_DIR_V_LABELS = {
+    "2": "position_2",
+    "4": "position_4",
+    "5": "position_5",
+    "6": "position_6",
+    "7": "position_7",
+    "8": "swing",
+}
+FAN_DIR_H_LABELS = {
+    "0": "position_0",
+    "3": "position_3",
+    "4": "position_4",
+    "5": "position_5",
+    "6": "position_6",
+    "7": "position_7",
+}
+
 # --- Washing machine attributes -----------------------------------------------
 # Confirmed from the diagnostics of the HW80-B14959TU1IT device
 WM_ATTR_STATUS        = "machMode"

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.6.0-beta"
+  "version": "5.7.0"
 }

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -862,11 +862,20 @@ class HonAcDirectionSelect(HonBaseEntity, SelectEntity):
         param = settings_param(self._appliance, description.param)
         # Offer the LIVE per-model enum values, mapped to stable option keys (raw number
         # as a forward-safe fallback for an unmapped value); order follows the device
-        # enum. param_allowed_values([]/None) yields {} (gated-out params never reach
-        # here). Mirrors HonProgramOptionSelect.
-        self._raw_to_key: dict[str, str] = {
-            raw: label_map.get(raw, raw) for raw in param_allowed_values(param)
-        }
+        # enum. Each raw value is NORMALIZED to its canonical code (normalize_code:
+        # "5.0"/"5,0" -> "5") BEFORE it becomes a map key, so the stored key, the label
+        # lookup and the value we send share the SAME canonical form current_option()
+        # looks up with -- otherwise an enum advertised non-canonically (e.g. "13.0")
+        # would build a key the normalized read-back never matches and would surface as
+        # unknown. For the real per-model enums (clean small integers) this is a no-op.
+        # param_allowed_values([]/None) yields [] (gated-out params never reach here).
+        # Mirrors HonProgramOptionSelect / option_value_set, which already normalize.
+        self._raw_to_key: dict[str, str] = {}
+        for raw in param_allowed_values(param):
+            code = normalize_code(raw)
+            if code is None:
+                continue
+            self._raw_to_key[code] = label_map.get(code, code)
         self._key_to_raw: dict[str, str] = {
             key: raw for raw, key in self._raw_to_key.items()
         }

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -543,10 +543,12 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
     (capability-gated, never hard-coded). Unlike the washer select, selecting here sends
     IMMEDIATELY (no buffer/Start-button cycle): a program -> ``startProgram(program=X)``,
     ``off`` -> ``stopProgram``. ``current_option`` is derived from REAL device feedback:
-    first the live mode FLAGS (boost modes), then the cloud-persisted active-program field
-    ``programName``/``prStr``/``prCode`` (covers the iot_* presets, which set no flag) -
-    never optimistic state and never ``startProgram.program`` (the recovered default
-    category, which would otherwise pin a phantom mode forever)."""
+    first the live mode FLAGS (boost modes), then the cloud-persisted active-program
+    field ``programName``/``prStr``/``prCode`` - never optimistic state and never
+    ``startProgram.program`` (the recovered default category, which would otherwise pin
+    a phantom mode forever). An active iot_* preset (which sets no flag) is NOT observable
+    on the current engine -- the REF shadow carries no program-identity field for it --
+    so it correctly falls back to ``off`` (see ``_active_program_code``)."""
 
     _attr_icon = "mdi:snowflake"
 
@@ -615,8 +617,24 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
         return bool(HonProgramSelect._program_values(command, param_name))
 
     # Shadow attributes carrying the ACTIVE program identity (cloud-persisted: what the
-    # official app reads to show the running program, e.g. after an app reinstall). NOT
-    # startProgram.program, which is only the recovered default category.
+    # official app reads to show the running program, e.g. after an app reinstall),
+    # matched double-gated against the offered codes. NOT startProgram.program (only the
+    # recovered default category).
+    #
+    # Deliberately EXCLUDES the per-zone modeZ1/modeZ2: those are ENGINE-SYNTHETIC
+    # (client/engine/appliances/ref.py rewrites them from the boost flags by VALUE), so
+    # they only ever read holiday/auto_set/super_cool/super_freeze/"no_mode". Every offered
+    # value they could carry is already resolved by the FLAG path above, "no_mode" is not
+    # an offered code, and the engine clobbers any raw modeZ before the select sees it --
+    # so reading them here is strictly dead and cannot surface a program.
+    #
+    # GAP (blocked on a real iot_*-active dump): an active iot_* download preset sets no
+    # flag and, on the REF model we have evidence for (roberglezz, HCW58F18EWMP), leaves
+    # NO program-identity field in the raw shadow (no prCode/prStr/programName; activity
+    # ={}). Its only footprint is the tempSel setpoint triple, which is user-settable and
+    # therefore not identity-safe. We never guess from setpoints, so an active iot_*
+    # correctly reads off. programName/prStr/prCode stay as the forward-correct handler
+    # for any REF model that DOES expose a raw program-identity key.
     _REF_ACTIVE_PROGRAM_ATTRS = ("programName", "prStr", "prCode")
 
     @property
@@ -630,9 +648,10 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
                     redact_id(self._appliance_id), flag, code,
                 )
                 return code
-        # 2) Any other active program (e.g. the iot_* download presets, which set no
-        #    flag) from the cloud-persisted programName/prStr/prCode. Real device
-        #    feedback, NOT optimistic "remember what was clicked" state.
+        # 2) Any other active program surfaced via the cloud-persisted programName/prStr/
+        #    prCode. Real device feedback, NOT optimistic "remember what was clicked"
+        #    state. (An active iot_* preset is not observable here on the current engine --
+        #    see _REF_ACTIVE_PROGRAM_ATTRS -- so it falls through to off below.)
         matched = self._active_program_code()
         if matched is not None:
             return matched
@@ -645,9 +664,10 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
         programName/prStr ship as i18n keys (e.g. ``PROGRAMS.REF.IOT_EXTRA_COLD``), so we
         compare both the whole token and its last dotted segment, case-insensitively, and
         accept ONLY an exact match against an offered code (no fuzzy/substring match, to
-        never report the wrong program). This is what reflects the iot_* presets, which
-        set no mode flag. ``startProgram.program`` is deliberately NOT consulted (it is the
-        recovered default category, not the running program)."""
+        never report the wrong program). The idle sentinels ("No Program", "") are not
+        offered codes, so the double-gate rejects them. ``startProgram.program`` is
+        deliberately NOT consulted (it is the recovered default category, not the running
+        program)."""
         by_lower = {code.lower(): code for code in self._program_codes}
         for attr in self._REF_ACTIVE_PROGRAM_ATTRS:
             raw = self._get_attr(attr)

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -546,9 +546,10 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
     first the live mode FLAGS (boost modes), then the cloud-persisted active-program
     field ``programName``/``prStr``/``prCode`` - never optimistic state and never
     ``startProgram.program`` (the recovered default category, which would otherwise pin
-    a phantom mode forever). An active iot_* preset (which sets no flag) is NOT observable
-    on the current engine -- the REF shadow carries no program-identity field for it --
-    so it correctly falls back to ``off`` (see ``_active_program_code``)."""
+    a phantom mode forever). An active iot_* preset (which sets no flag) is NOT recoverable
+    from the cloud shadow -- it leaves no program-identity field, and the official app only
+    tracks it client-side -- so it correctly falls back to ``off`` (see
+    ``_active_program_code``)."""
 
     _attr_icon = "mdi:snowflake"
 
@@ -628,13 +629,20 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
     # an offered code, and the engine clobbers any raw modeZ before the select sees it --
     # so reading them here is strictly dead and cannot surface a program.
     #
-    # GAP (blocked on a real iot_*-active dump): an active iot_* download preset sets no
-    # flag and, on the REF model we have evidence for (roberglezz, HCW58F18EWMP), leaves
-    # NO program-identity field in the raw shadow (no prCode/prStr/programName; activity
-    # ={}). Its only footprint is the tempSel setpoint triple, which is user-settable and
-    # therefore not identity-safe. We never guess from setpoints, so an active iot_*
-    # correctly reads off. programName/prStr/prCode stay as the forward-correct handler
-    # for any REF model that DOES expose a raw program-identity key.
+    # iot_* DOWNLOAD PRESETS ARE NOT SHADOW-OBSERVABLE (proven, not merely dump-blocked):
+    # an active iot_* download preset sets no flag and leaves NO program-identity field in
+    # the raw cloud shadow (no prCode/prStr/prPhase/machMode/programName; activity={}),
+    # confirmed on BOTH observed REF models (HDPW5620CNPK, HCW58F18EWMP). The official hOn
+    # app does not recover it from the shadow either: it reads no shadow identity field and
+    # runs no setpoint reverse-match, and instead shows the running preset only as a
+    # CLIENT-LOCAL "Last used" label kept in React Native AsyncStorage (@quickSet, its own
+    # last send) -- a device-local memory we cannot and should not reconstruct from the
+    # cloud. Its only shadow footprint is the tempSel setpoint triple, which is
+    # user-settable (not identity-safe) and ambiguous (preset setpoints collide); we never
+    # guess from setpoints. So "off" is the PERMANENTLY-correct current_option for download
+    # presets; programName/prStr/prCode stay only as the forward-correct handler for any
+    # future REF model that DOES expose a real program-identity key. Evidence trail:
+    # apk/analysis/deep/ref-active-program-detection.md (+ refrigeration.md section 6).
     _REF_ACTIVE_PROGRAM_ATTRS = ("programName", "prStr", "prCode")
 
     @property

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -147,9 +147,11 @@ class HonAcDirectionSelectDescription:
 
 
 # Candidate AC fan-direction selects, capability-gated per device by
-# _supports_direction_select on the LIVE settings enum. Vertical value 8 = swing,
-# which coexists by design with the climate swing_mode (on/off) entity (both write the
-# SAME windDirectionVertical param).
+# _supports_direction_select on the LIVE settings enum. The two axes are SYMMETRIC (see
+# FAN_DIR_*_LABELS): each exposes fixed louver positions plus exactly one swing value --
+# value 8 on the vertical axis, value 7 on the horizontal axis. The vertical 8=swing
+# coexists by design with the climate swing_mode (on/off) entity (both write the SAME
+# windDirectionVertical param).
 _AC_DIRECTION_SELECTS: tuple[HonAcDirectionSelectDescription, ...] = (
     HonAcDirectionSelectDescription(
         key="fan_direction_vertical",

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -12,6 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_entity import HonBaseEntity
 from .const import (
+    AC_ATTR_SWING_H,
+    AC_ATTR_SWING_V,
+    AC_SWING_H_PARAM,
+    AC_SWING_V_PARAM,
+    APPLIANCE_AC,
     APPLIANCE_FR,
     APPLIANCE_FRE,
     APPLIANCE_REF,
@@ -24,6 +29,8 @@ from .const import (
     DRY_LEVEL_LABELS_TD,
     DRY_LEVEL_LABELS_WM,
     DRY_LEVEL_SENTINELS,
+    FAN_DIR_H_LABELS,
+    FAN_DIR_V_LABELS,
     PROGRAM_PARAM_NAMES,
     PROGRAM_PENDING_OPTIONS,
     PROGRAM_PENDING_STORE,
@@ -32,6 +39,7 @@ from .const import (
 )
 from .debug_utils import redact_id, redact_store
 from .hon_commands import async_send_command
+from .ac_command import async_send_settings, param_allowed_values, settings_param
 from .program_options import (
     HonProgramOptionEntity,
     async_send_program,
@@ -118,6 +126,66 @@ _PROGRAM_OPTION_SELECTS: tuple[HonProgramOptionSelectDescription, ...] = (
     ),
 )
 
+@dataclass(frozen=True, kw_only=True)
+class HonAcDirectionSelectDescription:
+    """A manual AC fan-direction (louver position) select (#37).
+
+    ``param`` is the settings-command parameter to WRITE (windDirectionVertical /
+    windDirectionHorizontal); ``attr`` is the dotted READ path of the live value;
+    ``label_map`` is the SUPERSET raw-value -> option-key map (offered options are the
+    live per-model enum mapped through it, with the raw number as a forward-safe
+    fallback for an unmapped value). Vertical and horizontal carry distinct
+    translation_keys so their overlapping numbers never collide.
+    """
+
+    key: str
+    param: str
+    attr: str
+    translation_key: str
+    label_map: dict[str, str]
+    icon: str
+
+
+# Candidate AC fan-direction selects, capability-gated per device by
+# _supports_direction_select on the LIVE settings enum. Vertical value 8 = swing,
+# which coexists by design with the climate swing_mode (on/off) entity (both write the
+# SAME windDirectionVertical param).
+_AC_DIRECTION_SELECTS: tuple[HonAcDirectionSelectDescription, ...] = (
+    HonAcDirectionSelectDescription(
+        key="fan_direction_vertical",
+        param=AC_SWING_V_PARAM,
+        attr=AC_ATTR_SWING_V,
+        translation_key="fan_direction_vertical",
+        label_map=FAN_DIR_V_LABELS,
+        icon="mdi:arrow-up-down",
+    ),
+    HonAcDirectionSelectDescription(
+        key="fan_direction_horizontal",
+        param=AC_SWING_H_PARAM,
+        attr=AC_ATTR_SWING_H,
+        translation_key="fan_direction_horizontal",
+        label_map=FAN_DIR_H_LABELS,
+        icon="mdi:arrow-left-right",
+    ),
+)
+
+
+def _supports_direction_select(param) -> bool:
+    """True iff ``param`` is a real, adjustable position control.
+
+    A manual fan-direction control exists only when the settings param is a WRITABLE
+    enum with more than one option. The fixed-typology trap is excluded explicitly
+    (AS68PDAHRA horizontal: typology=fixed, enum=[0]) so a non-adjustable louver is
+    never surfaced; the >1 guard also drops a degenerate single-value enum. The enum
+    itself is always read live (param_allowed_values), never hard-coded.
+    """
+    if param is None:
+        return False
+    if getattr(param, "typology", "") == "fixed":
+        return False
+    return len(param_allowed_values(param)) > 1
+
+
 # "Safe" commands (they do not start a cycle) to read/write the program from.
 PROGRAM_SELECT_COMMANDS = ("settings", "setProgram", "setProgramme", "programSettings")
 # Commands to DRAW the program list from. We also include startProgram as a
@@ -169,6 +237,33 @@ async def async_setup_entry(
                     "needs startProgram(program enum) + stopProgram",
                     data.get("name"),
                     redact_id(appliance_id),
+                )
+            continue
+        if app_type == APPLIANCE_AC:
+            # Manual fan-direction position selects (#37), capability-gated on the
+            # live per-model settings enum (vertical and/or horizontal independently).
+            # AC falls through here today with no select; the climate swing_mode
+            # (on/off) entity is intentionally left untouched (coexistence by design).
+            created_dirs: list[str] = []
+            for desc in _AC_DIRECTION_SELECTS:
+                if not _supports_direction_select(settings_param(appliance, desc.param)):
+                    continue
+                entities.append(
+                    HonAcDirectionSelect(coordinator, appliance_id, desc, client)
+                )
+                created_dirs.append(desc.key)
+            if created_dirs:
+                _LOGGER.info(
+                    "Added %d AC fan-direction selects: id=%s -> %s",
+                    len(created_dirs),
+                    redact_id(appliance_id),
+                    created_dirs,
+                )
+            else:
+                _LOGGER.debug(
+                    "Select debug: no AC fan-direction selects for id=%s type=%s",
+                    redact_id(appliance_id),
+                    app_type,
                 )
             continue
         if app_type not in APPLIANCE_WASH_GROUP:
@@ -731,3 +826,104 @@ class HonRefProgramSelect(HonBaseEntity, SelectEntity):
                 translation_placeholders={"error": str(err)},
             ) from err
         await self._async_request_command_refresh()
+
+
+class HonAcDirectionSelect(HonBaseEntity, SelectEntity):
+    """Manual fan-direction (louver position) select for air conditioners (#37).
+
+    One entity per axis (vertical / horizontal). Options come from the device's LIVE
+    per-model settings enum (windDirectionVertical / windDirectionHorizontal), never
+    hard-coded, mapped to stable bilingual option keys. Selecting sends IMMEDIATELY
+    through ac_command.async_send_settings -- the SAME sanitizer-guarded path the
+    climate swing uses -- so a requested position survives the windDirection sanitizer
+    (it is applied AFTER the pre_send hook and therefore wins). current_option maps the
+    live reading to an offered key and returns None when the firmware reports a value
+    outside the offered enum (e.g. 0 when off, or a value the setter enum excludes): HA
+    shows unknown, never a false map, never a raise. Coexists by design with the climate
+    swing_mode (on/off) entity: both it and this vertical select write
+    windDirectionVertical (value 8 = swing).
+    """
+
+    def __init__(
+        self,
+        coordinator,
+        appliance_id: str,
+        description: HonAcDirectionSelectDescription,
+        client=None,
+    ) -> None:
+        super().__init__(coordinator, appliance_id, client)
+        self._desc = description
+        self._attr_translation_key = description.translation_key
+        self._attr_unique_id = f"{appliance_id}_{description.key}"
+        self._attr_icon = description.icon
+        label_map = description.label_map
+        param = settings_param(self._appliance, description.param)
+        # Offer the LIVE per-model enum values, mapped to stable option keys (raw number
+        # as a forward-safe fallback for an unmapped value); order follows the device
+        # enum. param_allowed_values([]/None) yields {} (gated-out params never reach
+        # here). Mirrors HonProgramOptionSelect.
+        self._raw_to_key: dict[str, str] = {
+            raw: label_map.get(raw, raw) for raw in param_allowed_values(param)
+        }
+        self._key_to_raw: dict[str, str] = {
+            key: raw for raw, key in self._raw_to_key.items()
+        }
+        self._attr_options = list(self._raw_to_key.values())
+        _LOGGER.debug(
+            "Select debug: init AC direction select '%s' id=%s param=%s options=%s",
+            redact_id(self._attr_unique_id, appliance_id),
+            redact_id(appliance_id),
+            description.param,
+            self._attr_options,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        # Map the LIVE windDirection value to an offered key. Out-of-enum reads (0 when
+        # off, or e.g. horizontal 2 outside the setter enum) -> None: never raise, never
+        # false-map.
+        raw = self._get_attr(self._desc.attr)
+        if raw is None:
+            return None
+        return self._raw_to_key.get(normalize_code(raw))
+
+    async def async_select_option(self, option: str) -> None:
+        raw = self._key_to_raw.get(option)
+        if raw is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_setpoint",
+                translation_placeholders={
+                    "value": option,
+                    "allowed": ", ".join(self._attr_options),
+                },
+            )
+        appliance = self._appliance
+        client = self._hon_client
+        if not appliance or not client:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="appliance_or_client_unavailable",
+            )
+        try:
+            _LOGGER.info(
+                "Select: AC %s -> %s=%s id=%s",
+                self._desc.key,
+                self._desc.param,
+                raw,
+                redact_id(self._appliance_id),
+            )
+            await async_send_settings(self.hass, client, appliance, {self._desc.param: raw})
+            await self._async_request_command_refresh()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            _LOGGER.error(
+                "Select: AC %s set error %s=%s: %s",
+                self._desc.key, self._desc.param, raw, err, exc_info=True,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -763,6 +763,28 @@
           "delicate": "Delicate",
           "synthetic": "Synthetic"
         }
+      },
+      "fan_direction_vertical": {
+        "name": "Vertical fan direction",
+        "state": {
+          "position_2": "Position 2",
+          "position_4": "Position 4",
+          "position_5": "Position 5",
+          "position_6": "Position 6",
+          "position_7": "Position 7",
+          "swing": "Swing"
+        }
+      },
+      "fan_direction_horizontal": {
+        "name": "Horizontal fan direction",
+        "state": {
+          "position_0": "Position 0",
+          "position_3": "Position 3",
+          "position_4": "Position 4",
+          "position_5": "Position 5",
+          "position_6": "Position 6",
+          "position_7": "Position 7"
+        }
       }
     },
     "button": {

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -783,7 +783,7 @@
           "position_4": "Position 4",
           "position_5": "Position 5",
           "position_6": "Position 6",
-          "position_7": "Position 7"
+          "swing": "Swing"
         }
       }
     },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -763,6 +763,28 @@
           "delicate": "Delicati",
           "synthetic": "Sintetici"
         }
+      },
+      "fan_direction_vertical": {
+        "name": "Direzione aria verticale",
+        "state": {
+          "position_2": "Posizione 2",
+          "position_4": "Posizione 4",
+          "position_5": "Posizione 5",
+          "position_6": "Posizione 6",
+          "position_7": "Posizione 7",
+          "swing": "Oscillazione"
+        }
+      },
+      "fan_direction_horizontal": {
+        "name": "Direzione aria orizzontale",
+        "state": {
+          "position_0": "Posizione 0",
+          "position_3": "Posizione 3",
+          "position_4": "Posizione 4",
+          "position_5": "Posizione 5",
+          "position_6": "Posizione 6",
+          "position_7": "Posizione 7"
+        }
       }
     },
     "button": {

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -783,7 +783,7 @@
           "position_4": "Posizione 4",
           "position_5": "Posizione 5",
           "position_6": "Posizione 6",
-          "position_7": "Posizione 7"
+          "swing": "Oscillazione"
         }
       }
     },

--- a/tests/test_ac_fan_direction_select.py
+++ b/tests/test_ac_fan_direction_select.py
@@ -226,6 +226,21 @@ class AcFanDirectionSelectTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsNone(self._by_key(added, "fan_direction_vertical").current_option)
 
+    async def test_non_canonical_enum_value_normalized(self) -> None:
+        # A device advertising a non-canonical enum value ("5.0") must still build the
+        # clean option key, read back through current_option, and carry the canonical
+        # code as the send value -- the option map is normalized in __init__ so it stays
+        # symmetric with current_option()'s normalize_code lookup (CodeRabbit, PR #42).
+        added, _, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5.0", values=["2", "4", "5.0", "6", "8"])},
+            attributes={"settings.windDirectionVertical": "5.0"},
+        )
+        v = self._by_key(added, "fan_direction_vertical")
+        self.assertIn("position_5", v._attr_options)
+        self.assertNotIn("5.0", v._attr_options)
+        self.assertEqual("position_5", v.current_option)
+        self.assertEqual("5", v._key_to_raw["position_5"])
+
     async def test_select_sends_setparameters(self) -> None:
         added, settings, coord = await self._setup(
             {

--- a/tests/test_ac_fan_direction_select.py
+++ b/tests/test_ac_fan_direction_select.py
@@ -1,0 +1,298 @@
+"""Tests for the AC manual fan-direction position selects (discussion #37).
+
+Two capability-gated selects per AC -- vertical + horizontal louver position --
+whose options come from the device's LIVE per-model enum (never hard-coded), which
+send immediately through ac_command.async_send_settings (so a requested position
+survives the windDirection sanitizer), and whose current_option maps the reported
+value (None when out-of-enum, never raising). Ground truth:
+apk/dump/ac_mik/config_entry_diag.json (AS68PDAHRA / AS35RBAHRA-3 / AS35PBPHRA-PRE)
+cross-validated by apk/dump/ac_roberto (AS35PBPHRA-PRE, H actively 5).
+
+Drives the real async_setup_entry end-to-end (gating + registration), reusing the HA
+stubs + Fake* harness from test_program_select (importing it installs the stubs at
+module load). A local DirParam adds `typology` (the shared Param lacks it) and a local
+RecordingCommand captures the sent payload. Golden enums/keys are hard-coded (NOT
+imported from const) so a const mutation cannot pass unnoticed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from test_program_select import (  # noqa: E402
+    FakeClient,
+    FakeCoordinator,
+    FakeEntry,
+    FakeHass,
+    _ac,
+)
+
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.addhon import select  # noqa: E402
+from custom_components.addhon.const import DOMAIN  # noqa: E402
+
+
+class DirParam:
+    """settings enum/fixed param stub: value + values + typology (the shared Param has
+    no typology, which the fixed-typology gate needs)."""
+
+    def __init__(self, value=None, values=None, typology="enum") -> None:
+        self.value = value
+        self.values = values
+        self.typology = typology
+
+
+class RecordingCommand:
+    """Captures the payload frozen at send() time (what reaches the device)."""
+
+    def __init__(self, parameters=None) -> None:
+        self.parameters = parameters or {}
+        self.send_calls = 0
+        self.sent = None
+
+    async def send(self) -> None:
+        self.send_calls += 1
+        self.sent = {k: p.value for k, p in self.parameters.items()}
+
+
+# Golden per-model enums (apk/dump/ac_mik + ac_roberto), NOT imported from const.
+V_FULL = ["2", "4", "5", "6", "7", "8"]      # AS68PDAHRA / AS35PBPHRA-PRE
+V_NO_7 = ["2", "4", "5", "6", "8"]           # AS35RBAHRA-3 (no 7)
+H_ENUM = ["0", "3", "4", "5", "6", "7"]      # AS35RBAHRA-3 / AS35PBPHRA-PRE
+H_FIXED = ["0"]                              # AS68PDAHRA (typology=fixed)
+
+
+class AcFanDirectionSelectTest(unittest.IsolatedAsyncioTestCase):
+    async def _setup(self, settings_params, attributes=None):
+        settings = RecordingCommand(settings_params)
+        coordinator = FakeCoordinator(_ac({"settings": settings}, attributes))
+        hass = FakeHass(
+            {DOMAIN: {"entry-1": {"coordinator": coordinator, "client": FakeClient()}}}
+        )
+        added: list = []
+        await select.async_setup_entry(hass, FakeEntry(), added.extend)
+        for entity in added:
+            entity.hass = hass
+        return added, settings, coordinator
+
+    @staticmethod
+    def _maybe(added, translation_key):
+        for entity in added:
+            if getattr(entity, "_attr_translation_key", None) == translation_key:
+                return entity
+        return None
+
+    def _by_key(self, added, translation_key):
+        entity = self._maybe(added, translation_key)
+        self.assertIsNotNone(entity, f"missing select {translation_key}")
+        return entity
+
+    async def test_vertical_options_from_live_enum(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("3", values=H_ENUM),
+            }
+        )
+        v = self._by_key(added, "fan_direction_vertical")
+        self.assertEqual(
+            ["position_2", "position_4", "position_5", "position_6", "position_7", "swing"],
+            v._attr_options,
+        )
+
+    async def test_vertical_per_model_no_7(self) -> None:
+        added, _, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5", values=V_NO_7)}
+        )
+        v = self._by_key(added, "fan_direction_vertical")
+        self.assertEqual(
+            ["position_2", "position_4", "position_5", "position_6", "swing"],
+            v._attr_options,
+        )
+        self.assertNotIn("position_7", v._attr_options)
+
+    async def test_horizontal_options_from_live_enum(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("5", values=H_ENUM),
+            }
+        )
+        h = self._by_key(added, "fan_direction_horizontal")
+        self.assertEqual(
+            ["position_0", "position_3", "position_4", "position_5", "position_6", "position_7"],
+            h._attr_options,
+        )
+        self.assertNotIn("swing", h._attr_options)
+
+    async def test_both_created_for_enum_model(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=H_ENUM),
+            }
+        )
+        self.assertEqual(
+            {"fan_direction_vertical", "fan_direction_horizontal"},
+            {e._attr_translation_key for e in added},
+        )
+
+    async def test_horizontal_gated_out_on_fixed_typology(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("6", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=H_FIXED, typology="fixed"),
+            }
+        )
+        self.assertIsNone(self._maybe(added, "fan_direction_horizontal"))
+        self.assertIsNotNone(self._maybe(added, "fan_direction_vertical"))
+
+    async def test_fixed_typology_gates_independent_of_count(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("6", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=["0", "3", "4"], typology="fixed"),
+            }
+        )
+        self.assertIsNone(self._maybe(added, "fan_direction_horizontal"))
+
+    async def test_single_value_enum_gated_out(self) -> None:
+        added, _, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5", values=["5"])}
+        )
+        self.assertEqual([], added)
+
+    async def test_no_selects_when_params_absent(self) -> None:
+        added, _, _ = await self._setup({"onOffStatus": DirParam("0", values=["0", "1"])})
+        self.assertEqual([], added)
+
+    async def test_current_option_maps_live_value(self) -> None:
+        added, _, _ = await self._setup(
+            {"windDirectionHorizontal": DirParam("5", values=H_ENUM)},
+            attributes={"settings.windDirectionHorizontal": "5"},
+        )
+        self.assertEqual(
+            "position_5", self._by_key(added, "fan_direction_horizontal").current_option
+        )
+
+    async def test_current_option_swing(self) -> None:
+        added, _, _ = await self._setup(
+            {"windDirectionVertical": DirParam("8", values=V_FULL)},
+            attributes={"settings.windDirectionVertical": "8"},
+        )
+        self.assertEqual(
+            "swing", self._by_key(added, "fan_direction_vertical").current_option
+        )
+
+    async def test_current_option_none_when_out_of_enum(self) -> None:
+        added, _, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("0", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=H_ENUM),
+            },
+            attributes={
+                "settings.windDirectionVertical": "0",
+                "settings.windDirectionHorizontal": "2",
+            },
+        )
+        self.assertIsNone(self._by_key(added, "fan_direction_vertical").current_option)
+        self.assertIsNone(self._by_key(added, "fan_direction_horizontal").current_option)
+
+    async def test_current_option_none_when_absent(self) -> None:
+        added, _, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5", values=V_FULL)}
+        )
+        self.assertIsNone(self._by_key(added, "fan_direction_vertical").current_option)
+
+    async def test_select_sends_setparameters(self) -> None:
+        added, settings, coord = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("3", values=H_ENUM),
+            }
+        )
+        await self._by_key(added, "fan_direction_vertical").async_select_option("position_6")
+        self.assertEqual("6", settings.sent["windDirectionVertical"])
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_select_swing_sends_8(self) -> None:
+        added, settings, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5", values=V_FULL)}
+        )
+        await self._by_key(added, "fan_direction_vertical").async_select_option("swing")
+        self.assertEqual("8", settings.sent["windDirectionVertical"])
+
+    async def test_select_horizontal_sends(self) -> None:
+        added, settings, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=H_ENUM),
+            }
+        )
+        await self._by_key(added, "fan_direction_horizontal").async_select_option("position_5")
+        self.assertEqual("5", settings.sent["windDirectionHorizontal"])
+
+    async def test_requested_position_wins_over_sanitizer(self) -> None:
+        added, settings, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("0", values=V_FULL),
+                "windDirectionHorizontal": DirParam("9", values=H_ENUM),
+            }
+        )
+        await self._by_key(added, "fan_direction_vertical").async_select_option("position_6")
+        self.assertEqual("6", settings.sent["windDirectionVertical"])
+        self.assertEqual("3", settings.sent["windDirectionHorizontal"])
+
+    async def test_invalid_option_raises_without_send(self) -> None:
+        added, settings, _ = await self._setup(
+            {"windDirectionVertical": DirParam("5", values=V_FULL)}
+        )
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await self._by_key(added, "fan_direction_vertical").async_select_option("nope")
+        self.assertEqual("invalid_setpoint", getattr(ctx.exception, "translation_key", None))
+        self.assertEqual(0, settings.send_calls)
+        self.assertIsNone(settings.sent)
+
+
+class AcFanDirectionI18nTest(unittest.TestCase):
+    """Every offered option key must be translated in BOTH en.json and it.json, with
+    identical state-key sets (project rule addhon-i18n-eng-ita; no strings.json)."""
+
+    def _select(self, lang):
+        base = REPO_ROOT / "custom_components" / "addhon" / "translations"
+        return json.loads((base / f"{lang}.json").read_text(encoding="utf-8"))["entity"]["select"]
+
+    def test_completeness_and_parity(self) -> None:
+        from custom_components.addhon.const import FAN_DIR_H_LABELS, FAN_DIR_V_LABELS
+
+        en = self._select("en")
+        it = self._select("it")
+        for key, label_map in (
+            ("fan_direction_vertical", FAN_DIR_V_LABELS),
+            ("fan_direction_horizontal", FAN_DIR_H_LABELS),
+        ):
+            self.assertIn("name", en[key])
+            self.assertIn("name", it[key])
+            en_state = set(en[key]["state"])
+            it_state = set(it[key]["state"])
+            for opt_key in label_map.values():
+                self.assertIn(opt_key, en_state, f"en missing {key}.{opt_key}")
+                self.assertIn(opt_key, it_state, f"it missing {key}.{opt_key}")
+            self.assertEqual(en_state, it_state, f"en/it parity {key}")
+
+    def test_swing_only_on_vertical(self) -> None:
+        en = self._select("en")
+        self.assertIn("swing", en["fan_direction_vertical"]["state"])
+        self.assertNotIn("swing", en["fan_direction_horizontal"]["state"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ac_fan_direction_select.py
+++ b/tests/test_ac_fan_direction_select.py
@@ -126,11 +126,15 @@ class AcFanDirectionSelectTest(unittest.IsolatedAsyncioTestCase):
             }
         )
         h = self._by_key(added, "fan_direction_horizontal")
+        # Horizontal mirrors vertical: fixed positions (0,3,4,5,6) plus exactly one swing
+        # value, which on the horizontal axis is 7 (FAN_DIR_H_LABELS); order follows the
+        # device enum, so "swing" (7) lands last.
         self.assertEqual(
-            ["position_0", "position_3", "position_4", "position_5", "position_6", "position_7"],
+            ["position_0", "position_3", "position_4", "position_5", "position_6", "swing"],
             h._attr_options,
         )
-        self.assertNotIn("swing", h._attr_options)
+        self.assertNotIn("position_7", h._attr_options)   # 7 is swing, not a position
+        self.assertIn("swing", h._attr_options)
 
     async def test_both_created_for_enum_model(self) -> None:
         added, _, _ = await self._setup(
@@ -178,8 +182,19 @@ class AcFanDirectionSelectTest(unittest.IsolatedAsyncioTestCase):
             {"windDirectionHorizontal": DirParam("5", values=H_ENUM)},
             attributes={"settings.windDirectionHorizontal": "5"},
         )
+        # 5 is a fixed horizontal position -> position_5.
         self.assertEqual(
             "position_5", self._by_key(added, "fan_direction_horizontal").current_option
+        )
+
+    async def test_current_option_horizontal_swing(self) -> None:
+        # 7 is the ONE horizontal swing value -> "swing" (mirror of vertical 8).
+        added, _, _ = await self._setup(
+            {"windDirectionHorizontal": DirParam("7", values=H_ENUM)},
+            attributes={"settings.windDirectionHorizontal": "7"},
+        )
+        self.assertEqual(
+            "swing", self._by_key(added, "fan_direction_horizontal").current_option
         )
 
     async def test_current_option_swing(self) -> None:
@@ -240,6 +255,16 @@ class AcFanDirectionSelectTest(unittest.IsolatedAsyncioTestCase):
         await self._by_key(added, "fan_direction_horizontal").async_select_option("position_5")
         self.assertEqual("5", settings.sent["windDirectionHorizontal"])
 
+    async def test_select_horizontal_swing_sends_7(self) -> None:
+        added, settings, _ = await self._setup(
+            {
+                "windDirectionVertical": DirParam("5", values=V_FULL),
+                "windDirectionHorizontal": DirParam("0", values=H_ENUM),
+            }
+        )
+        await self._by_key(added, "fan_direction_horizontal").async_select_option("swing")
+        self.assertEqual("7", settings.sent["windDirectionHorizontal"])
+
     async def test_requested_position_wins_over_sanitizer(self) -> None:
         added, settings, _ = await self._setup(
             {
@@ -288,10 +313,26 @@ class AcFanDirectionI18nTest(unittest.TestCase):
                 self.assertIn(opt_key, it_state, f"it missing {key}.{opt_key}")
             self.assertEqual(en_state, it_state, f"en/it parity {key}")
 
-    def test_swing_only_on_vertical(self) -> None:
-        en = self._select("en")
-        self.assertIn("swing", en["fan_direction_vertical"]["state"])
-        self.assertNotIn("swing", en["fan_direction_horizontal"]["state"])
+    def test_each_axis_has_one_swing_key(self) -> None:
+        # The two axes are symmetric: each carries exactly one "swing" key (vertical value
+        # 8, horizontal value 7) plus fixed "position_N" keys; no "fixed" key on either.
+        # Holds in both languages.
+        for lang in ("en", "it"):
+            sel = self._select(lang)
+            v_state = sel["fan_direction_vertical"]["state"]
+            h_state = sel["fan_direction_horizontal"]["state"]
+            self.assertIn("swing", v_state)
+            self.assertIn("swing", h_state)
+            self.assertNotIn("fixed", v_state)
+            self.assertNotIn("fixed", h_state)
+            self.assertTrue(
+                all(k == "swing" or k.startswith("position_") for k in v_state),
+                f"{lang}: vertical keys must be swing or position_N",
+            )
+            self.assertTrue(
+                all(k == "swing" or k.startswith("position_") for k in h_state),
+                f"{lang}: horizontal keys must be swing or position_N",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -215,10 +215,12 @@ def _collect_code_keys() -> dict[str, set[str]]:
         | {"pause", "debug_logging", "mqtt_realtime_debug"}
     )
     # Program select (fixed key) + the REF program/mode select (#40) + the
-    # program-option selects (#35).
-    used["select"] = {"program", "ref_program"} | {
-        d.translation_key for d in select._PROGRAM_OPTION_SELECTS
-    }
+    # program-option selects (#35) + the AC fan-direction selects (#37).
+    used["select"] = (
+        {"program", "ref_program"}
+        | {d.translation_key for d in select._PROGRAM_OPTION_SELECTS}
+        | {d.translation_key for d in select._AC_DIRECTION_SELECTS}
+    )
     used["button"] = {"start_program", "stop_program", "force_refresh", "reset_debug"}
     return used
 
@@ -441,7 +443,7 @@ def _collect_select_state_keys() -> dict[str, set[str]]:
     from custom_components.addhon import select
 
     by_tk: dict[str, set[str]] = {}
-    for d in select._PROGRAM_OPTION_SELECTS:
+    for d in (*select._PROGRAM_OPTION_SELECTS, *select._AC_DIRECTION_SELECTS):
         label_map = getattr(d, "label_map", None)
         if not label_map:
             continue

--- a/tests/test_ref_program_select.py
+++ b/tests/test_ref_program_select.py
@@ -460,6 +460,67 @@ class RefProgramSelectBehaviourTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual("super_cool", entity.current_option)
 
+    async def test_modez_synthetic_field_not_surfaced(self) -> None:
+        # modeZ1/modeZ2 are ENGINE-SYNTHETIC (client/engine/appliances/ref.py rewrites
+        # them from the boost flags), so they can never carry an iot_* code on the real
+        # engine and the select deliberately does NOT read them. Even if a modeZ field
+        # somehow held a real offered code, it must not be surfaced. Guards against
+        # re-adding modeZ1/modeZ2 to the active-program matcher.
+        for attr in ("modeZ1", "modeZ2"):
+            entity, _ = self._entity(_ref_commands(), {attr: "iot_extra_cold"})
+            self.assertEqual("off", entity.current_option, attr)
+
+    async def test_current_option_modez_no_mode_is_off(self) -> None:
+        entity, _ = self._entity(
+            _ref_commands(), {"modeZ1": "no_mode", "modeZ2": "no_mode"}
+        )
+        self.assertEqual("off", entity.current_option)
+        self.assertNotIn("no_mode", entity._attr_options)
+
+    async def test_current_option_modez_empty_is_off(self) -> None:
+        entity, _ = self._entity(_ref_commands(), {"modeZ1": "", "modeZ2": ""})
+        self.assertEqual("off", entity.current_option)
+
+    async def test_current_option_modez_gated_by_live_enum(self) -> None:
+        entity, _ = self._entity(_ref_commands(), {"modeZ1": "auto_set"})
+        self.assertEqual("off", entity.current_option)
+
+    async def test_flag_wins_over_modez(self) -> None:
+        entity, _ = self._entity(
+            _ref_commands(), {"quickModeZ1": "1", "modeZ1": "iot_daily_use"}
+        )
+        self.assertEqual("super_cool", entity.current_option)
+
+    async def test_current_option_real_super_cool_dump(self) -> None:
+        entity, _ = self._entity(
+            _ref_commands(),
+            {
+                "quickModeZ1": "1",
+                "modeZ1": "super_cool",
+                "modeZ2": "no_mode",
+                "programName": "No Program",
+            },
+        )
+        self.assertEqual("super_cool", entity.current_option)
+
+    async def test_iot_preset_not_surfaced_by_current_engine(self) -> None:
+        # CAVEAT (load-bearing): current engine derives modeZ from flags only, so an active
+        # iot_* preset (no flag) yields modeZ1=modeZ2="no_mode"; reading modeZ does NOT by
+        # itself close the iot_* gap. This pins that reality.
+        entity, _ = self._entity(
+            _ref_commands(),
+            {
+                "quickModeZ1": "0",
+                "quickModeZ2": "0",
+                "holidayMode": "0",
+                "intelligenceMode": "0",
+                "modeZ1": "no_mode",
+                "modeZ2": "no_mode",
+                "programName": "No Program",
+            },
+        )
+        self.assertEqual("off", entity.current_option)
+
 
 class RefProgramStateTranslationTest(unittest.TestCase):
     """The ref_program state map must label every code the select can show: the read-back


### PR DESCRIPTION
Automated release PR for `v5.7.0`.

<!-- release-tag: v5.7.0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new AC fan-direction controls for vertical and horizontal louver positions, including swing and position-based options.
  * Expanded language support for these new select options in English and Italian.

* **Bug Fixes**
  * Improved how current appliance states are shown for fridge program selection, especially for edge cases and inactive modes.
  * Tightened option handling so unsupported choices are not shown or sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release adds per-axis AC fan-direction (louver position) selects for vertical and horizontal axes, capability-gated live on the per-model settings enum, and tightens the REF program select so that iot_* download presets no longer surface incorrectly as the current option.

- **AC fan-direction selects**: Two new capability-gated `HonAcDirectionSelect` entities per AC (vertical / horizontal), with options drawn from the live device enum, mapped to stable translation keys. Values are normalized in `__init__` and sent through `async_send_settings` (which applies the sanitizer before the requested value wins).
- **REF program select hardening**: `_REF_ACTIVE_PROGRAM_ATTRS` now excludes `modeZ1`/`modeZ2` (engine-synthetic fields) and explicitly documents that active iot_* presets are unobservable from the cloud shadow. New tests cover the modeZ exclusion and the iot_* fall-through to \"off\".
- **Translations and tests**: en/it translations added for both new select entities, and a comprehensive `test_ac_fan_direction_select.py` validates capability gating, option building, send values, and sanitizer coexistence.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are capability-gated on the live device schema, no hard-coded assumptions about model-specific values, and the sanitizer interaction is proven correct by tests.

The AC fan-direction select follows the same well-tested capability-gating pattern already used by the program-option selects. The REF program select changes are documentation and comment updates only, with new tests that pin the previously undocumented modeZ exclusion. Translation keys are complete and in parity across both languages. No behavioural regression surfaces in any changed code path.

No files require special attention. The most complex new logic is in select.py (HonAcDirectionSelect.__init__ and async_select_option), which is fully exercised by test_ac_fan_direction_select.py.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/select.py | Adds HonAcDirectionSelect class and wires it into async_setup_entry; adds capability-gating helper _supports_direction_select; minor REF program select docstring and comment updates. Logic is sound. |
| custom_components/addhon/const.py | Adds FAN_DIR_V_LABELS and FAN_DIR_H_LABELS dicts (raw value to option key, superset design, forward-safe). Values are distinct within each map and consistent with the translation files. |
| tests/test_ac_fan_direction_select.py | New comprehensive test file covering capability gating, per-model enum variation, option normalization, current_option mapping, send values, and sanitizer interaction. |
| tests/test_ref_program_select.py | Adds tests pinning the modeZ1/modeZ2 exclusion and the iot_* preset fall-through to off. |
| custom_components/addhon/translations/en.json | Adds fan_direction_vertical and fan_direction_horizontal state blocks; keys match FAN_DIR_V_LABELS / FAN_DIR_H_LABELS values exactly. |
| custom_components/addhon/translations/it.json | Italian translations added with state keys in parity with en.json. |
| tests/test_entity_translation_keys.py | Updated to include _AC_DIRECTION_SELECTS, keeping translation-key coverage consistent with the new entities. |
| custom_components/addhon/manifest.json | Version bumped from 5.6.0-beta to 5.7.0. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant HA as Home Assistant
    participant Setup as async_setup_entry
    participant Gate as _supports_direction_select
    participant Entity as HonAcDirectionSelect
    participant Cmd as async_send_settings
    participant San as sanitize_wind_direction

    HA->>Setup: "setup AC appliance"
    Setup->>Gate: "settings_param(appliance, windDirectionVertical)"
    Gate-->>Setup: "param (typology=enum, len>1)"
    Setup->>Entity: "HonAcDirectionSelect(coordinator, id, desc, client)"
    Note over Entity: "Build _raw_to_key from live enum, _attr_options = option keys"

    HA->>Entity: "async_select_option(position_6)"
    Entity->>Entity: "_key_to_raw[position_6] = 6"
    Entity->>Cmd: "async_send_settings({windDirectionVertical: 6})"
    Cmd->>San: "pre_send(command_params)"
    San-->>Cmd: "other params sanitized if invalid"
    Cmd->>Cmd: "param.value = 6 (wins over sanitizer)"
    Cmd->>Cmd: "command.send()"
    Cmd-->>Entity: "done"
    Entity->>Entity: "_async_request_command_refresh()"

    HA->>Entity: "current_option (on refresh)"
    Entity->>Entity: "_get_attr(settings.windDirectionVertical) = 6"
    Entity-->>HA: "position_6"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant HA as Home Assistant
    participant Setup as async_setup_entry
    participant Gate as _supports_direction_select
    participant Entity as HonAcDirectionSelect
    participant Cmd as async_send_settings
    participant San as sanitize_wind_direction

    HA->>Setup: "setup AC appliance"
    Setup->>Gate: "settings_param(appliance, windDirectionVertical)"
    Gate-->>Setup: "param (typology=enum, len>1)"
    Setup->>Entity: "HonAcDirectionSelect(coordinator, id, desc, client)"
    Note over Entity: "Build _raw_to_key from live enum, _attr_options = option keys"

    HA->>Entity: "async_select_option(position_6)"
    Entity->>Entity: "_key_to_raw[position_6] = 6"
    Entity->>Cmd: "async_send_settings({windDirectionVertical: 6})"
    Cmd->>San: "pre_send(command_params)"
    San-->>Cmd: "other params sanitized if invalid"
    Cmd->>Cmd: "param.value = 6 (wins over sanitizer)"
    Cmd->>Cmd: "command.send()"
    Cmd-->>Entity: "done"
    Entity->>Entity: "_async_request_command_refresh()"

    HA->>Entity: "current_option (on refresh)"
    Entity->>Entity: "_get_attr(settings.windDirectionVertical) = 6"
    Entity-->>HA: "position_6"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["HonAcDirectionSelect: normalize enum cod..."](https://github.com/tis24dev/addhon/commit/d5ad7699acb8dbf8dc1e7ccc74a5478c73e6f69c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40808402)</sub>

<!-- /greptile_comment -->