### PR TITLE
fix: bug-fix batch from dev review

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -186,17 +186,46 @@ def _apply_debug_options(entry: ConfigEntry, *, reset_when_off: bool = True) -> 
         silence_mqtt_noise()
 
 
+_DEBUG_OPTS_KEY = "debug_options"
+
+
+def _debug_opts(entry: ConfigEntry) -> tuple[bool, bool]:
+    """Current (integration-debug, mqtt-debug) toggles for the entry."""
+    return (
+        entry.options.get(CONF_ENABLE_DEBUG, False),
+        entry.options.get(CONF_ENABLE_MQTT_DEBUG, False),
+    )
+
+
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Re-apply the log levels on the fly when the toggles change (no reload).
 
     A reload would tear down auth and the MQTT channel just to change a log level;
     here we re-apply the levels on the fly, as the existing services do.
+
+    HA fires update listeners on ANY entry change (data, options, title), not only
+    on an options change. A data-only write -- e.g. _persist_refresh_token rotating
+    the OAuth refresh token during a routine poll -- must NOT re-apply/reset the
+    debug levels: that would silently kill a debug level raised at runtime via the
+    set_log_level / set_mqtt_log_level service (reset_when_off=True), exactly when the
+    logs are needed. So re-apply only when the debug toggles actually changed.
     """
+    current = _debug_opts(entry)
+    hass_data = getattr(hass, "data", None)
+    entry_data = (
+        hass_data.get(DOMAIN, {}).get(entry.entry_id)
+        if isinstance(hass_data, dict)
+        else None
+    )
+    if entry_data is not None:
+        if entry_data.get(_DEBUG_OPTS_KEY) == current:
+            return  # entry changed but the debug toggles didn't
+        entry_data[_DEBUG_OPTS_KEY] = current
     _LOGGER.debug(
         "Options debug: options updated entry=%s enable_debug=%s enable_mqtt_debug=%s",
         entry.entry_id,
-        entry.options.get(CONF_ENABLE_DEBUG, False),
-        entry.options.get(CONF_ENABLE_MQTT_DEBUG, False),
+        current[0],
+        current[1],
     )
     _apply_debug_options(entry)
 
@@ -530,6 +559,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "coordinator": coordinator,
             "client": hon_client,
             "integration_version": integration_version,
+            # Baseline for _async_options_updated: the toggles already applied at the
+            # start of setup, so a later data-only entry write (token rotation) is a
+            # no-op and only a real options change re-applies the levels.
+            _DEBUG_OPTS_KEY: _debug_opts(entry),
         }
         stored = True
         _LOGGER.debug("Setup debug: coordinator and client stored in hass.data for entry=%s", entry.entry_id)

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -164,7 +164,19 @@ class HonBaseEntity(CoordinatorEntity):
         NB: the connectivity binary_sensor excludes the `available` gate (it must
         stay available to signal 'disconnected'): it uses `_present` directly.
         """
-        return self._present and bool(self._attributes.get("available", True))
+        # Short-circuit on _present FIRST: it guards coordinator.data being a dict, so
+        # _get_attr below (which reads coordinator.data) is never reached when the data
+        # is missing/None.
+        if not self._present:
+            return False
+        # Read `available` through _get_attr so it shares the same normalization as
+        # every other attribute read: a raw `.get(...)` + bool() would report a
+        # disconnected device as available if `available` ever arrived wrapped in a
+        # HonAttribute (an object is always truthy) or as a "false"/"0" string.
+        available = self._get_attr("available", True)
+        if isinstance(available, str):
+            available = available.strip().lower() not in ("false", "0", "no", "off", "")
+        return bool(available)
 
     @property
     def _present(self) -> bool:

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -321,7 +321,8 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[BinarySensorEntity] = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})
         attributes = attributes if isinstance(attributes, dict) else {}

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -151,6 +151,31 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             redact_store(store),
             command_names(appliance),
         )
+        # Rollback state for a failed send: applying the pending program both mutates
+        # the program parameter AND swaps appliance.commands[name] to the selected
+        # category. Populated inside _inner BEFORE the mutation and consumed by the
+        # except below, so a send failure does not leave the appliance pointing at a
+        # program/command the cloud never accepted (which would otherwise skew the
+        # per-program option ranges until the next poll self-heals it). Mirrors the
+        # snapshot/restore in hon_commands.async_send_command.
+        rollback: dict = {}
+
+        def _snapshot_params(ps):
+            if not isinstance(ps, dict):
+                return {}
+            return {k: dict(p.__dict__) for k, p in ps.items() if hasattr(p, "__dict__")}
+
+        def _restore_params(ps, snap):
+            if not isinstance(ps, dict):
+                return
+            for key, saved in snap.items():
+                param = ps.get(key)
+                if param is not None and hasattr(param, "__dict__"):
+                    # Restore via __dict__ (not the setter) so rules are not re-fired
+                    # and values/min/max are restored too.
+                    param.__dict__.clear()
+                    param.__dict__.update(saved)
+
         try:
             def _do():
                 async def _inner():
@@ -163,6 +188,11 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             f"Available: {list(commands.keys())}"
                         )
                     params = getattr(command, "parameters", {})
+                    # Record the pre-swap state so a failed send can be fully rolled back.
+                    rollback["commands"] = commands
+                    rollback["name"] = self._command_name
+                    rollback["original_command"] = command
+                    rollback["snapshots"] = [(params, _snapshot_params(params))]
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug(
                             "Button debug: before command '%s' params=%s",
@@ -211,6 +241,9 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                         )
                         command = refreshed
                         params = getattr(command, "parameters", {})
+                        # Snapshot the post-swap command's params too, so options/fixed
+                        # applied below are rolled back with the swap on a send failure.
+                        rollback["snapshots"].append((params, _snapshot_params(params)))
                     # (b) Apply the buffered program options to the POST-SWAP command
                     # (#35): selecting the program swaps the active startProgram command,
                     # so the options must land on the new one. apply_pending_options skips
@@ -249,6 +282,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             param_snapshot(params),
                         )
                     await command.send()
+                    rollback.clear()  # sent: nothing to roll back
                     _LOGGER.debug("Button debug: command '%s' send completed", self._command_name)
 
                 client.run_command_sync(_inner())
@@ -285,6 +319,16 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             _LOGGER.info("Button: command '%s' sent", self._command_name)
             await self._async_request_command_refresh()
         except Exception as err:
