### PR TITLE
Release v5.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ controls where they have been mapped.
 - **Tumble Dryer:** Haier HD100-C367GU1-IT
 - **Tumble Dryer:** Haier HD90-A3959 INT
 - **Refrigerator:** Haier HDPW5620CNPK
+- **Refrigerator:** HCW58F18EWMP
+- **Oven:** HWO60SM5T5BH
 
 Other hOn-compatible Haier appliances should work; feel free to test and report.
 

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -195,7 +195,7 @@ class HonCommand:
             second, HonParameterFixed
         ):
             return second
-        if len(second.values) > len(first.values):
+        if second.option_count() > first.option_count():
             return second
         return first
 

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -49,6 +49,16 @@ class HonParameter:
     def values(self) -> list[str]:
         return [str(self.value)]
 
+    def option_count(self) -> int:
+        """Cheap count of selectable ``values``.
+
+        Default = len of the (already small) materialized list, correct for
+        enum/fixed/program. HonParameterRange overrides it to count the min..max grid
+        ARITHMETICALLY, so HonCommand._more_options can compare cardinality on a merge
+        without materializing a range of up to _MAX_RANGE_VALUES strings.
+        """
+        return len(self.values)
+
     @property
     def category(self) -> str:
         return self._category

--- a/custom_components/addhon/client/engine/parameter/range.py
+++ b/custom_components/addhon/client/engine/parameter/range.py
@@ -1,9 +1,10 @@
 """Range parameter (min/max/step) for hOn commands.
 
 min/max/step/default via `str_to_float` (reuses client.helpers). `step` falls back to 1
-if 0. The setter validates range+step (modulo *100 to avoid float imprecision) and
-raises ValueError if out of bounds (the entities rely on it for the rollback). `values`
-enumerates min..max in steps of step.
+if 0. The setter validates range+step via `_on_grid` (snap-to-nearest-index with a
+magnitude-scaled epsilon, decimal-agnostic) and raises ValueError if out of bounds or
+off-grid (the entities rely on the ValueError for the rollback). `values` enumerates
+min..max in steps of step (index-based, bounded).
 """
 from __future__ import annotations
 
@@ -11,6 +12,13 @@ from typing import Any
 
 from ...helpers import str_to_float
 from .base import HonParameter
+
+# Safety bound when materializing a range's reachable ``values``: a malformed schema
+# (huge max / tiny step) must never loop unbounded. Generous on purpose so no plausible
+# real setpoint range is ever truncated -- truncating would silently drop valid grid
+# points, the same class of data loss the setter fix below removes. program_options uses
+# a tighter 1000 for UI select options, which is a different purpose.
+_MAX_RANGE_VALUES = 100000
 
 
 class HonParameterRange(HonParameter):
@@ -76,20 +84,68 @@ class HonParameterRange(HonParameter):
             value = str_to_float(str(value))
         else:
             value = str_to_float(value)
-        if self.min <= value <= self.max and not ((value - self.min) * 100) % (
-            self.step * 100
-        ):
+        if self._on_grid(value):
             self._value = value
             self.check_trigger(value)
         else:
             allowed = f"min {self.min} max {self.max} step {self.step}"
             raise ValueError(f"Allowed: {allowed} But was: {value}")
 
+    def _on_grid(self, value: float) -> bool:
+        """True if ``value`` is in [min, max] AND lands on the min/step grid.
+
+        Replaces the inherited ``((value - min) * 100) % (step * 100)`` trick, which was
+        NOT a tolerance but a naive integerization: ``(value - min) * 100`` stays a float
+        and keeps its IEEE-754 representation error, so an on-grid setpoint with a
+        non-zero min and a decimal step (e.g. 20.1 on 20..25 step 0.1, or 16.3 on 16..30
+        step 0.1) was wrongly rejected. That reject surfaces as a ValueError on the write
+        path (climate.py setpoint / number.py), which the entities read as a failed set
+        and SILENTLY roll the user's value back.
+
+        Instead snap to the nearest grid index and accept when the value is within a
+        tolerance of that grid point. The tolerance is program_options' 1e-9 float-drift
+        epsilon scaled by the operand magnitude, so it always dominates the
+        ~1e-15 * magnitude rounding error of ``min + n * step`` yet stays orders of
+        magnitude below any real off-grid distance (a genuine off-grid value is at least a
+        fraction of a step away). It is decimal-agnostic (any number of decimals). An
+        exact fractions.Fraction oracle over the realistic parameter space gives 0 false
+        negatives and 0 false positives, and the integer-step ranges of the golden fridge
+        dump validate exactly as before.
+        """
+        if not self.min <= value <= self.max:
+            return False
+        step = self.step
+        if step <= 0:
+            # Malformed incrementValue (non-positive): there is no grid to test and we must
+            # not divide by it. Accept anything already in [min, max] rather than reject a
+            # legitimate value on corrupt metadata (a reject would re-trigger the silent
+            # rollback this fix removes). The step property maps a falsy 0 -> 1, so this
+            # only fires for a genuinely negative step.
+            return True
+        index = round((value - self.min) / step)
+        tolerance = 1e-9 * max(1.0, abs(self.min), abs(self.max), abs(step))
+        return abs(self.min + index * step - value) <= tolerance
+
     @property
     def values(self) -> list[str]:
-        result = []
-        i = self.min
-        while i <= self.max:
-            result.append(str(i))
-            i += self.step
+        # Index-based enumeration (min + i*step), NOT a ``+= step`` accumulator: the old
+        # accumulator compounded float error on decimal steps ("20.700000000000003") and
+        # could DROP the final grid point (24.9.. + 0.1 overshoots max) or, on a malformed
+        # range, loop forever (commands.py _more_options calls this to compare lengths).
+        # Bounded by _MAX_RANGE_VALUES and an epsilon on the max bound (1e-9 * magnitude,
+        # NOT step/2, so an overshooting step cannot add a phantom point past max). Keeps
+        # the previous ``str()`` formatting, so integer-step ranges (all real fridge
+        # params) render byte-for-byte as before (golden-verified).
+        step = self.step
+        if step <= 0:
+            return [str(self.min)]
+        result: list[str] = []
+        index = 0
+        tolerance = 1e-9 * max(1.0, abs(self.min), abs(self.max), abs(step))
+        while index < _MAX_RANGE_VALUES:
+            current = self.min + index * step
+            if current > self.max + tolerance:
+                break
+            result.append(str(current))
+            index += 1
         return result

--- a/custom_components/addhon/client/engine/parameter/range.py
+++ b/custom_components/addhon/client/engine/parameter/range.py
@@ -8,6 +8,7 @@ min..max in steps of step (index-based, bounded).
 """
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 from ...helpers import str_to_float
@@ -102,15 +103,15 @@ class HonParameterRange(HonParameter):
         path (climate.py setpoint / number.py), which the entities read as a failed set
         and SILENTLY roll the user's value back.
 
-        Instead snap to the nearest grid index and accept when the value is within a
-        tolerance of that grid point. The tolerance is program_options' 1e-9 float-drift
-        epsilon scaled by the operand magnitude, so it always dominates the
-        ~1e-15 * magnitude rounding error of ``min + n * step`` yet stays orders of
-        magnitude below any real off-grid distance (a genuine off-grid value is at least a
-        fraction of a step away). It is decimal-agnostic (any number of decimals). An
-        exact fractions.Fraction oracle over the realistic parameter space gives 0 false
-        negatives and 0 false positives, and the integer-step ranges of the golden fridge
-        dump validate exactly as before.
+        Instead snap to the nearest grid index and accept when the value is within
+        ``_grid_eps`` of that grid point. The tolerance is program_options' 1e-9
+        float-drift epsilon scaled by the operand magnitude AND capped to step/4, so it
+        dominates the ~1e-15 * magnitude rounding error of ``min + n * step`` yet stays
+        strictly below the half-step off-grid distance even on absurd schemas. It is
+        decimal-agnostic (any number of decimals). An exact fractions.Fraction oracle over
+        the realistic AND the extreme parameter space gives 0 false negatives and 0 false
+        positives, and the integer-step ranges of the golden fridge dump validate exactly
+        as before.
         """
         if not self.min <= value <= self.max:
             return False
@@ -123,29 +124,103 @@ class HonParameterRange(HonParameter):
             # only fires for a genuinely negative step.
             return True
         index = round((value - self.min) / step)
