### PR TITLE
fix(transport): auth / retry / MQTT hardening from v5.7.1 review

### DIFF
--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -87,13 +87,11 @@ class NativeHon:
 
     @property
     def appliances(self) -> list[Any]:
+        # Read-only on purpose: no setter. The MQTT client binds this list by
+        # reference at __init__, so the inventory is mutated IN PLACE (setup()
+        # clears + appends) and never rebound -- a `session.appliances = [...]`
+        # would swap the object out from under the live subscriptions.
         return self._appliances
-
-    @appliances.setter
-    def appliances(self, appliances: list[Any]) -> None:
-        # NB: the MQTT client binds the list by reference at __init__. Do not rebind
-        # after MQTT is started, or the subscriptions would not see the new list.
-        self._appliances = appliances
 
     async def create(self) -> "NativeHon":
         try:

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -207,6 +207,13 @@ class NativeHon:
         self._appliances.append(appliance)
 
     async def setup(self) -> None:
+        # Drop any partial inventory from an earlier setup() that a mid-setup MFA
+        # challenge interrupted: submit_mfa_code() resumes by calling setup() again, and
+        # without this the appliances built before the challenge would be appended a
+        # second time -- duplicate appliance objects, each updated every poll (the
+        # coordinator dedupes by id, so no double entities, just wasted work). Clear
+        # IN PLACE, never rebind: the MQTT client binds this list by reference.
+        self._appliances.clear()
         self._setup_phase = "load_appliances"
         appliances = await self.api.load_appliances()
         self._setup_phase = "load_appliance"

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -438,7 +438,12 @@ class HonAuth:
             "grant_type": "refresh_token",
         }
         async with self._session.post(
-            f"{AUTH_API}/services/oauth2/token", params=params, headers=self._ua()
+            # Send the refresh_token in the FORM BODY (data=), not the query string
+            # (params=). With params= it lands in the request URL, where it leaks into
+            # proxy/access logs and aiohttp exception reprs (request_info.real_url). The
+            # OAuth2 token endpoint expects application/x-www-form-urlencoded; Salesforce
+            # accepts both, and a dict passed as data= is form-encoded into the body.
+            f"{AUTH_API}/services/oauth2/token", data=params, headers=self._ua()
         ) as resp:
             if resp.status >= 400:
                 return False

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import aiohttp
 
+from ...error_codes import DECODE_ERROR
 from .auth import HonAuth, NativeAuthError
 from .device import HonDevice
 from .headers import build_auth_headers
@@ -163,12 +164,19 @@ class HonConnection:
         # that may get rejected, not one a sibling rotated to meanwhile.
         refresh_gen = self._refresh_gen
         async with method(url, *args, **kwargs) as response:
-            if (self.auth.token_expires_soon or response.status in (401, 403)) and loop == 0:
-                _LOGGER.info("addhOn: token expiring/%s, refresh", response.status)
+            # Replay ONLY on a real rejection (401/403). The old condition also
+            # replayed on token_expires_soon/token_is_expired -- but then a *successful*
+            # 200 got discarded and re-sent whenever the pre-refresh in _check_headers
+            # had failed silently (refresh() -> False leaves _expires stale, so the
+            # flag stays True for the whole period). For a POST /commands/v1/send that
+            # means the command is delivered TWICE. Token expiry is already handled
+            # BEFORE the request in _check_headers; here we only recover a rejection.
+            if response.status in (401, 403) and loop == 0:
+                _LOGGER.info("addhOn: rejected (%s), refresh+retry", response.status)
                 await self._refresh_after_rejection(refresh_gen)
                 async with self._intercept(method, url, *args, loop=1, **kwargs) as result:
                     yield result
-            elif (self.auth.token_is_expired or response.status in (401, 403)) and loop == 1:
+            elif response.status in (401, 403) and loop == 1:
                 _LOGGER.warning("addhOn: re-auth after %s", response.status)
                 await self.create()
                 async with self._intercept(method, url, *args, loop=2, **kwargs) as result:
@@ -182,6 +190,16 @@ class HonConnection:
                 # discarding a successful recovery).
                 raise NativeAuthError(f"Login failure (status {response.status})")
             else:
+                # A 5xx / 429 with a JSON body would otherwise decode cleanly here and
+                # be delivered as "success" (api.py then extracts {} -> empty attributes,
+                # an empty AWS token, no error). Raise a transient, NON-auth error that
+                # carries the status, so _is_retryable_server_error and classify() route
+                # it to the 3-attempt backoff in async_get_appliances_data (which was
+                # effectively dead code for real server errors before). Deliberately a
+                # RuntimeError, NOT a NativeAuthError: no "auth" in the class name keeps
+                # the routing transient.
+                if response.status >= 500 or response.status == 429:
+                    raise RuntimeError(f"hOn server error (status {response.status})")
                 # Force a decode-check before yielding.
                 # content_type=None: DELIBERATE (consistent with auth.py); it tolerates
                 # a non-JSON content-type but a valid JSON body (Salesforce sometimes does this);
@@ -190,7 +208,16 @@ class HonConnection:
                     await response.json(content_type=None)
                     yield response
                 except (json.JSONDecodeError, aiohttp.ContentTypeError) as exc:
-                    raise NativeAuthError("Decode Error") from exc
+                    # A non-JSON body (HTML maintenance/CDN page, Cloudflare challenge,
+                    # captive portal) is a TRANSIENT cloud hiccup, not bad credentials.
+                    # Attach the existing DECODE_ERROR code (requires_reauth=False) so the
+                    # duck-typed _requires_reauth routes it as UpdateFailed (the coordinator
+                    # retries) instead of opening a spurious reauth -- and, with 2FA on,
+                    # prompting the user for a new OTP. Aligns the routing with classify(),
+                    # which already maps "decode error" -> DECODE_ERROR (ADDHON-470).
+                    err = NativeAuthError(f"Decode Error (status {response.status})")
+                    err.error_code = DECODE_ERROR
+                    raise err from exc
 
     @asynccontextmanager
     async def get(self, *args: Any, **kwargs: Any) -> AsyncIterator[aiohttp.ClientResponse]:

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -207,7 +207,12 @@ class HonConnection:
                 # effectively dead code for real server errors before). Deliberately a
                 # RuntimeError, NOT a NativeAuthError: no "auth" in the class name keeps
                 # the routing transient.
-                if response.status >= 500 or response.status == 429:
+                if response.status == 429:
+                    # 429 is a rate-limit, not a server fault: keep the "429" token so
+                    # classify() maps it to RATE_LIMITED and _is_retryable_server_error
+                    # still routes it to the backoff, but don't mislabel it "server error".
+                    raise RuntimeError("hOn rate limited (status 429)")
+                if response.status >= 500:
                     raise RuntimeError(f"hOn server error (status {response.status})")
                 # Force a decode-check before yielding.
                 # content_type=None: DELIBERATE (consistent with auth.py); it tolerates

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -121,9 +121,14 @@ class HonConnection:
         if _need_refresh() or _need_auth():
             async with self._refresh_lock:
                 if _need_refresh():
-                    await self.auth.refresh(self._refresh_token)
-                    self._refresh_token = self.auth.refresh_token
-                    self._refresh_gen += 1
+                    # Advance the generation ONLY on a real refresh (CR#3/finding 5).
+                    # refresh() returns False without touching the tokens on a failed
+                    # refresh (token endpoint outage, consumed token). Bumping the gen
+                    # anyway would make a concurrent 401-retry sibling believe a fresh
+                    # token exists and SKIP its own refresh, reusing stale tokens.
+                    if await self.auth.refresh(self._refresh_token):
+                        self._refresh_token = self.auth.refresh_token
+                        self._refresh_gen += 1
                 if _need_auth():
                     await self.auth.authenticate()
                     self._refresh_token = self.auth.refresh_token
@@ -148,9 +153,13 @@ class HonConnection:
         async with self._refresh_lock:
             if self._refresh_gen != gen_at_send:
                 return  # a sibling already refreshed; reuse its fresh tokens