+            # Roll back the command swap + parameter mutations left by a failed send,
+            # so the appliance does not keep pointing at a program the cloud rejected.
+            if rollback:
+                cmds = rollback.get("commands")
+                name = rollback.get("name")
+                original = rollback.get("original_command")
+                if isinstance(cmds, dict) and original is not None and cmds.get(name) is not original:
+                    cmds[name] = original
+                for ps, snap in reversed(rollback.get("snapshots", [])):
+                    _restore_params(ps, snap)
             _LOGGER.error(
                 "Button %s: command error: %s",
                 self._command_name, err, exc_info=True,

--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -126,7 +126,14 @@ class HonAppliance:
 
     @property
     def model_id(self) -> int:
-        return int(self._info.get("applianceModelId", 0))
+        # The `0` default only covers a MISSING key; a present-but-empty or
+        # non-numeric `applianceModelId` (seen on some payloads) would make
+        # int("") raise ValueError. model_id feeds the entity identity, so parse
+        # defensively and fall back to 0.
+        try:
+            return int(self._info.get("applianceModelId") or 0)
+        except (TypeError, ValueError):
+            return 0
 
     # --- state / data ---
     @property

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -74,6 +74,17 @@ class HonCommand:
         # rules act only on itself.
         for parameter in new._parameters.values():
             parameter.reset_triggers()
+            # A copied HonParameterProgram keeps its base back-references intact:
+            # `_command` points at the BASE command and its value-setter does
+            # `self._command.category = value` (which swaps `appliance.commands`).
+            # Rebind them to the copy so a write on the copy's program parameter can
+            # never reach the base command. The current favourite loader never hits
+            # this (the raw "PROGRAMS.X" value is not in the cleaned `.values`, so the
+            # setter raises a suppressed ValueError), but rebinding removes the latent
+            # back-door for good.
+            if isinstance(parameter, HonParameterProgram):
+                parameter._command = new
+                parameter._programs = new.categories
         new._rules = [ruleset.rebound(new) for ruleset in self._rules]
         return new
 

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -14,6 +14,7 @@ false "sent".
 """
 from __future__ import annotations
 
+from copy import copy
 from typing import Any, Optional, Union
 
 from .exceptions import ApiError, NoAuthenticationException
@@ -52,6 +53,20 @@ class HonCommand:
 
     def __repr__(self) -> str:
         return f"{self._name} command"
+
+    def __copy__(self) -> "HonCommand":
+        # `_add_favourites` (command_loader) does `copy(base)` and then MUTATES the
+        # copy's parameters (sets values, injects a `favourite` fixed, sets the program
+        # value). A default shallow copy shares the SAME `_parameters` dict AND the same
+        # parameter objects with the base program command (also reachable via
+        # `parent.categories`), so those mutations corrupt the base program: its values
+        # get overwritten, it gains `favourite="1"`, and it then disappears from
+        # `HonParameterProgram.ids` (which filters favourites out). Give each copy its own
+        # parameter dict with copied parameter objects so the base stays pristine.
+        new = self.__class__.__new__(self.__class__)
+        new.__dict__.update(self.__dict__)
+        new._parameters = {name: copy(param) for name, param in self._parameters.items()}
+        return new
 
     @property
     def name(self) -> str:

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -66,6 +66,15 @@ class HonCommand:
         new = self.__class__.__new__(self.__class__)
         new.__dict__.update(self.__dict__)
         new._parameters = {name: copy(param) for name, param in self._parameters.items()}
+        # A shallow-copied parameter still SHARES its `_triggers` table with the base, and
+        # every rule callback in it closes over THIS command -- so setting a value on the
+        # copy would fire rules that mutate the base's parameters (the exact corruption the
+        # `_parameters` isolation above prevents, via the trigger back-door). Give each
+        # copied param a fresh trigger table and rebind the rule sets to the copy, so its
+        # rules act only on itself.
+        for parameter in new._parameters.values():
+            parameter.reset_triggers()
+        new._rules = [ruleset.rebound(new) for ruleset in self._rules]
         return new
 
     @property

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -76,7 +76,11 @@ class HonParameter:
         return self._group
 
     def add_trigger(self, value: str, func: Callable[[Any], None], data: Any) -> None:
-        if self._value == value:
+        # Normalize both sides like `check_trigger` does: `_value` may be numeric
+        # (range/int) while the trigger value is always a string, so a raw `==`
+        # would miss `1 == "1"` and skip the immediate-fire for a param whose
+        # default already equals the trigger value.
+        if str(self._value).lower() == str(value).lower():
             func(data)
         self._triggers.setdefault(value, []).append((func, data))
 

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -110,5 +110,14 @@ class HonParameter:
                     param[rule.param_key] = rule.param_data.get("defaultValue", "")
         return result
 
+    def reset_triggers(self) -> None:
+        """Replace the trigger table with a fresh empty one.
+
+        Used by `HonCommand.__copy__`: a shallow-copied parameter shares this dict with the
+        original, whose rule callbacks close over the original command. Rebinding to a NEW
+        dict (not `.clear()`, which would empty the shared/original table) lets the copy's
+        rules be re-attached against the copy without touching the base."""
+        self._triggers = {}
+
     def reset(self) -> None:
         self._set_attributes()

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -244,9 +244,30 @@ class HonRuleSet:
 
     def patch(self) -> None:
         self._duplicate_for_extra_conditions()
+        self._attach_triggers()
+        self._apply_config_rules()
+
+    def _attach_triggers(self) -> None:
+        """Register every (already-expanded) rule as a trigger on its command's params."""
         for name, parameter in self._command.parameters.items():
             if name not in self._rules:
                 continue
             for data in self._rules.get(name, []):
                 self._add_trigger(parameter, data)
-        self._apply_config_rules()
+
+    def rebound(self, command: Any) -> "HonRuleSet":
+        """A copy of this (already-expanded) rule set bound to `command`, with its
+        triggers attached to `command`'s parameters.
+
+        `HonCommand.__copy__` uses this: a shallow-copied command shares each parameter's
+        trigger table, and every rule callback closes over the ORIGINAL command -- so
+        setting a value on the copy (applying a favourite) would fire rules that mutate the
+        BASE command. `_duplicate_for_extra_conditions` is NOT re-run (self is already
+        expanded); HonRule entries are read-only in the apply path, so they are shared."""
+        new = HonRuleSet.__new__(HonRuleSet)
+        new._command = command
+        new._rules = {key: list(rules) for key, rules in self._rules.items()}
+        new._config_rules = list(self._config_rules)
+        new._attach_triggers()
+        new._apply_config_rules()
+        return new

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -23,12 +23,15 @@ rules are a cohesive cluster.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from .parameter.base import HonParameter
 from .parameter.enum import HonParameterEnum
 from .parameter.range import HonParameterRange
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -188,10 +191,26 @@ class HonRuleSet:
                 return
             if not (param := self._command.parameters.get(rule.param_key)):
                 return
-            if fixed_value := rule.param_data.get("fixedValue", ""):
-                self._apply_fixed(param, fixed_value)
-            elif rule.param_data.get("typology") == "enum":
-                self._apply_enum(param, rule)
+            try:
+                if fixed_value := rule.param_data.get("fixedValue", ""):
+                    self._apply_fixed(param, fixed_value)
+                elif rule.param_data.get("typology") == "enum":
+                    self._apply_enum(param, rule)
+            except (ValueError, TypeError) as err:
+                # A malformed rule (non-numeric or off-grid `fixedValue`, bad enum
+                # value) must NOT abort the whole appliance's command-load. The
+                # immediate-fire in `HonParameter.add_trigger` runs at construction
+                # time, so an escaping ValueError from `_apply_fixed` (e.g. float("x")
+                # or an off-step value rejected by the range setter) would fail setup
+                # for every entity of the device. Log and skip the bad rule instead;
+                # the runtime path already tolerates this via the entity write-path.
+                _LOGGER.debug(
+                    "addhOn: skipping unapplicable rule for '%s' (trigger %s=%s): %s",
+                    rule.param_key,
+                    rule.trigger_key,
+                    rule.trigger_value,
+                    err,
+                )
 
         parameter.add_trigger(data.trigger_value, apply, data)
 

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -15,6 +15,7 @@ import logging
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 from yarl import URL
 
@@ -490,7 +491,9 @@ class HonAuth:
         # fast-path with tokens that may no longer be valid. The previous
         # `AUTH_API.split("/")[-2]` was '' (AUTH_API has no trailing slash), so
         # clear_domain('') was a no-op and never cleared anything; use the real host.
-        auth_host = URL(AUTH_API).host
+        # urlsplit().netloc (stdlib) mirrors how oauth._AUTH_HOST is derived and, unlike
+        # yarl.URL(...).host, works under the CI's minimal URL stub (which has no .host).
+        auth_host = urlsplit(AUTH_API).netloc
         if auth_host:
             self._session.cookie_jar.clear_domain(auth_host)
         self.cognito_token = ""

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -173,7 +173,22 @@ class HonAuth:
             login_url = extract_login_url(text)
             if login_url is None:
                 if is_oauth_done(text):
-                    t = parse_token_fragment(text)
+                    # Append a trailing '&' so parse_token_fragment captures the LAST
+                    # fragment field too: its regex is `name=(.*?)&`, so a token at the
+                    # end without a trailing '&' (typically id_token) is dropped -> ""
+                    # -> _api_auth later fails with an empty id-token even though the SSO
+                    # cookies were valid. Then require .complete before committing the
+                    # tokens, mirroring _resume_tokens_after_2fa, instead of proceeding
+                    # with a half-parsed fragment.
+                    t = parse_token_fragment(text + "&")
+                    if not t.complete:
+                        self._phase(
+                            "introduce", status=resp.status,
+                            no_auth_needed=True, tokens_complete=False,
+                        )
+                        raise NativeAuthError(
+                            f"introduce: incomplete token fragment (status {resp.status})"
+                        )
                     self.access_token = t.access_token
                     self.refresh_token = t.refresh_token
                     self.id_token = t.id_token
@@ -470,10 +485,14 @@ class HonAuth:
         return True
 
     def clear(self) -> None:
-        # Note: `AUTH_API.split("/")[-2]` is '' here (not the host, because there is
-        # no trailing slash), so clear_domain('') is effectively a no-op on any
-        # session. This is intentional.
-        self._session.cookie_jar.clear_domain(AUTH_API.split("/")[-2])
+        # Clear the auth host's cookies so a REUSED session cannot carry a stale SSO
+        # cookie into the next login and send _introduce down the already-authorized
+        # fast-path with tokens that may no longer be valid. The previous
+        # `AUTH_API.split("/")[-2]` was '' (AUTH_API has no trailing slash), so
+        # clear_domain('') was a no-op and never cleared anything; use the real host.
+        auth_host = URL(AUTH_API).host
+        if auth_host:
+            self._session.cookie_jar.clear_domain(auth_host)
         self.cognito_token = ""
         self.id_token = ""
         self.access_token = ""

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -66,6 +66,14 @@ class HonConnection:
         # a concurrent burst collapses to a single refresh without gating on
         # token_expires_soon (a non-expiry 401 must still refresh once). See CR#3.
         self._refresh_gen = 0
+        # Single-flight the loop-1 re-auth even when it FAILS. If authenticate()
+        # raises (typically MFAChallengeRequired), the generation is still advanced
+        # and the exception cached against the generation that was rejected, so the
+        # other siblings of the burst reuse THIS error instead of each firing their
+        # own create()+authenticate() -- N sequential logins / OTP prompts on a 2FA
+        # account, exactly when the login is already failing.
+        self._reauth_error: BaseException | None = None
+        self._reauth_error_gen = -1
 
     @property
     def device(self) -> HonDevice:
@@ -176,9 +184,27 @@ class HonConnection:
         # keeps the whole re-login inside the lock so the burst collapses to exactly one.
         async with self._refresh_lock:
             if self._refresh_gen != gen_at_send:
+                # A sibling already ran the re-auth for this generation. If it FAILED
+                # (e.g. MFA), re-raise its cached error instead of recursing to loop 2
+                # -- where _check_headers would see the token-less auth create() left
+                # behind and fire our OWN login (another OTP). Collapsing the FAILING
+                # burst to one attempt is the whole point on a 2FA account.
+                if self._reauth_error is not None and self._reauth_error_gen == gen_at_send:
+                    raise self._reauth_error
                 return  # a sibling already re-authenticated; reuse its fresh tokens
-            await self.create()
-            await self.auth.authenticate()
+            try:
+                await self.create()
+                await self.auth.authenticate()
+            except BaseException as err:
+                # Advance the generation and cache the error so the siblings above
+                # skip their own login and reuse this one. create() has already reset
+                # self._auth to a token-less HonAuth, so leaving the gen unbumped would
+                # let every sibling re-login through loop-2 _check_headers.
+                self._reauth_error = err
+                self._reauth_error_gen = gen_at_send
+                self._refresh_gen += 1
+                raise
+            self._reauth_error = None
             self._refresh_token = self.auth.refresh_token
             self._refresh_gen += 1
 

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -161,6 +161,34 @@ class HonConnection:
                 self._refresh_token = self.auth.refresh_token
                 self._refresh_gen += 1
 
+    async def _reauth_after_rejection(self, gen_at_send: int) -> None:
+        # Full re-login recovery (loop 1), single-flighted under the SAME lock and
+        # generation as the refresh path. Without this, a concurrent-request burst
+        # (e.g. command_loader's asyncio.gather) that all reach loop 1 would each call
+        # create() -- which resets self._auth to a FRESH, token-less HonAuth -- so the
+        # loop-2 _check_headers of every sibling sees _need_auth() True and fires its
+        # OWN full Salesforce login on the shared ClientSession. The concurrent logins
+        # race on the shared cookie jar (the OAuth flow needs the cookies to persist in
+        # sequence) and, with 2FA on, generate multiple OTP emails / MFAChallengeRequired.
+        # Under the lock we re-auth only if no sibling (refresh OR re-auth) has advanced
+        # the generation since THIS request was sent; otherwise we reuse their fresh
+        # tokens. authenticate() here (instead of relying on the loop-2 _check_headers)
+        # keeps the whole re-login inside the lock so the burst collapses to exactly one.
+        async with self._refresh_lock:
+            if self._refresh_gen != gen_at_send:
+                return  # a sibling already re-authenticated; reuse its fresh tokens
+            await self.create()
+            await self.auth.authenticate()
+            self._refresh_token = self.auth.refresh_token
+            self._refresh_gen += 1
+
+    @staticmethod
+    def _is_html_challenge(response: aiohttp.ClientResponse) -> bool:
+        # A 403 whose body is HTML is a WAF/Cloudflare challenge or captive portal,
+        # not an hOn auth rejection (the hOn API answers auth failures with JSON).
+        content_type = getattr(response, "content_type", "") or ""
+        return content_type in ("text/html", "application/xhtml+xml")
+
     @asynccontextmanager
     async def _intercept(
         self, method, url: Any, *args: Any, loop: int = 0, **kwargs: Any
@@ -180,6 +208,17 @@ class HonConnection:
             # flag stays True for the whole period). For a POST /commands/v1/send that
             # means the command is delivered TWICE. Token expiry is already handled
             # BEFORE the request in _check_headers; here we only recover a rejection.
+            if response.status == 403 and self._is_html_challenge(response):
+                # A Cloudflare/WAF HTML 403 is a TRANSIENT edge hiccup, not bad
+                # credentials: routing it through refresh -> re-auth -> NativeAuthError
+                # would open a spurious reauth (and, with 2FA on, prompt for a new OTP).
+                # Attach DECODE_ERROR (requires_reauth=False) so the coordinator retries
+                # via UpdateFailed instead, exactly like the non-JSON body branch below.
+                # hOn's real auth-403s carry a JSON body and still follow the ladder.
+                _LOGGER.info("addhOn: HTML 403 (edge challenge), transient retry")
+                err = NativeAuthError("Decode Error (status 403)")
+                err.error_code = DECODE_ERROR
+                raise err
             if response.status in (401, 403) and loop == 0:
                 _LOGGER.info("addhOn: rejected (%s), refresh+retry", response.status)
                 await self._refresh_after_rejection(refresh_gen)
@@ -187,7 +226,7 @@ class HonConnection:
                     yield result
             elif response.status in (401, 403) and loop == 1:
                 _LOGGER.warning("addhOn: re-auth after %s", response.status)
-                await self.create()
+                await self._reauth_after_rejection(refresh_gen)
                 async with self._intercept(method, url, *args, loop=2, **kwargs) as result:
                     yield result
             elif loop >= 2 and (

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -447,6 +447,16 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             target = AC_SWING_V_ON
         else:
             target = fixed_vertical_value(allowed)
+            if target == AC_SWING_V_ON:
+                # No genuine fixed (non-swing) position exists for this model, so
+                # fixed_vertical_value fell back to the swing-ON code (8). Sending it
+                # for an OFF request would START oscillation -- the opposite of what
+                # was asked. Refuse instead of transmitting the wrong command.
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="swing_position_not_allowed",
+                    translation_placeholders={"position": str(target), "allowed": str(allowed)},
+                )
         if allowed and target not in allowed:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -226,6 +226,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
+        if reauth_entry is None:
+            # The entry was removed while the reauth flow was open: abort cleanly
+            # instead of raising AttributeError on reauth_entry.data below.
+            return self.async_abort(reason="reauth_account_mismatch")
         email = reauth_entry.data["email"]
 
         if user_input is not None:

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -228,8 +228,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         if reauth_entry is None:
             # The entry was removed while the reauth flow was open: abort cleanly
-            # instead of raising AttributeError on reauth_entry.data below.
-            return self.async_abort(reason="reauth_account_mismatch")
+            # instead of raising AttributeError on reauth_entry.data below. Use a
+            # dedicated reason -- reauth_account_mismatch ("credentials must belong to
+            # the same account") would be a misleading message for a missing entry.
+            return self.async_abort(reason="reauth_entry_not_found")
         email = reauth_entry.data["email"]
 
         if user_input is not None:

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -32,7 +32,7 @@ from .const import (
     DOMAIN,
     PROGRAM_PARAM_NAMES,
 )
-from .debug_utils import redact_id
+from .debug_utils import _MAC_RE, redact_id
 from .hon_commands import SETTINGS_COMMANDS, param_range, param_values
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ _TO_REDACT = frozenset(
         # (leaks the full MAC despite mac/macAddress being redacted), mobileId is the
         # phone-install id of whoever issued the last command (often a third party).
         "transactionid",
+        "transaction_id",
         "mobileid",
         "mobile_id",
     }
@@ -177,14 +178,16 @@ def _jsonable(value):
     encoder raises ``TypeError`` on them. Unwrap a ``.value`` if present (one level),
     else stringify, so the dump never carries an unserializable object.
     """
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if value is None or isinstance(value, (bool, int, float)):
         return value
+    if isinstance(value, str):
+        return _MAC_RE.sub(_REDACTED, value)
     if hasattr(value, "value"):
         inner = value.value
-        if inner is None or isinstance(inner, (str, int, float, bool)):
+        if inner is None or isinstance(inner, (bool, int, float)):
             return inner
-        return str(inner)
-    return str(value)
+        return _MAC_RE.sub(_REDACTED, str(inner))
+    return _MAC_RE.sub(_REDACTED, str(value))
 
 
 def _redact(value):
@@ -220,12 +223,19 @@ def _param_schema(param) -> dict:
         "category": getattr(param, "category", None),
         "mandatory": getattr(param, "mandatory", None),
     }
-    enum = param_values(param)
-    if enum:
-        schema["enum"] = enum
+    # Check range FIRST and emit ONLY min/max/step for a range param. param_values()
+    # calls `.values`, which on a HonParameterRange ENUMERATES the whole grid (up to
+    # _MAX_RANGE_VALUES = 100000 strings) synchronously on the event loop -- a huge,
+    # redundant dump for what min/max/step already describe. program_options makes the
+    # same rule explicit ("never call .values on a HonParameterRange"). enum is only
+    # meaningful for enum/fixed params, where param_range() returns None.
     rng = param_range(param)
     if rng is not None:
         schema["min"], schema["max"], schema["step"] = rng
+    else:
+        enum = param_values(param)
+        if enum:
+            schema["enum"] = enum
     return schema
 
 

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -218,7 +218,8 @@ async def async_setup_entry(
     coordinator = entry_data["coordinator"]
     client = entry_data["client"]
     entities = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         appliance = data.get("appliance")
         app_type = data.get("type")
         _LOGGER.debug(
@@ -321,8 +322,23 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         if appliance is not None:
             self._program_map = self._load_programs(appliance)
 
-        self._program_reverse: dict[str, str] = {v: k for k, v in self._program_map.items()}
-        self._attr_options = list(self._program_reverse.keys())
+        # Disambiguate collided labels: two program CODES sharing a display label would
+        # otherwise collapse in the reverse map, leaving one program unreachable from the
+        # UI and mapping current_option of the lost code onto the survivor's code. Suffix
+        # ONLY the colliding labels with their raw code so every code stays selectable and
+        # the reverse map is injective (mirrors HonProgramOptionSelect). Unique labels are
+        # untouched, keeping their translatable string.
+        label_counts: dict[str, int] = {}
+        for label in self._program_map.values():
+            label_counts[label] = label_counts.get(label, 0) + 1
+        self._program_display: dict[str, str] = {
+            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
+            for code, label in self._program_map.items()
+        }
+        self._program_reverse: dict[str, str] = {
+            display: code for code, display in self._program_display.items()
+        }
+        self._attr_options = list(self._program_display.values())
         _LOGGER.debug(
             "Select debug: initialized '%s' id=%s programs=%d map=%s",
             redact_id(self._attr_unique_id, appliance_id),
@@ -449,7 +465,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         #    until the user starts the cycle with the "Avvia programma" button.
         pending = self._coordinator_store(PROGRAM_PENDING_STORE).get(self._appliance_id)
         if pending is not None:
-            label = self._program_map.get(str(pending))
+            label = self._program_display.get(str(pending))
             if label is not None:
                 _LOGGER.debug(
                     "Select debug: current_option uses pending id=%s code=%s label=%s",
@@ -495,9 +511,9 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
                     "Select debug: current_option key '%s' token code=%s label=%s",
                     key,
                     token,
-                    self._program_map[token],
+                    self._program_display[token],
                 )
-                return self._program_map[token]
+                return self._program_display[token]
             if token in self._program_reverse:
                 _LOGGER.debug(
                     "Select debug: current_option key '%s' token label=%s",

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -834,7 +834,8 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[SensorEntity] = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})
         attributes = attributes if isinstance(attributes, dict) else {}

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -252,6 +252,10 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             redact_id(self._appliance_id),
             _command_names(appliance),
         )
+        # Rollback state: the pause param is mutated in memory before send; on a send
+        # failure restore it so the switch does not report a local pause/resume the
+        # cloud never accepted until the next poll. Populated inside _inner.
+        restore_pause: dict = {}
         try:
             def _do():
                 async def _inner():
@@ -267,8 +271,12 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
                         _param_snapshot(params),
                     )
                     if isinstance(params, dict) and "pause" in params:
-                        previous = getattr(params["pause"], "value", None)
-                        params["pause"].value = pause_value
+                        pause_param = params["pause"]
+                        if hasattr(pause_param, "__dict__"):
+                            restore_pause["param"] = pause_param
+                            restore_pause["snap"] = dict(pause_param.__dict__)
+                        previous = getattr(pause_param, "value", None)
+                        pause_param.value = pause_value
                         _LOGGER.debug(
                             "Switch debug: pause parameter set to %s (previous=%s)",
                             pause_value,
@@ -280,6 +288,7 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
                             command_name,
                         )
                     await command.send()
+                    restore_pause.clear()  # sent: nothing to roll back
                     _LOGGER.debug("Switch debug: command '%s' send completed", command_name)
                 client.run_command_sync(_inner())
 
@@ -287,6 +296,11 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             _LOGGER.info("Pause: %s sent", command_name)
             await self._async_request_command_refresh()
         except Exception as err:
+            param = restore_pause.get("param")
+            snap = restore_pause.get("snap")
+            if param is not None and isinstance(snap, dict):
+                param.__dict__.clear()
+                param.__dict__.update(snap)
             _LOGGER.error("Pause %s: Error: %s", command_name, err, exc_info=True)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -53,6 +53,7 @@
       "already_configured": "This hOn account is already configured.",
       "reauth_successful": "Re-authentication was successful.",
       "reauth_account_mismatch": "The new credentials must belong to the same hOn account.",
+      "reauth_entry_not_found": "The configuration entry no longer exists. Please add the integration again.",
       "mfa_no_challenge": "The two-factor session expired. Please start again."
     }
   },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -53,6 +53,7 @@
       "already_configured": "Questo account hOn è già configurato.",
       "reauth_successful": "Ri-autenticazione completata.",
       "reauth_account_mismatch": "Le nuove credenziali devono appartenere allo stesso account hOn.",
+      "reauth_entry_not_found": "La voce di configurazione non esiste più. Aggiungi di nuovo l'integrazione.",
       "mfa_no_challenge": "La sessione di verifica in due passaggi è scaduta. Riprova da capo."
     }
   },

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -365,6 +365,15 @@ class DiagnosticsValuesTest(unittest.TestCase):
         self.assertNotIn("3C:71:BF:BD:32:2C", dumped)
         self.assertEqual(out["someInfo"], "***_1699999999")
 
+    def test_mac_in_value_wrapped_object_is_masked(self):
+        # _jsonable also unwraps a HonAttribute/HonParameter-like object via `.value`;
+        # a MAC carried inside that `.value` must be masked too, so wrapping it does
+        # not smuggle the identity into the dump in cleartext.
+        out = diagnostics._redact({"deviceInfo": FakeWrapper("mac 3C:71:BF:BD:32:2C")})
+        dumped = json.dumps(out)
+        self.assertNotIn("3C:71:BF:BD:32:2C", dumped)
+        self.assertEqual(out["deviceInfo"], "mac ***")
+
 
 class DiagnosticsCoverageTest(unittest.TestCase):
     def test_unmapped_bare_attribute_surfaces(self):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -342,6 +342,29 @@ class DiagnosticsValuesTest(unittest.TestCase):
         self.assertEqual(machmode["enum"], ["0", "1", "2"])
         self.assertEqual(machmode["value"], "1")
 
+    def test_range_param_schema_omits_enumerated_grid(self):
+        # A real HonParameterRange exposes BOTH min/max/step AND a .values property
+        # that ENUMERATES the whole grid (up to 100k strings). _param_schema must
+        # emit only min/max/step and never dump that grid into `enum`.
+        grid = [str(v) for v in range(0, 1401, 100)]
+        param = FakeParam(value="1000", typology="range", rng=(0, 1400, 100), values=grid)
+        schema = diagnostics._param_schema(param)
+        self.assertEqual((schema["min"], schema["max"], schema["step"]), (0, 1400, 100))
+        self.assertNotIn("enum", schema)
+
+    def test_mac_in_value_under_benign_key_is_masked(self):
+        # Identity that lands in a string VALUE under a non-redacted key (an event
+        # payload, a transactionId-shaped value under a benign name) must still be
+        # masked, matching the log path (debug_utils.redact_identity).
+        out = diagnostics._redact(
+            {"someInfo": "3c-71-bf-bd-32-2c_1699999999",
+             "nested": {"note": "mac 3C:71:BF:BD:32:2C here"}}
+        )
+        dumped = json.dumps(out)
+        self.assertNotIn("3c-71-bf-bd-32-2c", dumped)
+        self.assertNotIn("3C:71:BF:BD:32:2C", dumped)
+        self.assertEqual(out["someInfo"], "***_1699999999")
+
 
 class DiagnosticsCoverageTest(unittest.TestCase):
     def test_unmapped_bare_attribute_surfaces(self):

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import sys
 import unittest
+from copy import copy
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -379,6 +380,33 @@ class ClusterBehaviorTest(unittest.TestCase):
         fav = start.categories["MyFav"]
         self.assertEqual(float(fav.parameters["tempSel"].value), 7.0)
         self.assertEqual(str(fav.parameters["favourite"].value), "1")
+
+    def test_favourite_copy_rules_do_not_corrupt_base(self) -> None:
+        # Regression: isolating `_parameters` in __copy__ was not enough. A shallow-copied
+        # parameter SHARED its trigger table with the base, and every rule callback closed
+        # over the BASE command. Applying a favourite sets values on the copy (see
+        # command_loader._update_base_command_with_data), which fires check_trigger -> the
+        # rule ran against the BASE program and mutated it. __copy__ now gives the copy its
+        # own trigger tables + rule sets bound to itself.
+        attrs = {
+            "parameters": {
+                "mode": _enum("cold", ["cold", "hot"]),
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "28"}}}})},
+        }
+        base = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        fav = copy(base)
+        # Applying the favourite fires the rule ON THE COPY: mode=hot -> temp=28.
+        fav.parameters["mode"].value = "hot"
+        self.assertEqual(fav.parameters["temp"].value, 28)  # the copy IS constrained
+        # ...and the base program keeps its own default, uncorrupted.
+        self.assertEqual(base.parameters["temp"].value, 20)  # bug: became 28
+        self.assertEqual(base.parameters["mode"].value, "cold")
+        # White-box: the copy's rule set is a distinct object bound to the copy, and the
+        # copied parameter's trigger table is not shared with the base.
+        self.assertIsNot(fav._rules[0], base._rules[0])
+        self.assertIsNot(fav.parameters["mode"]._triggers, base.parameters["mode"]._triggers)
 
     def test_favourites_malformed_do_not_crash(self) -> None:
         # Stale/malformed favourites payloads must not stop the loader.

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -360,6 +360,26 @@ class ClusterBehaviorTest(unittest.TestCase):
     def test_favourite_added(self) -> None:
         self.assertIn("MyFav", _native_snapshot()["rich_favourites_categories"])
 
+    def test_favourite_does_not_corrupt_base_program(self) -> None:
+        # Regression: `_add_favourites` shallow-copied the base command, sharing its
+        # `_parameters` dict AND parameter objects. Applying MyFav (tempSel=7 on
+        # SUPER_COOL) then mutated the REAL super_cool program -> it got tempSel=7 and
+        # a favourite="1" flag, and `HonParameterProgram.ids` (which drops favourites)
+        # hid it entirely. HonCommand.__copy__ now isolates the parameters.
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS, favourites=_RICH_FAVOURITES))
+        start = app.commands["startProgram"]
+        base = start.categories["super_cool"]  # the real program, not the MyFav copy
+        # base keeps its own default, untouched by the favourite's tempSel=7
+        self.assertEqual(float(base.parameters["tempSel"].value), 5.0)
+        # base is NOT flagged as a favourite...
+        self.assertNotIn("favourite", base.parameters)
+        # ...so it still appears in the selectable program ids (prCode 1 -> super_cool)
+        self.assertEqual(start.parameters["program"].ids.get(1), "super_cool")
+        # the favourite itself is a distinct command carrying tempSel=7 + favourite=1
+        fav = start.categories["MyFav"]
+        self.assertEqual(float(fav.parameters["tempSel"].value), 7.0)
+        self.assertEqual(str(fav.parameters["favourite"].value), "1")
+
     def test_favourites_malformed_do_not_crash(self) -> None:
         # Stale/malformed favourites payloads must not stop the loader.
         bad_favs = [

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -408,6 +408,53 @@ class ClusterBehaviorTest(unittest.TestCase):
         self.assertIsNot(fav._rules[0], base._rules[0])
         self.assertIsNot(fav.parameters["mode"]._triggers, base.parameters["mode"]._triggers)
 
+    def test_malformed_fixed_value_rule_skipped_at_runtime(self) -> None:
+        # A rule whose fixedValue is non-numeric for a RANGE target must NOT raise out
+        # of the runtime trigger (the range setter rejects "x" with ValueError). The
+        # rule is skipped and the parameter keeps its value; setup is not aborted.
+        attrs = {
+            "parameters": {
+                "mode": _enum("cold", ["cold", "hot"]),
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "not-a-number"}}}})},
+        }
+        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        cmd.parameters["mode"].value = "hot"  # fires the bad rule -> must be swallowed
+        self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
+
+    def test_malformed_fixed_value_rule_skipped_at_construction(self) -> None:
+        # Same malformed rule, but the trigger value equals the param DEFAULT, so the
+        # immediate-fire runs during construction (patch()). Building the command must
+        # not raise -- the ValueError from _apply_fixed used to abort the whole load.
+        attrs = {
+            "parameters": {
+                "mode": _enum("hot", ["cold", "hot"]),  # default already == trigger
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "not-a-number"}}}})},
+        }
+        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())  # must not raise
+        self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
+
+    def test_copy_rebinds_program_param_backrefs(self) -> None:
+        # A HonParameterProgram carries `_command` (the base command); its value-setter
+        # does `self._command.category = value` (swapping appliance.commands). A shallow
+        # copy shares that back-reference, so a write on the copy's program parameter
+        # could reach the base. __copy__ now rebinds `_command`/`_programs` to the copy.
+        from custom_components.addhon.client.engine.parameter.program import (
+            HonParameterProgram,
+        )
+
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS, favourites=_RICH_FAVOURITES))
+        base = app.commands["startProgram"].categories["super_cool"]
+        self.assertIsInstance(base.parameters["program"], HonParameterProgram)
+        fav = copy(base)
+        fav_prog = fav.parameters["program"]
+        self.assertIs(fav_prog._command, fav)       # rebound to the copy...
+        self.assertIsNot(fav_prog._command, base)   # ...not the base command
+        self.assertIs(fav_prog._programs, fav.categories)
+
     def test_favourites_malformed_do_not_crash(self) -> None:
         # Stale/malformed favourites payloads must not stop the loader.
         bad_favs = [

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -281,6 +281,49 @@ class ApplyDebugOptionsTest(unittest.TestCase):
             logging.getLogger("custom_components.addhon").level, logging.NOTSET
         )
 
+    def test_options_listener_skips_when_toggles_unchanged(self) -> None:
+        # HA fires update listeners on ANY entry write (e.g. a refresh-token rotation),
+        # not only options changes. With the toggles unchanged the listener must NOT
+        # re-apply/reset the levels, so a debug level raised at runtime survives.
+        import asyncio
+
+        from custom_components.addhon import (
+            _DEBUG_OPTS_KEY,
+            _async_options_updated,
+            _debug_opts,
+        )
+        from custom_components.addhon.const import DOMAIN
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: False})
+
+        class _Hass:
+            data = {DOMAIN: {entry.entry_id: {_DEBUG_OPTS_KEY: _debug_opts(entry)}}}
+
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        asyncio.run(_async_options_updated(_Hass(), entry))
+        # unchanged toggles -> level preserved, NOT reset to NOTSET
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.DEBUG
+        )
+
+    def test_options_listener_applies_when_toggles_changed(self) -> None:
+        # A genuine options change (baseline debug ON, now OFF) still re-applies live.
+        import asyncio
+
+        from custom_components.addhon import _DEBUG_OPTS_KEY, _async_options_updated
+        from custom_components.addhon.const import DOMAIN
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: False})
+
+        class _Hass:
+            data = {DOMAIN: {entry.entry_id: {_DEBUG_OPTS_KEY: (True, False)}}}
+
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        asyncio.run(_async_options_updated(_Hass(), entry))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.NOTSET
+        )
+
 
 class ResetHelperTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -480,6 +480,61 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         # The fixed parameters were applied to the NEW (swapped) command, not the stale one.
         self.assertEqual("Y", new_cmd.parameters["prStr"].value)
 
+    async def test_start_button_rolls_back_swap_on_send_failure(self) -> None:
+        # If send() fails AFTER the program apply swapped the active command, the button
+        # must roll back: restore appliance.commands[name] to the original command and
+        # undo the parameter mutations, so the appliance does not keep pointing at a
+        # program the cloud never accepted. Pending program is kept for retry.
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        appliance = types.SimpleNamespace(commands={})
+
+        class FailingCommand(RecordingCommand):
+            async def send(self) -> None:
+                self.send_calls += 1
+                raise RuntimeError("cloud rejected")
+
+        new_cmd = FailingCommand({"prStr": Param("X")})
+
+        class ProgramSwapParam:
+            def __init__(self) -> None:
+                self._value = None
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd  # category swap
+
+        old_cmd = RecordingCommand({"program": ProgramSwapParam()})
+        appliance.commands["startProgram"] = old_cmd
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": "2"}
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+            command_parameters={"prStr": "Y"},
+        )
+        self._attach(button)
+
+        with self.assertRaises(HomeAssistantError):
+            await button.async_press()
+
+        # rolled back to the ORIGINAL command and its pre-apply parameter state
+        self.assertIs(old_cmd, appliance.commands["startProgram"])
+        self.assertIsNone(old_cmd.parameters["program"].value)
+        self.assertEqual("X", new_cmd.parameters["prStr"].value)  # fixed mutation undone
+        # pending program NOT consumed: the user can retry
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+
     async def test_stop_button_ignores_pending_program(self) -> None:
         from custom_components.addhon.button import HonProgramCommandButton
 

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -290,6 +290,28 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("program", added[0]._attr_translation_key)
         self.assertEqual(["Cotone", "Sintetici"], added[0]._attr_options)
 
+    async def test_duplicate_program_labels_stay_distinct(self) -> None:
+        # Two program CODES sharing a display label must both stay selectable and map
+        # back to their OWN code, instead of collapsing (one code unreachable, the other
+        # mis-selected). Colliding labels get a "(code)" suffix; unique ones untouched.
+        from custom_components.addhon.select import HonProgramSelect
+
+        start = RecordingCommand(
+            {"program": Param(values={"1": "Eco", "2": "Eco", "3": "Cotone"})}
+        )
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        self.assertEqual(["Eco (1)", "Eco (2)", "Cotone"], entity._attr_options)
+        await entity.async_select_option("Eco (1)")
+        self.assertEqual({"washer-1": "1"}, coordinator.pending_programs)
+        await entity.async_select_option("Eco (2)")
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+        # current_option reflects the pending disambiguated option (must be in options)
+        self.assertEqual("Eco (2)", entity.current_option)
+        self.assertIn(entity.current_option, entity._attr_options)
+
     async def test_select_option_records_pending_without_starting(self) -> None:
         from custom_components.addhon.select import HonProgramSelect
 

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -273,6 +273,42 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(auth.refresh_calls, 1)
         self.assertEqual(auth.authenticate_calls, 0)
 
+    def test_concurrent_reauth_single_flight(self) -> None:
+        # The loop-1 re-auth is now single-flighted under the same lock+generation as
+        # the refresh: a burst that all reach loop 1 collapses to ONE create() +
+        # authenticate(). Before, each request's create() reset self._auth to a
+        # token-less HonAuth, so the loop-2 _check_headers of every sibling fired its
+        # OWN full login on the shared session (colliding cookie jars / multiple OTPs).
+        created = {"n": 0}
+
+        class SlowFakeAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                await asyncio.sleep(0)  # yield so siblings pile up on the lock
+                self.cognito_token, self.id_token, self.refresh_token = "COG", "IDT", "RT"
+
+        auth = SlowFakeAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            created["n"] += 1
+            return conn  # a real re-login repopulates the same connection's auth
+
+        conn.create = _fake_create
+
+        async def run():
+            gen = conn._refresh_gen  # all three "sent" at the same generation
+            await asyncio.gather(
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+            )
+
+        asyncio.run(run())
+        self.assertEqual(auth.authenticate_calls, 1)  # one re-login, not three
+        self.assertEqual(created["n"], 1)             # one create(), not three
+        self.assertEqual(conn._refresh_gen, 1)        # advanced exactly once
+
     def test_retry_on_403_refreshes(self) -> None:
         # Same branch as the 401 (the code treats them identically) but made explicit
         # to avoid regressions on the 403 (CodeRabbit nitpick).

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -309,6 +309,44 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(created["n"], 1)             # one create(), not three
         self.assertEqual(conn._refresh_gen, 1)        # advanced exactly once
 
+    def test_concurrent_reauth_single_flight_on_failure(self) -> None:
+        # A FAILING loop-1 re-auth (e.g. MFAChallengeRequired) must also collapse to
+        # ONE attempt: without caching the error + advancing the generation, each
+        # queued sibling would run its own create()+authenticate() -- N sequential
+        # logins / OTP prompts on a 2FA account exactly when the login is failing.
+        created = {"n": 0}
+
+        class SlowFailAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                await asyncio.sleep(0)  # yield so siblings pile up on the lock
+                raise NativeAuthError("2FA challenge required")
+
+        auth = SlowFailAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            created["n"] += 1
+            return conn
+
+        conn.create = _fake_create
+
+        async def run():
+            gen = conn._refresh_gen  # all three "sent" at the same generation
+            return await asyncio.gather(
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                return_exceptions=True,
+            )
+
+        results = asyncio.run(run())
+        self.assertEqual(auth.authenticate_calls, 1)  # one attempt, not three
+        self.assertEqual(created["n"], 1)             # one create(), not three
+        # every caller surfaces the SAME auth error (the siblings reuse the cached one)
+        self.assertTrue(all(isinstance(r, NativeAuthError) for r in results))
+        self.assertEqual(conn._refresh_gen, 1)        # advanced once, even on failure
+
     def test_retry_on_403_refreshes(self) -> None:
         # Same branch as the 401 (the code treats them identically) but made explicit
         # to avoid regressions on the 403 (CodeRabbit nitpick).
@@ -654,6 +692,59 @@ class InterceptCloudErrorRoutingTest(unittest.TestCase):
         self.assertIs(ctx.exception.error_code, DECODE_ERROR)
         self.assertFalse(DECODE_ERROR.requires_reauth)
         self.assertEqual(auth.authenticate_calls, 0)  # no spurious full re-login
+
+    def test_html_403_is_transient_not_reauth(self) -> None:
+        # A 403 whose body is HTML (Cloudflare/WAF challenge, captive portal) is a
+        # transient edge hiccup, NOT an hOn auth rejection. It must carry DECODE_ERROR
+        # (coordinator retries via UpdateFailed) and never enter the refresh -> reauth
+        # ladder, which on a 2FA account would open a spurious OTP prompt.
+        class HtmlResp(FakeResp):
+            content_type = "text/html"
+
+        class HtmlSession(FakeSession):
+            def _resp(self, url, **kw):
+                self.calls.append(kw.get("headers", {}))
+                return HtmlResp(403)
+
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, HtmlSession([]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        with self.assertRaises(NativeAuthError) as ctx:
+            asyncio.run(run())
+        self.assertIs(ctx.exception.error_code, DECODE_ERROR)
+        self.assertFalse(DECODE_ERROR.requires_reauth)
+        self.assertEqual(auth.refresh_calls, 0)       # not routed to refresh
+        self.assertEqual(auth.authenticate_calls, 0)  # nor to a full reauth
+        self.assertEqual(len(conn._session.calls), 1)  # raised, not retried in-band
+
+    def test_json_403_still_climbs_the_reauth_ladder(self) -> None:
+        # A NON-HTML 403 that persists must still follow refresh (loop 0) -> full
+        # re-auth (loop 1) -> retry, so a genuine auth rejection is never masked by
+        # the HTML-challenge shortcut. FakeResp has no content_type -> not HTML.
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([403, 403, 200]))
+        conn._refresh_token = "RT"
+
+        async def _fake_create():
+            return conn  # a real re-login repopulates the same connection's auth
+
+        conn.create = _fake_create
+
+        async def run():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        status = asyncio.run(run())
+        self.assertEqual(status, 200)
+        self.assertEqual(auth.refresh_calls, 1)       # loop 0 refresh
+        self.assertEqual(auth.authenticate_calls, 1)  # loop 1 full reauth
 
     def test_5xx_json_body_raises_retryable_not_success(self) -> None:
         # A 502 whose body decodes as JSON must NOT be yielded as a good response


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of device controls by rolling back failed actions instead of leaving commands in a partial state.
  * Fixed issues that could cause duplicate labels, incorrect availability, or unexpected errors when device data is missing or malformed.
  * Made connection handling more resilient during re-login, authentication, and challenge-response failures.

* **New Features**
  * Better select options now distinguish items with the same display name.
  * Debug settings now stay consistent when unrelated configuration data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a coordinated set of bug fixes targeting three main areas: command-parameter isolation when loading favourite programs, connection resilience during re-authentication, and entity state correctness. Each fix is accompanied by targeted regression tests that reproduce the exact pre-fix failure.

- **Command copy isolation** (`commands.py`, `rules.py`, `parameter/base.py`): `HonCommand.__copy__` now gives each favourite copy its own parameter dict, fresh trigger tables, and rule sets rebound to the copy. A companion try/except in the trigger callback prevents malformed rule data from aborting device setup.
- **Connection resilience** (`connection.py`, `auth.py`): Loop-1 re-auth is single-flighted under the existing generation lock so a concurrent burst on a 2FA account collapses to one OTP attempt; HTML 403 WAF challenges are short-circuited to `DECODE_ERROR` to avoid spurious re-logins.
- **Entity state** (`base_entity.py`, `select.py`, `button.py`, `switch.py`, `climate.py`, `__init__.py`, `diagnostics.py`): `available` unwraps `HonAttribute` objects and normalises falsy strings; duplicate select labels get `(code)` suffixes; failed sends roll back parameter mutations and command swaps.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all fixes are well-scoped, every changed path has a direct regression test, and no new failure modes were introduced.

The core invariants are preserved: command copies are properly isolated, the re-auth single-flight correctly collapses concurrent bursts on both success and failure paths, and entity-state fixes handle edge cases without regressing normal operation.

No files require special attention; the most complex change (HonCommand.__copy__ + HonRuleSet.rebound) has thorough white-box tests in test_engine_cluster.py.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/commands.py | Adds a custom __copy__ that gives favourite copies their own _parameters dict, fresh trigger tables, and rule sets rebound to the copy, preventing base-command corruption. |
| custom_components/addhon/client/engine/rules.py | Adds rebound() to re-attach triggers and config rules to a copied command, and wraps the trigger callback in try/except to prevent malformed rule data from aborting command load. |
| custom_components/addhon/client/transport/connection.py | Adds single-flight error caching for the loop-1 re-auth path and a fast-exit for HTML 403 WAF challenges to avoid spurious 2FA OTP prompts in concurrent-request bursts. |
| custom_components/addhon/client/transport/auth.py | Fixes two auth bugs: appends & to capture trailing fragment fields in parse_token_fragment, and replaces the no-op clear_domain('') with the actual auth host from urlsplit().netloc. |
| custom_components/addhon/button.py | Adds snapshot/rollback logic around program-command sends so a failed send restores the appliance to its pre-send state. |
| custom_components/addhon/select.py | Disambiguates duplicate program display labels with a (code) suffix; adds data_map guard for non-dict coordinator data on setup. |
| custom_components/addhon/base_entity.py | Fixes available to read through _get_attr and normalizes falsy strings so a disconnected device is not reported as available. |
| custom_components/addhon/__init__.py | Makes _async_options_updated a no-op when only non-debug data triggers the HA update listener, preventing spurious debug-level resets. |

<sub>Reviews (5): Last reviewed commit: ["test(diagnostics): cover MAC masking on ..."](https://github.com/tis24dev/addhon/commit/42d6d49f7b4e10c9b13b88f239fe1b425a3974a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41955627)</sub>

<!-- /greptile_comment -->