-        tolerance = 1e-9 * max(1.0, abs(self.min), abs(self.max), abs(step))
-        return abs(self.min + index * step - value) <= tolerance
+        return abs(self.min + index * step - value) <= self._grid_eps(step)
+
+    def _grid_eps(self, step: float) -> float:
+        """Snap/enumeration tolerance for the min/step grid, capped to a fraction of step.
+
+        The base epsilon is program_options' 1e-9 float-drift value scaled by the operand
+        magnitude, so it always dominates the ~1e-15 * magnitude rounding error of
+        ``min + n * step``. On its own that magnitude term can EXCEED half a step on a
+        pathological schema (min 0, max 1_000_000, step 0.001 -> 1e-3 > step/2 = 5e-4),
+        which would accept an off-grid value and violate the setter's off-grid -> ValueError
+        contract (the rollback depends on it). Capping at ``step / 4`` keeps the epsilon
+        strictly below the half-step distance in EVERY schema while staying orders of
+        magnitude above the real rounding error, so it adds no false negative on any
+        realistic range. The SAME epsilon backs _on_grid, option_count() and values(), so
+        acceptance and enumeration can never disagree. Callers pass the resolved POSITIVE
+        step (this is only reached after the step <= 0 guard). Proven with a
+        fractions.Fraction oracle: 0 false negatives / 0 false positives on the realistic
+        space and on the 1e6 / 0.001 extreme.
+        """
+        return min(1e-9 * max(1.0, abs(self.min), abs(self.max), abs(step)), step / 4)
+
+    @staticmethod
+    def _decimals(number: float) -> int:
+        """Fractional-digit count of a parsed numeric value (0.1 -> 1, 0.125 -> 3, 1 -> 0).
+
+        Uses ``Decimal(str(number))``: str() is the float's shortest round-tripping repr
+        (Python guarantees str(0.1) == "0.1", and a decimal-comma "5,5" is already the
+        float 5.5 via str_to_float), and normalize() drops an integer's trailing zeros
+        (1.0 / 100 -> 0). Only ever used to format values() output, never the stored value.
+        """
+        exponent = Decimal(str(number)).normalize().as_tuple().exponent
+        return -exponent if isinstance(exponent, int) and exponent < 0 else 0
+
+    def _grid_ndigits(self) -> int:
+        """Rounding precision for values() output = max(decimals(step), decimals(min)).
+
+        A grid point ``min + i*step`` carries at most max(decimals(min), decimals(step))
+        decimals, so rounding to this precision is exact: it removes float drift without
+        ever collapsing a distinct point (e.g. min=16.5 step=1 keeps 16.5, 17.5, ...).
+        Cosmetic only -- it formats values() and never touches the setter/intern_value.
+        """
+        return max(self._decimals(self.step), self._decimals(self.min))
+
+    def _grid_count(self, step: float) -> int:
+        """Reachable grid-point count for step > 0, bounded by _MAX_RANGE_VALUES.
+
+        Computed ARITHMETICALLY so option_count() and values() never materialize the value
+        strings just to measure them. int() floors ``(max + eps - min) / step``; the two
+        short reconcile loops pin the result to the exact per-index predicate values() uses
+        (``min + i*step <= max + eps``), so a one-ULP disagreement between the float
+        division and the iteration cannot make option_count() drift from len(values()) and
+        no phantom point past max is emitted. Returns 0 for an inverted range (max < min).
+        Callers pass the resolved POSITIVE step.
+        """
+        eps = self._grid_eps(step)
+        limit = self.max + eps
+        count = int((limit - self.min) / step) + 1
+        if count < 0:
+            count = 0
+        while count > 0 and self.min + (count - 1) * step > limit:
+            count -= 1
+        while self.min + count * step <= limit:
+            count += 1
+        return min(count, _MAX_RANGE_VALUES)
+
+    def option_count(self) -> int:
+        """Reachable ``values`` count WITHOUT materializing the strings (F2).
+
+        Arithmetic equivalent of ``len(self.values)`` (same capped epsilon and
+        _MAX_RANGE_VALUES cap), so the two are equal by construction -- values() builds
+        ``range(self._grid_count(step))``. Lets HonCommand._more_options compare cardinality
+        while merging available_settings without allocating up to _MAX_RANGE_VALUES strings.
+        """
+        step = self.step
+        if step <= 0:
+            return 1  # values() returns the single [str(self.min)]
+        return self._grid_count(step)
 
     @property
     def values(self) -> list[str]:
         # Index-based enumeration (min + i*step), NOT a ``+= step`` accumulator: the old
         # accumulator compounded float error on decimal steps ("20.700000000000003") and
         # could DROP the final grid point (24.9.. + 0.1 overshoots max) or, on a malformed
-        # range, loop forever (commands.py _more_options calls this to compare lengths).
-        # Bounded by _MAX_RANGE_VALUES and an epsilon on the max bound (1e-9 * magnitude,
-        # NOT step/2, so an overshooting step cannot add a phantom point past max). Keeps
-        # the previous ``str()`` formatting, so integer-step ranges (all real fridge
-        # params) render byte-for-byte as before (golden-verified).
+        # range, loop forever. The point count comes from _grid_count (shared with
+        # option_count -- same capped epsilon + _MAX_RANGE_VALUES bound), so
+        # len(values) == option_count() by construction. Each value is ROUNDED to the
+        # step/min decimal precision before str() (F3), which cleans decimal drift
+        # ("24.200000000000003" -> "24.2") WITHOUT reformatting integers: an integer step
+        # rounds to 0 decimals and str(round(int, 0)) stays the bare integer, so
+        # integer-step ranges (all real fridge params) render byte-for-byte as before
+        # (golden-verified). Rounding is cosmetic; the stored value / intern_value are set
+        # by the setter and are never touched here.
         step = self.step
         if step <= 0:
             return [str(self.min)]
-        result: list[str] = []
-        index = 0
-        tolerance = 1e-9 * max(1.0, abs(self.min), abs(self.max), abs(step))
-        while index < _MAX_RANGE_VALUES:
-            current = self.min + index * step
-            if current > self.max + tolerance:
-                break
-            result.append(str(current))
-            index += 1
-        return result
+        ndigits = self._grid_ndigits()
+        return [
+            str(round(self.min + index * step, ndigits))
+            for index in range(self._grid_count(step))
+        ]

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.7.0"
+  "version": "5.7.1"
 }

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -19,7 +19,10 @@ from _golden import REPO, frozen, install_stubs  # noqa: E402
 install_stubs()
 _DUMP = REPO / "tests" / "fixtures" / "ref_10136" / "commands.json"
 