-            await self.auth.refresh(self._refresh_token)
-            self._refresh_token = self.auth.refresh_token
-            self._refresh_gen += 1
+            # Advance the generation ONLY on success (finding 5): a failed refresh()
+            # returns False leaving the stale tokens in place. Bumping regardless would
+            # let a concurrent sibling skip its own refresh and reuse tokens that were
+            # never actually rotated -- guaranteeing its next request 401s too.
+            if await self.auth.refresh(self._refresh_token):
+                self._refresh_token = self.auth.refresh_token
+                self._refresh_gen += 1
 
     @asynccontextmanager
     async def _intercept(

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -470,6 +470,13 @@ class NativeMqttClient:
         for topic in self._all_topics():
             if topic in self._subscribed_topics_set:
                 continue
+            # Snapshot the set identity BEFORE the await. If a disconnect + awscrt
+            # auto-reconnect (SAME generation, so no _start()) fires while this SUBACK
+            # is in flight, the lifecycle handlers rebind _subscribed_topics_set to a
+            # fresh empty set (the reconnected session carries no subscriptions). The
+            # reconnect flips _connection back to True, so the watchdog's post-await
+            # guard sees "healthy" and cannot catch it -- only this identity check can.
+            ref = self._subscribed_topics_set
             try:
                 await self._subscribe_topic(topic)
             except asyncio.CancelledError:
@@ -487,7 +494,12 @@ class NativeMqttClient:
                     "MQTT: subscribe failed for one topic, continuing: %s", err
                 )
                 continue
-            self._subscribed_topics_set.add(topic)
+            # Commit only if the session that ACKed is still the current one: an identity
+            # mismatch means a reconnect rebound the set mid-await and this SUBACK belongs
+            # to a session that has since dropped its subscriptions. Skip; the next
+            # watchdog tick re-subscribes the topic on the fresh (empty) set.
+            if self._subscribed_topics_set is ref:
+                ref.add(topic)
 
     # Thin compatibility wrappers over the per-topic primitives above. _subscribe_missing
     # is the path used by create()/the watchdog; these keep the per-appliance call shape

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -709,6 +709,20 @@ class HonClient:
                         _LOGGER.debug("Fallback OK: %s", method_name)
                         _debug_appliance_consumption(f"after {method_name}", appliance)
                     except Exception as err:
+                        # Match the primary update() path (see the load_statistics guard
+                        # above): a failed load_statistics is non-fatal -- it only carries
+                        # the consumption counters -- UNLESS it is an auth/retryable error
+                        # the caller must act on. Without this, a single stats hiccup made
+                        # the WHOLE appliance unavailable in the fallback path while the
+                        # primary path tolerated it (inconsistent). load_attributes and
+                        # load_commands stay fatal: that IS the appliance's data.
+                        if method_name == "load_statistics" and not (
+                            _requires_reauth(err) or _is_retryable_server_error(err)
+                        ):
+                            _LOGGER.debug(
+                                "Fallback load_statistics tolerated (non-auth): %s", err
+                            )
+                            continue
                         _LOGGER.debug("Fallback %s failed: %s", method_name, err)
                         raise RuntimeError(f"Fallback {method_name} failed: {err}") from err
 

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -89,6 +89,73 @@ def _client(appliances=None):
     return c
 
 
+class _FallbackAppliance:
+    """No update() attribute -> _do_update takes the load_* fallback path directly.
+    Records which loads ran; load_statistics can be made to raise a chosen error."""
+
+    def __init__(self, stats_error=None) -> None:
+        self.unique_id = "APP-1"
+        self.attributes = {"parameters": {}}
+        self.settings: dict = {}
+        self.statistics: dict = {}
+        self._stats_error = stats_error
+        self.calls: list[str] = []
+
+    async def load_attributes(self) -> None:
+        self.calls.append("load_attributes")
+
+    async def load_commands(self) -> None:
+        self.calls.append("load_commands")
+
+    async def load_statistics(self) -> None:
+        self.calls.append("load_statistics")
+        if self._stats_error is not None:
+            raise self._stats_error
+
+
+class FallbackLoadStatisticsToleranceTest(unittest.TestCase):
+    """Finding 7: in the load_* FALLBACK path a failed load_statistics (consumption
+    counters only) must be tolerated for non-auth/non-retryable errors -- exactly like
+    the primary update() path -- instead of failing the whole appliance. Auth and
+    retryable errors still propagate so reauth/backoff can act on them."""
+
+    def _client_running(self) -> HonClient:
+        c = HonClient(email="e@x", password="p")
+        # Run _do_update inline instead of on the dedicated loop.
+        c._run_on_hon_loop = lambda coro: asyncio.run(coro)  # type: ignore[assignment]
+        return c
+
+    def test_non_auth_load_statistics_failure_is_tolerated(self) -> None:
+        app = _FallbackAppliance(stats_error=ValueError("stats parse boom"))
+        c = self._client_running()
+        c._update_appliance_sync(app)  # must NOT raise: attrs+commands loaded
+        self.assertEqual(app.calls, ["load_attributes", "load_commands", "load_statistics"])
+
+    def test_retryable_load_statistics_failure_still_raises(self) -> None:
+        app = _FallbackAppliance(stats_error=TimeoutError())
+        c = self._client_running()
+        with self.assertRaises(RuntimeError):
+            c._update_appliance_sync(app)
+
+    def test_auth_load_statistics_failure_still_raises(self) -> None:
+        app = _FallbackAppliance(stats_error=RuntimeError("401 unauthorized"))
+        c = self._client_running()
+        with self.assertRaises(RuntimeError):
+            c._update_appliance_sync(app)
+
+    def test_load_attributes_failure_is_still_fatal(self) -> None:
+        # Regression guard: the tolerance is load_statistics-only. A broken
+        # load_attributes (the real data) must still fail the appliance.
+        class _BadAttrs(_FallbackAppliance):
+            async def load_attributes(self) -> None:
+                self.calls.append("load_attributes")
+                raise ValueError("attrs boom")
+
+        c = self._client_running()
+        with self.assertRaises(RuntimeError):
+            c._update_appliance_sync(_BadAttrs())
+
+
 class HonClientRealtimeTest(unittest.TestCase):
     def test_subscribe_updates_forwarded(self) -> None:
         c = _client()

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -211,6 +211,25 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.events.count("mqtt"), 1)
         self.assertEqual(len(h.mqtt_calls), 1)
 