-from custom_components.addhon.client.engine.parameter.range import HonParameterRange as NaRange  # noqa: E402
+from custom_components.addhon.client.engine.parameter.range import (  # noqa: E402
+    HonParameterRange as NaRange,
+    _MAX_RANGE_VALUES,
+)
 from custom_components.addhon.client.engine.parameter.enum import HonParameterEnum as NaEnum  # noqa: E402
 from custom_components.addhon.client.engine.parameter.fixed import HonParameterFixed as NaFixed  # noqa: E402
 
@@ -156,6 +159,125 @@ class NativeEnumEdgeBehaviorTest(unittest.TestCase):
         na = NaEnum("k", dict(data), "grp")
         with self.assertRaises(ValueError):
             na.value = "A|B|C"
+
+
+class RangeGridSetterTest(unittest.TestCase):
+    """Regression for the x100 modulo grid-check bug: an on-grid setpoint with a
+    non-zero min and a decimal step (e.g. 20.1 on 20..25 step 0.1) was wrongly
+    rejected with a ValueError, which the write path (climate.py / number.py) reads as
+    a failed set and SILENTLY rolls the user's value back. The replacement snap-to-index
+    grid-check accepts every real on-grid value while still rejecting off-grid /
+    out-of-range ones."""
+
+    def _range(self, lo, hi, step):
+        return NaRange("temp", {"category": "command", "typology": "range",
+                                "mandatory": 0, "minimumValue": lo, "maximumValue": hi,
+                                "incrementValue": step, "defaultValue": lo}, "grp")
+
+    # --- values that USED to be wrongly rejected (the actual bug) ---
+    def test_decimal_min_nonzero_accept_string(self) -> None:
+        p = self._range("20", "25", "0.1")
+        p.value = "20.1"  # on-grid, non-zero min, decimal step -> was ValueError
+        self.assertEqual(p.value, 20.1)
+        self.assertEqual(p.intern_value, "20.1")
+
+    def test_decimal_min_nonzero_accept_direct_float(self) -> None:
+        p = self._range("20", "25", "0.1")
+        p.value = 20.1  # fractional float assigned directly, must not truncate to 20
+        self.assertEqual(p.value, 20.1)
+        self.assertEqual(p.intern_value, "20.1")
+
+    def test_16_30_step_01_accept(self) -> None:
+        p = self._range("16", "30", "0.1")
+        p.value = "16.3"  # was ValueError
+        self.assertEqual(p.value, 16.3)
+        self.assertEqual(p.intern_value, "16.3")
+
+    def test_three_decimals_accept(self) -> None:
+        p = self._range("0", "1", "0.001")
+        p.value = "0.003"  # >2 decimals was ValueError under the x100 trick
+        self.assertEqual(p.value, 0.003)
+        self.assertEqual(p.intern_value, "0.003")
+
+    # --- genuinely off-grid values must STILL raise ValueError (rollback contract) ---
+    def test_off_grid_half_step_string_rejected(self) -> None:
+        p = self._range("16", "30", "0.1")
+        with self.assertRaises(ValueError):
+            p.value = "16.35"
+
+    def test_off_grid_three_decimals_rejected(self) -> None:
+        p = self._range("0", "1", "0.001")
+        with self.assertRaises(ValueError):
+            p.value = "0.0035"
+
+    def test_off_grid_direct_float_rejected_not_truncated(self) -> None:
+        # 22.3 is off the 0.5 grid: must raise, not be silently truncated to 22.
+        p = self._range("20", "25", "0.5")
+        with self.assertRaises(ValueError):
+            p.value = 22.3
+
+    # --- out-of-range still rejected, on-grid boundary still accepted ---
+    def test_out_of_range_rejected(self) -> None:
+        p = self._range("20", "25", "0.5")
+        with self.assertRaises(ValueError):
+            p.value = 25.5
+
+    def test_boundary_max_on_grid_accepted(self) -> None:
+        p = self._range("20", "25", "0.5")
+        p.value = "25.0"
+        self.assertEqual(p.value, 25.0)
+
+    # --- intern_value invariant: integer-valued inputs stay clean ("24", not "24.0") ---
+    def test_integer_inputs_clean_intern(self) -> None:
+        for v in ("24", 24, 24.0):
+            p = self._range("20", "25", "0.5")
+            p.value = v
+            self.assertEqual(p.value, 24)
+            self.assertEqual(p.intern_value, "24")
+
+    def test_decimal_comma_preserved(self) -> None:
+        p = self._range("20", "25", "0.5")
+        p.value = "22,5"  # cloud decimal comma
+        self.assertEqual(p.value, 22.5)
+        self.assertEqual(p.intern_value, "22.5")
+
+    # --- negative-min integer grid ---
+    def test_negative_min_integer_grid(self) -> None:
+        p = self._range("-24", "-16", "1")
+        p.value = -20
+        self.assertEqual(p.value, -20)
+        self.assertEqual(p.intern_value, "-20")
+        p2 = self._range("-24", "-16", "1")
+        with self.assertRaises(ValueError):
+            p2.value = "-20.5"
+
+    # --- malformed negative step: no ZeroDivisionError, no spurious reject ---
+    def test_malformed_negative_step_no_crash(self) -> None:
+        p = self._range("0", "10", "-1")
+        self.assertEqual(p.step, -1)  # step property keeps a genuine negative
+        p.value = "5"  # in-range: accepted via the step<=0 branch, no crash
+        self.assertEqual(p.value, 5)
+
+    # --- values(): index-based, no dropped final point, no unbounded loop ---
+    def test_values_decimal_endpoints_and_length(self) -> None:
+        p = self._range("16", "30", "0.1")
+        v = p.values
+        self.assertEqual(len(v), 141)
+        self.assertEqual(v[0], "16.0")
+        self.assertEqual(v[-1], "30.0")  # final point no longer dropped / drifted
+
+    def test_values_half_step_range(self) -> None:
+        p = self._range("20", "25", "0.5")
+        self.assertEqual(
+            p.values,
+            ["20.0", "20.5", "21.0", "21.5", "22.0", "22.5",
+             "23.0", "23.5", "24.0", "24.5", "25.0"],
+        )
+
+    def test_values_bounded_on_malformed_range(self) -> None:
+        # tiny step over a huge span must not loop unbounded.
+        p = self._range("0", "1000", "0.001")
+        self.assertLessEqual(len(p.values), _MAX_RANGE_VALUES)
 
 
 class RangeSetterHardeningTest(unittest.TestCase):

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 import sys
 import unittest