+    def test_setup_twice_does_not_duplicate_appliances(self) -> None:
+        # Finding 9: a mid-setup MFA challenge makes submit_mfa_code() resume by calling
+        # setup() again. setup() must clear the (possibly partial) inventory first, or the
+        # appliances loaded before the challenge get appended a second time -> duplicates.
+        data = [
+            {"macAddress": "A", "applianceTypeName": "REF"},
+            {"macAddress": "B", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        first = nh.appliances  # the list object; must be cleared in place, not rebound
+        _run(nh.setup())
+        _run(nh.setup())
+        # No duplicates across the two setups.
+        self.assertEqual([a.mac_address for a in nh.appliances], ["A", "B"])
+        # Cleared IN PLACE (same object) -- the MQTT client holds this list by reference.
+        self.assertIs(nh.appliances, first)
+
     def test_mixed_zoned_and_normal_ordering(self) -> None:
         # a multi-zone appliance followed by a normal one: zone1,zone2,base(0) then normal(0),
         # all loaded BEFORE mqtt (which is last).

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -300,6 +300,36 @@ class RefreshTest(unittest.TestCase):
         auth = self._auth([FakeResp(status=400)])
         self.assertFalse(asyncio.run(auth.refresh()))
 
+    def test_refresh_sends_token_in_body_not_query_string(self) -> None:
+        # Finding 8: the refresh_token must be sent in the FORM BODY (data=), not the
+        # query string (params=), where it would leak into proxy/access logs and
+        # aiohttp exception reprs (request_info.real_url).
+        class CapturingSession(FakeSession):
+            def __init__(self, responses) -> None:
+                super().__init__(responses)
+                self.post_kwargs: list = []
+
+            def post(self, url, **kw):
+                self.post_kwargs.append((str(url), kw))
+                return self._next("POST", url)
+
+        sess = CapturingSession([
+            FakeResp(json={"id_token": "I", "access_token": "A", "refresh_token": "NEWRT"}),
+            FakeResp(json={"cognitoUser": {"Token": "COG"}}),  # _api_auth
+        ])
+        auth = HonAuth(sess, "user@x.it", "pw", HonDevice())
+        auth.refresh_token = "SECRET-RT"
+
+        self.assertTrue(asyncio.run(auth.refresh()))
+
+        token_posts = [kw for url, kw in sess.post_kwargs if "oauth2/token" in url]
+        self.assertEqual(len(token_posts), 1)
+        kw = token_posts[0]
+        self.assertNotIn("params", kw)              # NOT in the URL
+        self.assertIn("data", kw)                   # in the form body
+        self.assertEqual(kw["data"]["refresh_token"], "SECRET-RT")
+        self.assertEqual(kw["data"]["grant_type"], "refresh_token")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -516,6 +516,45 @@ class RetryRefreshSingleFlightTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertGreaterEqual(auth.refresh_calls, 2)  # loop0 retry + loop1 pre-request
 
+    def test_failed_retry_refresh_does_not_advance_generation(self) -> None:
+        # Finding 5: a retry refresh() that returns False (endpoint outage, tokens left
+        # untouched) must NOT advance _refresh_gen. Otherwise a concurrent sibling reads
+        # the bumped generation and SKIPS its own refresh, reusing never-refreshed tokens.
+        class FailingRefreshAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                return False  # tokens deliberately left as-is
+
+        auth = FailingRefreshAuth()
+        auth.cognito_token, auth.id_token, auth.refresh_token = "C", "I", "RT"
+        conn = _conn(auth, FakeSession([]))
+        conn._refresh_token = "RT"
+        conn._refresh_gen = 5
+
+        asyncio.run(conn._refresh_after_rejection(5))  # gen matches -> attempt
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(conn._refresh_gen, 5)       # NOT advanced on failure
+        self.assertEqual(conn._refresh_token, "RT")  # untouched
+
+    def test_failed_pre_request_refresh_does_not_advance_generation(self) -> None:
+        # Same invariant on the pre-request path (_check_headers): a failed refresh must
+        # not bump the generation, so a concurrent 401-retry sibling still refreshes.
+        class FailingRefreshAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                return False
+
+        auth = FailingRefreshAuth()
+        auth.cognito_token, auth.id_token = "C", "I"  # present but near expiry
+        auth.token_expires_soon = True
+        conn = _conn(auth, FakeSession([]))
+        conn._refresh_token = "RT"
+        conn._refresh_gen = 0
+
+        asyncio.run(conn._check_headers({}))
+        self.assertEqual(auth.refresh_calls, 1)
+        self.assertEqual(conn._refresh_gen, 0)  # failed refresh -> no bump
+
     def test_double_check_skips_when_gen_advanced(self) -> None:
         # Directly: if a sibling already refreshed since this request was sent (the
         # generation advanced), _refresh_after_rejection must NOT refresh again.

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -8,6 +8,7 @@ live-validated.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import types
 import unittest
@@ -61,6 +62,7 @@ _install_stubs()
 
 from custom_components.addhon.client.transport.connection import HonConnection  # noqa: E402
 from custom_components.addhon.client.transport.auth import NativeAuthError  # noqa: E402
+from custom_components.addhon.error_codes import DECODE_ERROR  # noqa: E402
 
 
 class FakeAuth:
@@ -540,6 +542,101 @@ class RetryRefreshSingleFlightTest(unittest.TestCase):
         self.assertEqual(auth.refresh_calls, 1)
         self.assertEqual(conn._refresh_token, "RT2")   # rotated + copied back
         self.assertEqual(conn._refresh_gen, 6)         # generation bumped
+
+
+class InterceptCloudErrorRoutingTest(unittest.TestCase):
+    """Findings 1-3: a transient cloud fault must not be delivered as success nor
+    mis-routed to reauth. (a) a non-JSON body carries DECODE_ERROR (transient, NOT
+    reauth); (b) a 5xx/429 raises a retryable server error instead of decoding an
+    error page as data; (c) a *successful* 200 is never replayed just because the
+    token looks like it is expiring (a re-sent POST would fire the command twice)."""
+
+    def test_non_json_body_carries_decode_error_code(self) -> None:
+        # A 200 carrying an HTML maintenance/CDN page: json() raises -> the decode
+        # branch must attach DECODE_ERROR so routing stays transient, not reauth.
+        class HtmlResp(FakeResp):
+            async def json(self, content_type=None):
+                raise json.JSONDecodeError("Expecting value", "<html>oops</html>", 0)
+
+        class HtmlSession(FakeSession):
+            def _resp(self, url, **kw):
+                self.calls.append(kw.get("headers", {}))
+                return HtmlResp(200)
+
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, HtmlSession([]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        with self.assertRaises(NativeAuthError) as ctx:
+            asyncio.run(run())
+        # The carried code is what _requires_reauth (duck-typed) reads: requires_reauth
+        # is False -> UpdateFailed (coordinator retries), NO reauth/2FA prompt.
+        self.assertIs(ctx.exception.error_code, DECODE_ERROR)
+        self.assertFalse(DECODE_ERROR.requires_reauth)
+        self.assertEqual(auth.authenticate_calls, 0)  # no spurious full re-login
+
+    def test_5xx_json_body_raises_retryable_not_success(self) -> None:
+        # A 502 whose body decodes as JSON must NOT be yielded as a good response
+        # (that produced silent empty attrs / empty AWS token before).
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([502]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(run())
+        self.assertIn("502", str(ctx.exception))
+        # NOT a NativeAuthError: no "auth" in the class name -> routed as retryable.
+        self.assertNotIsInstance(ctx.exception, NativeAuthError)
+
+    def test_429_raises_retryable(self) -> None:
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([429]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(run())
+        self.assertIn("429", str(ctx.exception))
+
+    def test_successful_200_not_replayed_on_sticky_expiry(self) -> None:
+        # Finding 2: refresh() "succeeds" but leaves the expiry flag set (models the
+        # real bug -- a silent refresh failure leaves _expires stale). A 200 must be
+        # returned as-is, NOT discarded and re-sent. The OLD condition replayed it
+        # (2 requests); re-sending a POST /commands/v1/send fires the command twice.
+        class StickyAuth(FakeAuth):
+            async def refresh(self, rt: str = "") -> bool:
+                self.refresh_calls += 1
+                self.cognito_token, self.id_token, self.refresh_token = "C2", "I2", "RT2"
+                self.token_expires_soon = True  # stays True (stale _expires)
+                return True
+
+        auth = StickyAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        auth.token_expires_soon = True
+        conn = _conn(auth, FakeSession([200, 200]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.post("https://x/api") as resp:
+                return resp.status
+
+        status = asyncio.run(run())
+        self.assertEqual(status, 200)
+        self.assertEqual(len(conn._session.calls), 1)  # sent once, not replayed
 
 
 class ConnectionCreateCleanupTest(unittest.TestCase):

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -1985,5 +1985,39 @@ class WatchdogDisconnectMidSubscribeClearsSetTest(unittest.TestCase):
         self.assertEqual(len(rebuilds), 0)          # one tick: no rebuild yet
 
 
+class SubscribeMissingRebindRaceTest(unittest.TestCase):
+    """Finding 6: a disconnect + awscrt auto-reconnect (SAME generation) that rebinds
+    _subscribed_topics_set WHILE a SUBACK is in flight must NOT let the topic be
+    committed to the fresh set. Committing it marks a topic 'subscribed' on a session
+    that never subscribed it -> the watchdog sees healthy and never re-subscribes ->
+    dead push for that topic. The reconnect restores _connection=True, so the
+    watchdog's outer post-await guard cannot catch it; only the in-place identity
+    check inside _subscribe_missing can."""
+
+    def test_rebind_during_suback_is_not_committed(self) -> None:
+        app = MultiTopicAppliance(["t/x"])
+        m = NativeMqttClient(FakeHon([app]), "MID")
+        m._generation = 1
+        m._connection = True
+
+        async def subscribe_then_reconnect(_topic):
+            # SUBACK in flight: a disconnect rebinds the set to a fresh empty one, then
+            # an auto-reconnect on the SAME generation flips _connection back to True.
+            m._on_lifecycle_disconnection(None, generation=1)       # rebinds set -> S2
+            m._on_lifecycle_connection_success(None, generation=1)  # _connection=True
+            # await returns: the OLD session's SUBACK finally lands.
+
+        m._subscribe_topic = subscribe_then_reconnect  # type: ignore[assignment]
+
+        _run(m._subscribe_missing())
+
+        # The topic was NOT committed to the rebound set (OLD code did add it):
+        self.assertEqual(m._subscribed_topics_set, set())
+        self.assertNotIn("t/x", m._subscribed_topics_set)
+        # Reconnected -> the watchdog's outer guard would (wrongly) trust the set; the
+        # fix is what keeps the topic pending so the next tick re-subscribes it.
+        self.assertTrue(m._connection)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes six transport-layer bugs identified in a cross-review of v5.7.1, covering auth error mis-routing, double command delivery, silent 5xx pass-through, refresh-generation accounting, MQTT subscription races, and inventory duplication on MFA-resumed setup.

- **Findings 1–3 (`connection.py` `_intercept`)**: Non-JSON (HTML) 200s now carry `DECODE_ERROR` so `_requires_reauth` returns False and the coordinator retries rather than prompting a 2FA re-entry; 5xx/429 responses are now raised as `RuntimeError` before the JSON decode so the 3-attempt backoff is no longer dead code; the replay-on-rejection condition is narrowed to real 401/403 rejections, preventing a successful POST from being sent twice when `token_expires_soon` is stuck True.
- **Finding 5 (`_check_headers` / `_refresh_after_rejection`)**: `_refresh_gen` is now advanced only on a successful `refresh()`, so a failed refresh no longer lets concurrent siblings skip their own refresh by trusting a falsely-bumped generation counter.
- **Finding 6 (`mqtt.py` `_subscribe_missing`)**: The subscribed-topics set identity is snapshotted before the `await`; a topic ACKed by a dropped session is no longer committed to the fresh empty set that a same-generation auto-reconnect created mid-SUBACK.
- **Finding 7 (`hon_client.py`)**: The fallback `load_*` path now tolerates a non-auth/non-retryable `load_statistics` failure, matching the primary `update()` path's existing behavior.
- **Finding 9 (`session.py`)**: `setup()` clears `_appliances` in-place before loading, preventing duplicates when MFA causes `setup()` to be called a second time. The `appliances` setter is removed since mutating the list in-place is the only safe operation given MQTT's by-reference binding.
- **Finding 8 (`auth.py`)**: `refresh_token` is now sent in the form body (`data=`) instead of the query string (`params=`), keeping it out of proxy logs and aiohttp exception representations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all six targeted bugs have targeted fixes with dedicated regression tests, and no new paths are introduced without coverage.

Each fix is narrow and self-contained: the error-routing changes are validated end-to-end against the existing _requires_reauth / classify() chain, the gen-counter fix is covered by two independent test cases (pre-request and rejection paths), the MQTT race fix correctly uses object identity rather than value equality to detect mid-await rebinds, and the session clear is verified to operate in-place. No pre-existing invariants are broken and no new failure modes are opened.

No files require special attention — the most complex change (_intercept in connection.py) is thoroughly commented and covered by tests for every new branch.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/transport/connection.py | Three correctness fixes in `_intercept` (non-JSON → DECODE_ERROR, double-POST on token_expires_soon, silent 5xx delivery) and one in `_refresh_after_rejection`/`_check_headers` (gen bump only on successful refresh). All routing paths verified against `_requires_reauth` / `classify()` logic. |
| custom_components/addhon/client/transport/auth.py | Single-line change: `params=` → `data=` on the OAuth2 token POST, moving the `refresh_token` from the URL query string into the form body. `_ua()` sets no Content-Type, so aiohttp's automatic `application/x-www-form-urlencoded` header is uncontested. |
| custom_components/addhon/client/transport/mqtt.py | Snapshot-before-await identity guard in `_subscribe_missing`: a SUBACK from a dropped session is not committed to the fresh set created by the same-generation auto-reconnect. The `ref.add(topic)` path is equivalent to the original `self._subscribed_topics_set.add(topic)` when the identity check passes. |
| custom_components/addhon/hon_client.py | Non-auth `load_statistics` failures in the fallback path are now tolerated (matching the primary `update()` path), while auth/retryable errors still propagate. The `loaded` flag is already True from prior successful loads, so the `if not loaded:` guard is unaffected. |
| custom_components/addhon/client/session.py | Adds `_appliances.clear()` at the top of `setup()` (in-place, preserving MQTT's by-reference binding) and removes the `appliances` setter to enforce the in-place-only contract. |
| tests/test_transport_connection.py | Adds 6 new test cases covering all three `_intercept` routing fixes and both refresh-generation paths. |
| tests/test_transport_mqtt.py | New `SubscribeMissingRebindRaceTest` faithfully simulates same-generation disconnect + reconnect mid-SUBACK, correctly verifying the set is empty after the race. |
| tests/test_hon_client_realtime.py | Adds `FallbackLoadStatisticsToleranceTest` with four cases covering non-auth tolerance, retryable/auth propagation, and the regression guard for `load_attributes`. |
| tests/test_native_session.py | New `test_setup_twice_does_not_duplicate_appliances` verifies both the no-duplication invariant and that the list is mutated in-place (same object identity). |
| tests/test_transport_auth.py | New `test_refresh_sends_token_in_body_not_query_string` captures POST kwargs and verifies the token is in `data`, not `params`. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_intercept: loop=0] --> B[_check_headers]
    B -->|refresh succeeds| C[gen bumped, fresh tokens]
    B -->|refresh fails| D[gen unchanged, stale tokens]
    C --> E[Send request]
    D --> E

    E --> F{response status}

    F -->|401 or 403, loop=0| G[_refresh_after_rejection]
    G -->|refresh succeeds| H[gen bumped]
    G -->|refresh fails| I[gen unchanged]
    H --> J[recurse loop=1]
    I --> J

    F -->|401 or 403, loop=1| K[create: full re-auth]
    K --> L[recurse loop=2]

    L --> M{still 401 or 403?}
    M -->|Yes| N[raise NativeAuthError Login failure]
    M -->|No| P

    F -->|429| Q[raise RuntimeError: rate limited]
    F -->|500 or above| R[raise RuntimeError: server error]
    F -->|2xx non-401/403| P{JSON decode?}

    P -->|OK| S[yield response]
    P -->|Fails: HTML or CDN page| T[NativeAuthError plus DECODE_ERROR requires_reauth=False coordinator retries via UpdateFailed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[_intercept: loop=0] --> B[_check_headers]
    B -->|refresh succeeds| C[gen bumped, fresh tokens]
    B -->|refresh fails| D[gen unchanged, stale tokens]
    C --> E[Send request]
    D --> E

    E --> F{response status}

    F -->|401 or 403, loop=0| G[_refresh_after_rejection]
    G -->|refresh succeeds| H[gen bumped]
    G -->|refresh fails| I[gen unchanged]
    H --> J[recurse loop=1]
    I --> J

    F -->|401 or 403, loop=1| K[create: full re-auth]
    K --> L[recurse loop=2]

    L --> M{still 401 or 403?}
    M -->|Yes| N[raise NativeAuthError Login failure]
    M -->|No| P

    F -->|429| Q[raise RuntimeError: rate limited]
    F -->|500 or above| R[raise RuntimeError: server error]
    F -->|2xx non-401/403| P{JSON decode?}

    P -->|OK| S[yield response]
    P -->|Fails: HTML or CDN page| T[NativeAuthError plus DECODE_ERROR requires_reauth=False coordinator retries via UpdateFailed]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `custom_components/addhon/client/transport/connection.py`, line 193-200 ([link](https://github.com/tis24dev/addhon/blob/e0ad6827be9d624fa8ef257610796630e7bf1cbc/custom_components/addhon/client/transport/connection.py#L193-L200)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **loop >= 2 branch can shadow the new 5xx guard on the error message**

   The new `if response.status >= 500` check lives in the `else` branch, but `elif loop >= 2 and (self.auth.token_is_expired or response.status in (401, 403))` is evaluated first. If `token_is_expired` is True at loop 2 and the server returns 5xx, this branch fires and emits `NativeAuthError("Login failure (status 502)")` rather than the cleaner `RuntimeError` from the 5xx guard. The routing is still correct — `_is_retryable_server_error` matches "500"/"502"/"server error" in the message, so `_requires_reauth` returns False — but the log line reads "Login failure" for what is a server-side fault, which can mislead log analysis.

   In practice `token_is_expired` should be False immediately after `create()` (which initialises `_expires = now`), so this is an edge case. Worth keeping in mind if the loop-2 condition is ever revisited.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(transport): label a 429 as rate-limi..."](https://github.com/tis24dev/addhon/commit/131d0885aa04f6934a4f97a4eadd3ecb6fa4a1d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41849629)</sub>

<!-- /greptile_comment -->