+from decimal import Decimal
+from fractions import Fraction
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -25,6 +27,7 @@ from custom_components.addhon.client.engine.parameter.range import (  # noqa: E4
 )
 from custom_components.addhon.client.engine.parameter.enum import HonParameterEnum as NaEnum  # noqa: E402
 from custom_components.addhon.client.engine.parameter.fixed import HonParameterFixed as NaFixed  # noqa: E402
+from custom_components.addhon.client.engine.commands import HonCommand  # noqa: E402
 
 _NA = {"range": NaRange, "enum": NaEnum, "fixed": NaFixed}
 
@@ -315,6 +318,236 @@ class RangeSetterHardeningTest(unittest.TestCase):
         p = self._range()
         p.value = "22,5"  # cloud decimal comma -> 22.5 (string path unchanged)
         self.assertEqual(p.value, 22.5)
+
+
+def _mk_range(lo, hi, step):
+    return NaRange("temp", {"category": "command", "typology": "range",
+                            "mandatory": 0, "minimumValue": lo, "maximumValue": hi,
+                            "incrementValue": step, "defaultValue": lo}, "grp")
+
+
+def _mk_enum(values, default=None):
+    data = {"category": "command", "typology": "enum", "mandatory": 1,
+            "enumValues": list(values)}
+    if default is not None:
+        data["defaultValue"] = default
+    return NaEnum("mode", data, "grp")
+
+
+def _mk_fixed(value):
+    return NaFixed("fx", {"category": "command", "typology": "fixed",
+                          "mandatory": 0, "fixedValue": value}, "grp")
+
+
+# (lo, hi, step) plus expected reachable-point count. Covers fractional steps,
+# endpoints, integer ranges and the extreme 1e6 magnitude / tiny step case.
+_GRID_MATRIX = [
+    ("16", "30", "0.1", 141),
+    ("20", "25", "0.5", 11),
+    ("0", "1", "0.001", 1001),
+    ("0", "40", "0.125", 321),
+    ("-10", "10", "0.25", 81),
+    ("100000", "100010", "0.001", 10001),
+    ("2", "8", "1", 7),
+    ("-24", "-16", "1", 9),
+    ("0", "5", "1", 6),
+]
+
+
+class RangeGridEpsilonF1Test(unittest.TestCase):
+    """F1: the snap tolerance is now capped at step/4, so it can never exceed the
+    half-step off-grid distance -- not even on a pathological schema where the
+    magnitude-scaled 1e-9 term alone would (min 0, max 1e6, step 0.001 -> old eps 1e-3
+    > step/2 = 5e-4). The setter's off-grid -> ValueError contract (the rollback depends
+    on it) must hold unconditionally, WITHOUT introducing a false negative on any
+    realistic on-grid value."""
+
+    def test_extreme_off_grid_rejected(self) -> None:
+        # Pre-fix (uncapped eps = 1e-3) accepted this off-grid value; capped eps = 2.5e-4
+        # rejects it. Oracle-confirmed the old code accepted 0.0005.
+        p = _mk_range("0", "1000000", "0.001")
+        with self.assertRaises(ValueError):
+            p.value = "0.0005"
+
+    def test_extreme_on_grid_still_accepted(self) -> None:
+        # The cap must not turn a real on-grid value into a false negative.
+        p = _mk_range("0", "1000000", "0.001")
+        p.value = "0.001"
+        self.assertEqual(p.value, 0.001)
+        p2 = _mk_range("0", "1000000", "0.001")
+        p2.value = "999999.999"
+        self.assertEqual(p2.value, 999999.999)
+
+    def test_eps_below_half_step_on_every_matrix_range(self) -> None:
+        for lo, hi, step, _n in _GRID_MATRIX:
+            p = _mk_range(lo, hi, step)
+            self.assertLess(p._grid_eps(p.step), p.step / 2)
+
+    def test_fraction_oracle_zero_fn_zero_fp(self) -> None:
+        """Exact fractions.Fraction oracle: every exact grid point is accepted and
+        every exact half-step midpoint in range is rejected (0 false negatives / 0
+        false positives) across the realistic AND extreme space."""
+        for lo, hi, step in [(m[0], m[1], m[2]) for m in _GRID_MATRIX] + [
+            ("0", "1000000", "0.001")
+        ]:
+            f_lo, f_hi, f_step = Fraction(lo), Fraction(hi), Fraction(step)
+            d_lo, d_step = Decimal(lo), Decimal(step)
+            n = int((f_hi - f_lo) / f_step) + 1
+            # Sample indices so the 1e6/0.001 case (1e9 points) stays fast, always
+            # including the endpoints.
+            stride = max(1, n // 60)
+            indices = sorted(set(list(range(0, n, stride)) + [n - 1]))
+            for i in indices:
+                gp = str(d_lo + i * d_step)  # exact on-grid decimal string
+                p = _mk_range(lo, hi, step)
+                try:
+                    p.value = gp
+                except ValueError:  # pragma: no cover - would be a false negative
+                    self.fail(f"false negative: {lo}..{hi}/{step} rejected on-grid {gp}")
+                if i < n - 1:
+                    mid = str(d_lo + (Decimal(i) + Decimal("0.5")) * d_step)
+                    pm = _mk_range(lo, hi, step)
+                    with self.assertRaises(
+                        ValueError,
+                        msg=f"false positive: {lo}..{hi}/{step} accepted off-grid {mid}",
+                    ):
+                        pm.value = mid
+
+
+class RangeOptionCountF2Test(unittest.TestCase):
+    """F2: option_count() counts the reachable grid points ARITHMETICALLY (no string
+    materialization), and must equal len(values()) in every case -- values() is built
+    from range(_grid_count(step)), so they share the exact same capped epsilon and
+    _MAX_RANGE_VALUES bound."""
+
+    def test_option_count_equals_len_values_matrix(self) -> None:
+        for lo, hi, step, expected in _GRID_MATRIX:
+            p = _mk_range(lo, hi, step)
+            self.assertEqual(p.option_count(), len(p.values), f"{lo}..{hi}/{step}")
+            self.assertEqual(p.option_count(), expected, f"{lo}..{hi}/{step}")
+
+    def test_cap_boundary_matches_and_saturates(self) -> None:
+        for lo, hi, step in [("0", "1000", "0.001"), ("0", "100", "0.001")]:
+            p = _mk_range(lo, hi, step)
+            self.assertEqual(p.option_count(), _MAX_RANGE_VALUES)
+            self.assertEqual(len(p.values), _MAX_RANGE_VALUES)
+
+    def test_inverted_range_is_zero(self) -> None:
+        p = _mk_range("10", "0", "1")
+        self.assertEqual(p.option_count(), 0)
+        self.assertEqual(p.values, [])
+
+    def test_single_point_range(self) -> None:
+        p = _mk_range("5", "5", "1")
+        self.assertEqual(p.option_count(), 1)
+        self.assertEqual(p.values, ["5"])
+
+    def test_non_positive_step_no_zero_division(self) -> None:
+        p = _mk_range("0", "10", "-1")
+        self.assertEqual(p.option_count(), 1)
+        self.assertEqual(p.values, ["0"])
+
+    def test_base_option_count_enum_and_fixed(self) -> None:
+        enum = _mk_enum(["A", "B", "C"], default="A")
+        self.assertEqual(enum.option_count(), 3)
+        self.assertEqual(enum.option_count(), len(enum.values))
+        fixed = _mk_fixed("cool")
+        self.assertEqual(fixed.option_count(), 1)
+        self.assertEqual(fixed.option_count(), len(fixed.values))
+
+    def test_more_options_selection_preserved(self) -> None:
+        # _more_options must still pick the parameter with MORE options; ties keep first.
+        fixed = _mk_fixed("cool")
+        range11 = _mk_range("20", "25", "0.5")   # 11 options
+        range5 = _mk_range("0", "2", "0.5")       # 5 options
+        enum3 = _mk_enum(["A", "B", "C"], default="A")
+        self.assertIs(HonCommand._more_options(fixed, range11), range11)
+        self.assertIs(HonCommand._more_options(range11, fixed), range11)
+        self.assertIs(HonCommand._more_options(enum3, range11), range11)
+        self.assertIs(HonCommand._more_options(range11, enum3), range11)
+        self.assertIs(HonCommand._more_options(range11, range5), range11)
+        enum3b = _mk_enum(["X", "Y", "Z"], default="X")
+        self.assertIs(HonCommand._more_options(enum3, enum3b), enum3)  # tie -> first
+
+
+class RangeValuesDriftF3Test(unittest.TestCase):
+    """F3: values() rounds each grid point to the step/min decimal precision before
+    str(), so decimal drift ("24.200000000000003") is gone -- WITHOUT touching integer
+    ranges (golden) or the setter's stored value / intern_value."""
+
+    def test_no_float_drift_in_labels(self) -> None:
+        p = _mk_range("16", "30", "0.1")
+        v = p.values
+        self.assertEqual(len(v), 141)
+        self.assertEqual(v[0], "16.0")
+        self.assertEqual(v[-1], "30.0")
+        self.assertIn("24.2", v)
+        self.assertNotIn("24.200000000000003", v)
+        for label in v:
+            frac = label.split(".")[1] if "." in label else ""
+            self.assertLessEqual(len(frac), 6, label)
+
+    def test_half_step_list_exact(self) -> None:
+        p = _mk_range("20", "25", "0.5")
+        self.assertEqual(
+            p.values,
+            ["20.0", "20.5", "21.0", "21.5", "22.0", "22.5",
+             "23.0", "23.5", "24.0", "24.5", "25.0"],
+        )
+
+    def test_quarter_eighth_step_three_decimals(self) -> None:
+        p = _mk_range("0", "1", "0.125")
+        self.assertEqual(
+            p.values,
+            ["0.0", "0.125", "0.25", "0.375", "0.5",
+             "0.625", "0.75", "0.875", "1.0"],
+        )
+
+    def test_integer_ranges_byte_identical(self) -> None:
+        # Integer step -> ndigits 0 -> bare integer strings (never "2.0"); this is what
+        # the golden fridge ranges rely on.
+        self.assertEqual(_mk_range("2", "8", "1").values,
+                         ["2", "3", "4", "5", "6", "7", "8"])
+        self.assertEqual(_mk_range("-24", "-16", "1").values,
+                         ["-24", "-23", "-22", "-21", "-20", "-19", "-18", "-17", "-16"])
+        self.assertEqual(_mk_range("0", "5", "1").values,
+                         ["0", "1", "2", "3", "4", "5"])
+
+    def test_min_finer_than_step_not_collapsed(self) -> None:
+        # ndigits = max(decimals(min), decimals(step)); a fractional min with an integer
+        # step must keep its .5 points (not banker's-round to 16/18).
+        p = _mk_range("16.5", "20.5", "1")
+        self.assertEqual(p.values, ["16.5", "17.5", "18.5", "19.5", "20.5"])
+
+    def test_setter_intern_value_untouched(self) -> None:
+        # F3 must alter ONLY values() output, never the setter's stored value.
+        p = _mk_range("20", "25", "0.5")
+        p.value = 22.5
+        self.assertEqual(p.value, 22.5)
+        self.assertEqual(p.intern_value, "22.5")
+        for v in ("24", 24, 24.0):
+            q = _mk_range("20", "25", "0.5")
+            q.value = v
+            self.assertEqual(q.value, 24)
+            self.assertEqual(q.intern_value, "24")
+        r = _mk_range("20", "25", "0.5")
+        r.value = "22,5"
+        self.assertEqual(r.value, 22.5)
+
+    def test_decimals_derivation_robust(self) -> None:
+        self.assertEqual(NaRange._decimals(0.1), 1)
+        self.assertEqual(NaRange._decimals(0.125), 3)
+        self.assertEqual(NaRange._decimals(0.001), 3)
+        self.assertEqual(NaRange._decimals(0.25), 2)
+        self.assertEqual(NaRange._decimals(0.5), 1)
+        self.assertEqual(NaRange._decimals(1), 0)
+        self.assertEqual(NaRange._decimals(5), 0)
+        self.assertEqual(NaRange._decimals(16.0), 0)
+        # decimal-comma "5,5" schema resolves to the float 5.5 via str_to_float -> 1.
+        self.assertEqual(NaRange._decimals(5.5), 1)
+        p = _mk_range("0", "22", "5,5")
+        self.assertEqual(p.step, 5.5)
+        self.assertEqual(p.values, ["0.0", "5.5", "11.0", "16.5", "22.0"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.7.1`.

<!-- release-tag: v5.7.1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the list of tested hardware in the README with additional refrigerator and oven models.

* **Bug Fixes**
  * Improved how supported value ranges are handled, making setpoints more reliable across decimal, offset, and boundary cases.
  * Prevented overly large or malformed ranges from causing excessive processing.
  * Reduced drift and overshoot when generating available values.

* **Chores**
  * Bumped the integration version to 5.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR (v5.7.1) fixes three floating-point correctness bugs in the `HonParameterRange` class and adds a bounded-range materialization guard. The fixes address silent setpoint rollbacks in Home Assistant climate/number entities caused by incorrect grid validation.

- **F1 (`_on_grid` rewrite):** Replaces the `((value - min) * 100) % (step * 100)` modulo trick with a snap-to-nearest-index check using a magnitude-scaled, step/4-capped epsilon. The old trick kept IEEE-754 representation error, silently rejecting on-grid decimal setpoints (e.g. 20.1 on a 20..25/0.1 range) and rolling back the user's value.
- **F2 (`option_count`):** Adds an arithmetic grid-point counter to `HonParameter` (base default via `len(values)`) and a fast override in `HonParameterRange` that avoids materializing up to `_MAX_RANGE_VALUES` strings just to compare cardinality in `HonCommand._more_options`.
- **F3 (`values` rewrite):** Replaces the floating accumulator (`+= step`) with an index-based enumeration (`min + i*step`) rounded to the step/min decimal precision, eliminating both float drift in displayed labels and the risk of the loop overshooting and dropping the final grid point.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes fix real silent-rollback bugs in the range setter and values enumeration, and every changed code path is covered by new regression tests including a Fraction-oracle sweep.

All three fixes address concrete, observable bugs (decimal setpoints silently rejected, final grid point dropped, float drift in labels). The new snap-to-index grid check, index-based enumeration, and arithmetic option_count are correct and consistent with each other by construction (shared _grid_count path). The test suite adds Fraction-oracle validation, matrix parametrization, and golden regression checks that would catch any regression on the changed paths.

No files require special attention. The reconciliation while-loops in _grid_count are bounded in practice by float precision (0–2 iterations) and the _MAX_RANGE_VALUES cap provides an additional safety net for malformed schemas.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/parameter/range.py | Core fix: replaces buggy modulo grid check and floating accumulator with snap-to-index + epsilon logic; adds _grid_count/_grid_eps/_decimals helpers and a bounded option_count() override. Logic is well-reasoned and extensively oracle-tested. |
| custom_components/addhon/client/engine/parameter/base.py | Adds option_count() base method delegating to len(self.values); correct default for enum/fixed/program subtypes, overridden by HonParameterRange. |
| custom_components/addhon/client/engine/commands.py | Single-line change in _more_options: switches from len(second.values) to second.option_count() to avoid materializing large range value lists on every available_settings merge. |
| tests/test_engine_parameters.py | Adds four new test classes (RangeGridSetterTest, RangeGridEpsilonF1Test, RangeOptionCountF2Test, RangeValuesDriftF3Test) with Fraction-oracle, matrix, and golden regression coverage for all three fixed bugs. |
| custom_components/addhon/manifest.json | Version bump from 5.7.0 to 5.7.1. |
| README.md | Adds two new tested hardware models (HCW58F18EWMP refrigerator and HWO60SM5T5BH oven) to the supported devices list. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["value setter\n(range.py)"] -->|"isinstance(float) and\nnot is_integer?"| B["str_to_float(str(value))"]
    A -->|else| C["str_to_float(value)"]
    B --> D["_on_grid(value)"]
    C --> D
    D -->|"not min ≤ value ≤ max"| E["return False → ValueError"]
    D -->|"step ≤ 0"| F["return True (accept)"]
    D -->|"step > 0"| G["index = round((value - min) / step)"]
    G --> H["abs(min + index*step - value)\n≤ _grid_eps(step)?"]
    H -->|Yes| I["_value = value\ncheck_trigger()"]
    H -->|No| E

    J["values property"] -->|"step ≤ 0"| K["[str(min)]"]
    J -->|"step > 0"| L["_grid_count(step)\n(capped at _MAX_RANGE_VALUES)"]
    L --> M["ndigits = _grid_ndigits()"]
    M --> N["str(round(min + i*step, ndigits))\nfor i in range(count)"]

    O["option_count()"] -->|"step ≤ 0"| P["return 1"]
    O -->|"step > 0"| Q["_grid_count(step)"]

    R["HonCommand._more_options"] -->|"second.option_count()\n> first.option_count()"| S["return second"]
    R -->|else| T["return first"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["value setter\n(range.py)"] -->|"isinstance(float) and\nnot is_integer?"| B["str_to_float(str(value))"]
    A -->|else| C["str_to_float(value)"]
    B --> D["_on_grid(value)"]
    C --> D
    D -->|"not min ≤ value ≤ max"| E["return False → ValueError"]
    D -->|"step ≤ 0"| F["return True (accept)"]
    D -->|"step > 0"| G["index = round((value - min) / step)"]
    G --> H["abs(min + index*step - value)\n≤ _grid_eps(step)?"]
    H -->|Yes| I["_value = value\ncheck_trigger()"]
    H -->|No| E

    J["values property"] -->|"step ≤ 0"| K["[str(min)]"]
    J -->|"step > 0"| L["_grid_count(step)\n(capped at _MAX_RANGE_VALUES)"]
    L --> M["ndigits = _grid_ndigits()"]
    M --> N["str(round(min + i*step, ndigits))\nfor i in range(count)"]

    O["option_count()"] -->|"step ≤ 0"| P["return 1"]
    O -->|"step > 0"| Q["_grid_count(step)"]

    R["HonCommand._more_options"] -->|"second.option_count()\n> first.option_count()"| S["return second"]
    R -->|else| T["return first"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["range: cap grid epsilon, arithmetic opti..."](https://github.com/tis24dev/addhon/commit/17b177367af29082e427e9591c6d5cf124fc9505) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41229320)</sub>

<!-- /greptile_comment -->