### PR TITLE
Release v5.8.0

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -186,17 +186,46 @@ def _apply_debug_options(entry: ConfigEntry, *, reset_when_off: bool = True) -> 
         silence_mqtt_noise()
 
 
+_DEBUG_OPTS_KEY = "debug_options"
+
+
+def _debug_opts(entry: ConfigEntry) -> tuple[bool, bool]:
+    """Current (integration-debug, mqtt-debug) toggles for the entry."""
+    return (
+        entry.options.get(CONF_ENABLE_DEBUG, False),
+        entry.options.get(CONF_ENABLE_MQTT_DEBUG, False),
+    )
+
+
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Re-apply the log levels on the fly when the toggles change (no reload).
 
     A reload would tear down auth and the MQTT channel just to change a log level;
     here we re-apply the levels on the fly, as the existing services do.
+
+    HA fires update listeners on ANY entry change (data, options, title), not only
+    on an options change. A data-only write -- e.g. _persist_refresh_token rotating
+    the OAuth refresh token during a routine poll -- must NOT re-apply/reset the
+    debug levels: that would silently kill a debug level raised at runtime via the
+    set_log_level / set_mqtt_log_level service (reset_when_off=True), exactly when the
+    logs are needed. So re-apply only when the debug toggles actually changed.
     """
+    current = _debug_opts(entry)
+    hass_data = getattr(hass, "data", None)
+    entry_data = (
+        hass_data.get(DOMAIN, {}).get(entry.entry_id)
+        if isinstance(hass_data, dict)
+        else None
+    )
+    if entry_data is not None:
+        if entry_data.get(_DEBUG_OPTS_KEY) == current:
+            return  # entry changed but the debug toggles didn't
+        entry_data[_DEBUG_OPTS_KEY] = current
     _LOGGER.debug(
         "Options debug: options updated entry=%s enable_debug=%s enable_mqtt_debug=%s",
         entry.entry_id,
-        entry.options.get(CONF_ENABLE_DEBUG, False),
-        entry.options.get(CONF_ENABLE_MQTT_DEBUG, False),
+        current[0],
+        current[1],
     )
     _apply_debug_options(entry)
 
@@ -530,6 +559,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "coordinator": coordinator,
             "client": hon_client,
             "integration_version": integration_version,
+            # Baseline for _async_options_updated: the toggles already applied at the
+            # start of setup, so a later data-only entry write (token rotation) is a
+            # no-op and only a real options change re-applies the levels.
+            _DEBUG_OPTS_KEY: _debug_opts(entry),
         }
         stored = True
         _LOGGER.debug("Setup debug: coordinator and client stored in hass.data for entry=%s", entry.entry_id)

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -14,6 +14,17 @@ from .debug_utils import debug_key_sample, redact_id
 _LOGGER = logging.getLogger(__name__)
 
 
+def coordinator_data_map(coordinator) -> dict:
+    """The coordinator's per-appliance data dict, or ``{}`` if not yet a dict.
+
+    Shared guard for the platform setup loops (sensor / binary_sensor / select):
+    ``coordinator.data`` can be ``None`` before the first successful refresh, so
+    every platform coerces it to a dict before iterating. Centralized here so the
+    guard stays consistent instead of being inlined identically in each platform.
+    """
+    return coordinator.data if isinstance(coordinator.data, dict) else {}
+
+
 def account_device_info(entry, sw_version: str | None = None) -> DeviceInfo:
     """DeviceInfo for the synthetic per-account "diagnostics" device.
 

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -164,7 +164,19 @@ class HonBaseEntity(CoordinatorEntity):
         NB: the connectivity binary_sensor excludes the `available` gate (it must
         stay available to signal 'disconnected'): it uses `_present` directly.
         """
-        return self._present and bool(self._attributes.get("available", True))
+        # Short-circuit on _present FIRST: it guards coordinator.data being a dict, so
+        # _get_attr below (which reads coordinator.data) is never reached when the data
+        # is missing/None.
+        if not self._present:
+            return False
+        # Read `available` through _get_attr so it shares the same normalization as
+        # every other attribute read: a raw `.get(...)` + bool() would report a
+        # disconnected device as available if `available` ever arrived wrapped in a
+        # HonAttribute (an object is always truthy) or as a "false"/"0" string.
+        available = self._get_attr("available", True)
+        if isinstance(available, str):
+            available = available.strip().lower() not in ("false", "0", "no", "off", "")
+        return bool(available)
 
     @property
     def _present(self) -> bool:

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -321,7 +321,8 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[BinarySensorEntity] = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})
         attributes = attributes if isinstance(attributes, dict) else {}

--- a/custom_components/addhon/binary_sensor.py
+++ b/custom_components/addhon/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .base_entity import HonAccountCoordinatorEntity, HonBaseEntity
+from .base_entity import HonAccountCoordinatorEntity, HonBaseEntity, coordinator_data_map
 from .const import (
     APPLIANCE_AC,
     APPLIANCE_DW,
@@ -321,7 +321,7 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[BinarySensorEntity] = []
-    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    data_map = coordinator_data_map(coordinator)
     for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -151,6 +151,31 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             redact_store(store),
             command_names(appliance),
         )
+        # Rollback state for a failed send: applying the pending program both mutates
+        # the program parameter AND swaps appliance.commands[name] to the selected
+        # category. Populated inside _inner BEFORE the mutation and consumed by the
+        # except below, so a send failure does not leave the appliance pointing at a
+        # program/command the cloud never accepted (which would otherwise skew the
+        # per-program option ranges until the next poll self-heals it). Mirrors the
+        # snapshot/restore in hon_commands.async_send_command.
+        rollback: dict = {}
+
+        def _snapshot_params(ps):
+            if not isinstance(ps, dict):
+                return {}
+            return {k: dict(p.__dict__) for k, p in ps.items() if hasattr(p, "__dict__")}
+
+        def _restore_params(ps, snap):
+            if not isinstance(ps, dict):
+                return
+            for key, saved in snap.items():
+                param = ps.get(key)
+                if param is not None and hasattr(param, "__dict__"):
+                    # Restore via __dict__ (not the setter) so rules are not re-fired
+                    # and values/min/max are restored too.
+                    param.__dict__.clear()
+                    param.__dict__.update(saved)
+
         try:
             def _do():
                 async def _inner():
@@ -163,6 +188,11 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             f"Available: {list(commands.keys())}"
                         )
                     params = getattr(command, "parameters", {})
+                    # Record the pre-swap state so a failed send can be fully rolled back.
+                    rollback["commands"] = commands
+                    rollback["name"] = self._command_name
+                    rollback["original_command"] = command
+                    rollback["snapshots"] = [(params, _snapshot_params(params))]
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug(
                             "Button debug: before command '%s' params=%s",
@@ -211,6 +241,9 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                         )
                         command = refreshed
                         params = getattr(command, "parameters", {})
+                        # Snapshot the post-swap command's params too, so options/fixed
+                        # applied below are rolled back with the swap on a send failure.
+                        rollback["snapshots"].append((params, _snapshot_params(params)))
                     # (b) Apply the buffered program options to the POST-SWAP command
                     # (#35): selecting the program swaps the active startProgram command,
                     # so the options must land on the new one. apply_pending_options skips
@@ -249,6 +282,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                             param_snapshot(params),
                         )
                     await command.send()
+                    rollback.clear()  # sent: nothing to roll back
                     _LOGGER.debug("Button debug: command '%s' send completed", self._command_name)
 
                 client.run_command_sync(_inner())
@@ -285,6 +319,16 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
             _LOGGER.info("Button: command '%s' sent", self._command_name)
             await self._async_request_command_refresh()
         except Exception as err:
+            # Roll back the command swap + parameter mutations left by a failed send,
+            # so the appliance does not keep pointing at a program the cloud rejected.
+            if rollback:
+                cmds = rollback.get("commands")
+                name = rollback.get("name")
+                original = rollback.get("original_command")
+                if isinstance(cmds, dict) and original is not None and cmds.get(name) is not original:
+                    cmds[name] = original
+                for ps, snap in reversed(rollback.get("snapshots", [])):
+                    _restore_params(ps, snap)
             _LOGGER.error(
                 "Button %s: command error: %s",
                 self._command_name, err, exc_info=True,

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -22,6 +22,7 @@ from .const import (
 )
 from .debug_utils import command_names, param_snapshot, redact_id, redact_store
 from .logging_utils import reset_integration_log_level, silence_mqtt_noise
+from .param_rollback import restore_params, snapshot_params
 from .program_options import apply_pending_options
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,26 +157,9 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
         # category. Populated inside _inner BEFORE the mutation and consumed by the
         # except below, so a send failure does not leave the appliance pointing at a
         # program/command the cloud never accepted (which would otherwise skew the
-        # per-program option ranges until the next poll self-heals it). Mirrors the
-        # snapshot/restore in hon_commands.async_send_command.
+        # per-program option ranges until the next poll self-heals it). Uses the shared
+        # snapshot/restore in param_rollback (same as hon_commands.async_send_command).
         rollback: dict = {}
-
-        def _snapshot_params(ps):
-            if not isinstance(ps, dict):
-                return {}
-            return {k: dict(p.__dict__) for k, p in ps.items() if hasattr(p, "__dict__")}
-
-        def _restore_params(ps, snap):
-            if not isinstance(ps, dict):
-                return
-            for key, saved in snap.items():
-                param = ps.get(key)
-                if param is not None and hasattr(param, "__dict__"):
-                    # Restore via __dict__ (not the setter) so rules are not re-fired
-                    # and values/min/max are restored too.
-                    param.__dict__.clear()
-                    param.__dict__.update(saved)
-
         try:
             def _do():
                 async def _inner():
@@ -192,7 +176,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                     rollback["commands"] = commands
                     rollback["name"] = self._command_name
                     rollback["original_command"] = command
-                    rollback["snapshots"] = [(params, _snapshot_params(params))]
+                    rollback["snapshots"] = [(params, snapshot_params(params))]
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug(
                             "Button debug: before command '%s' params=%s",
@@ -243,7 +227,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                         params = getattr(command, "parameters", {})
                         # Snapshot the post-swap command's params too, so options/fixed
                         # applied below are rolled back with the swap on a send failure.
-                        rollback["snapshots"].append((params, _snapshot_params(params)))
+                        rollback["snapshots"].append((params, snapshot_params(params)))
                     # (b) Apply the buffered program options to the POST-SWAP command
                     # (#35): selecting the program swaps the active startProgram command,
                     # so the options must land on the new one. apply_pending_options skips
@@ -328,7 +312,7 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                 if isinstance(cmds, dict) and original is not None and cmds.get(name) is not original:
                     cmds[name] = original
                 for ps, snap in reversed(rollback.get("snapshots", [])):
-                    _restore_params(ps, snap)
+                    restore_params(ps, snap)
             _LOGGER.error(
                 "Button %s: command error: %s",
                 self._command_name, err, exc_info=True,

--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -126,7 +126,14 @@ class HonAppliance:
 
     @property
     def model_id(self) -> int:
-        return int(self._info.get("applianceModelId", 0))
+        # The `0` default only covers a MISSING key; a present-but-empty or
+        # non-numeric `applianceModelId` (seen on some payloads) would make
+        # int("") raise ValueError. model_id feeds the entity identity, so parse
+        # defensively and fall back to 0.
+        try:
+            return int(self._info.get("applianceModelId") or 0)
+        except (TypeError, ValueError):
+            return 0
 
     # --- state / data ---
     @property

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -14,6 +14,7 @@ false "sent".
 """
 from __future__ import annotations
 
+from copy import copy
 from typing import Any, Optional, Union
 
 from .exceptions import ApiError, NoAuthenticationException
@@ -52,6 +53,40 @@ class HonCommand:
 
     def __repr__(self) -> str:
         return f"{self._name} command"
+
+    def __copy__(self) -> "HonCommand":
+        # `_add_favourites` (command_loader) does `copy(base)` and then MUTATES the
+        # copy's parameters (sets values, injects a `favourite` fixed, sets the program
+        # value). A default shallow copy shares the SAME `_parameters` dict AND the same
+        # parameter objects with the base program command (also reachable via
+        # `parent.categories`), so those mutations corrupt the base program: its values
+        # get overwritten, it gains `favourite="1"`, and it then disappears from
+        # `HonParameterProgram.ids` (which filters favourites out). Give each copy its own
+        # parameter dict with copied parameter objects so the base stays pristine.
+        new = self.__class__.__new__(self.__class__)
+        new.__dict__.update(self.__dict__)
+        new._parameters = {name: copy(param) for name, param in self._parameters.items()}
+        # A shallow-copied parameter still SHARES its `_triggers` table with the base, and
+        # every rule callback in it closes over THIS command -- so setting a value on the
+        # copy would fire rules that mutate the base's parameters (the exact corruption the
+        # `_parameters` isolation above prevents, via the trigger back-door). Give each
+        # copied param a fresh trigger table and rebind the rule sets to the copy, so its
+        # rules act only on itself.
+        for parameter in new._parameters.values():
+            parameter.reset_triggers()
+            # A copied HonParameterProgram keeps its base back-references intact:
+            # `_command` points at the BASE command and its value-setter does
+            # `self._command.category = value` (which swaps `appliance.commands`).
+            # Rebind them to the copy so a write on the copy's program parameter can
+            # never reach the base command. The current favourite loader never hits
+            # this (the raw "PROGRAMS.X" value is not in the cleaned `.values`, so the
+            # setter raises a suppressed ValueError), but rebinding removes the latent
+            # back-door for good.
+            if isinstance(parameter, HonParameterProgram):
+                parameter._command = new
+                parameter._programs = new.categories
+        new._rules = [ruleset.rebound(new) for ruleset in self._rules]
+        return new
 
     @property
     def name(self) -> str:

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -76,7 +76,11 @@ class HonParameter:
         return self._group
 
     def add_trigger(self, value: str, func: Callable[[Any], None], data: Any) -> None:
-        if self._value == value:
+        # Normalize both sides like `check_trigger` does: `_value` may be numeric
+        # (range/int) while the trigger value is always a string, so a raw `==`
+        # would miss `1 == "1"` and skip the immediate-fire for a param whose
+        # default already equals the trigger value.
+        if str(self._value).lower() == str(value).lower():
             func(data)
         self._triggers.setdefault(value, []).append((func, data))
 
@@ -105,6 +109,15 @@ class HonParameter:
                 else:
                     param[rule.param_key] = rule.param_data.get("defaultValue", "")
         return result
+
+    def reset_triggers(self) -> None:
+        """Replace the trigger table with a fresh empty one.
+
+        Used by `HonCommand.__copy__`: a shallow-copied parameter shares this dict with the
+        original, whose rule callbacks close over the original command. Rebinding to a NEW
+        dict (not `.clear()`, which would empty the shared/original table) lets the copy's
+        rules be re-attached against the copy without touching the base."""
+        self._triggers = {}
 
     def reset(self) -> None:
         self._set_attributes()

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -23,12 +23,15 @@ rules are a cohesive cluster.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from .parameter.base import HonParameter
 from .parameter.enum import HonParameterEnum
 from .parameter.range import HonParameterRange
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -188,10 +191,26 @@ class HonRuleSet:
                 return
             if not (param := self._command.parameters.get(rule.param_key)):
                 return
-            if fixed_value := rule.param_data.get("fixedValue", ""):
-                self._apply_fixed(param, fixed_value)
-            elif rule.param_data.get("typology") == "enum":
-                self._apply_enum(param, rule)
+            try:
+                if fixed_value := rule.param_data.get("fixedValue", ""):
+                    self._apply_fixed(param, fixed_value)
+                elif rule.param_data.get("typology") == "enum":
+                    self._apply_enum(param, rule)
+            except (ValueError, TypeError) as err:
+                # A malformed rule (non-numeric or off-grid `fixedValue`, bad enum
+                # value) must NOT abort the whole appliance's command-load. The
+                # immediate-fire in `HonParameter.add_trigger` runs at construction
+                # time, so an escaping ValueError from `_apply_fixed` (e.g. float("x")
+                # or an off-step value rejected by the range setter) would fail setup
+                # for every entity of the device. Log and skip the bad rule instead;
+                # the runtime path already tolerates this via the entity write-path.
+                _LOGGER.debug(
+                    "addhOn: skipping unapplicable rule for '%s' (trigger %s=%s): %s",
+                    rule.param_key,
+                    rule.trigger_key,
+                    rule.trigger_value,
+                    err,
+                )
 
         parameter.add_trigger(data.trigger_value, apply, data)
 
@@ -225,9 +244,30 @@ class HonRuleSet:
 
     def patch(self) -> None:
         self._duplicate_for_extra_conditions()
+        self._attach_triggers()
+        self._apply_config_rules()
+
+    def _attach_triggers(self) -> None:
+        """Register every (already-expanded) rule as a trigger on its command's params."""
         for name, parameter in self._command.parameters.items():
             if name not in self._rules:
                 continue
             for data in self._rules.get(name, []):
                 self._add_trigger(parameter, data)
-        self._apply_config_rules()
+
+    def rebound(self, command: Any) -> "HonRuleSet":
+        """A copy of this (already-expanded) rule set bound to `command`, with its
+        triggers attached to `command`'s parameters.
+
+        `HonCommand.__copy__` uses this: a shallow-copied command shares each parameter's
+        trigger table, and every rule callback closes over the ORIGINAL command -- so
+        setting a value on the copy (applying a favourite) would fire rules that mutate the
+        BASE command. `_duplicate_for_extra_conditions` is NOT re-run (self is already
+        expanded); HonRule entries are read-only in the apply path, so they are shared."""
+        new = HonRuleSet.__new__(HonRuleSet)
+        new._command = command
+        new._rules = {key: list(rules) for key, rules in self._rules.items()}
+        new._config_rules = list(self._config_rules)
+        new._attach_triggers()
+        new._apply_config_rules()
+        return new

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -15,6 +15,7 @@ import logging
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 from yarl import URL
 
@@ -173,7 +174,22 @@ class HonAuth:
             login_url = extract_login_url(text)
             if login_url is None:
                 if is_oauth_done(text):
-                    t = parse_token_fragment(text)
+                    # Append a trailing '&' so parse_token_fragment captures the LAST
+                    # fragment field too: its regex is `name=(.*?)&`, so a token at the
+                    # end without a trailing '&' (typically id_token) is dropped -> ""
+                    # -> _api_auth later fails with an empty id-token even though the SSO
+                    # cookies were valid. Then require .complete before committing the
+                    # tokens, mirroring _resume_tokens_after_2fa, instead of proceeding
+                    # with a half-parsed fragment.
+                    t = parse_token_fragment(text + "&")
+                    if not t.complete:
+                        self._phase(
+                            "introduce", status=resp.status,
+                            no_auth_needed=True, tokens_complete=False,
+                        )
+                        raise NativeAuthError(
+                            f"introduce: incomplete token fragment (status {resp.status})"
+                        )
                     self.access_token = t.access_token
                     self.refresh_token = t.refresh_token
                     self.id_token = t.id_token
@@ -470,10 +486,16 @@ class HonAuth:
         return True
 
     def clear(self) -> None:
-        # Note: `AUTH_API.split("/")[-2]` is '' here (not the host, because there is
-        # no trailing slash), so clear_domain('') is effectively a no-op on any
-        # session. This is intentional.
-        self._session.cookie_jar.clear_domain(AUTH_API.split("/")[-2])
+        # Clear the auth host's cookies so a REUSED session cannot carry a stale SSO
+        # cookie into the next login and send _introduce down the already-authorized
+        # fast-path with tokens that may no longer be valid. The previous
+        # `AUTH_API.split("/")[-2]` was '' (AUTH_API has no trailing slash), so
+        # clear_domain('') was a no-op and never cleared anything; use the real host.
+        # urlsplit().netloc (stdlib) mirrors how oauth._AUTH_HOST is derived and, unlike
+        # yarl.URL(...).host, works under the CI's minimal URL stub (which has no .host).
+        auth_host = urlsplit(AUTH_API).netloc
+        if auth_host:
+            self._session.cookie_jar.clear_domain(auth_host)
         self.cognito_token = ""
         self.id_token = ""
         self.access_token = ""

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -66,6 +66,14 @@ class HonConnection:
         # a concurrent burst collapses to a single refresh without gating on
         # token_expires_soon (a non-expiry 401 must still refresh once). See CR#3.
         self._refresh_gen = 0
+        # Single-flight the loop-1 re-auth even when it FAILS. If authenticate()
+        # raises (typically MFAChallengeRequired), the generation is still advanced
+        # and the exception cached against the generation that was rejected, so the
+        # other siblings of the burst reuse THIS error instead of each firing their
+        # own create()+authenticate() -- N sequential logins / OTP prompts on a 2FA
+        # account, exactly when the login is already failing.
+        self._reauth_error: BaseException | None = None
+        self._reauth_error_gen = -1
 
     @property
     def device(self) -> HonDevice:
@@ -161,6 +169,52 @@ class HonConnection:
                 self._refresh_token = self.auth.refresh_token
                 self._refresh_gen += 1
 
+    async def _reauth_after_rejection(self, gen_at_send: int) -> None:
+        # Full re-login recovery (loop 1), single-flighted under the SAME lock and
+        # generation as the refresh path. Without this, a concurrent-request burst
+        # (e.g. command_loader's asyncio.gather) that all reach loop 1 would each call
+        # create() -- which resets self._auth to a FRESH, token-less HonAuth -- so the
+        # loop-2 _check_headers of every sibling sees _need_auth() True and fires its
+        # OWN full Salesforce login on the shared ClientSession. The concurrent logins
+        # race on the shared cookie jar (the OAuth flow needs the cookies to persist in
+        # sequence) and, with 2FA on, generate multiple OTP emails / MFAChallengeRequired.
+        # Under the lock we re-auth only if no sibling (refresh OR re-auth) has advanced
+        # the generation since THIS request was sent; otherwise we reuse their fresh
+        # tokens. authenticate() here (instead of relying on the loop-2 _check_headers)
+        # keeps the whole re-login inside the lock so the burst collapses to exactly one.
+        async with self._refresh_lock:
+            if self._refresh_gen != gen_at_send:
+                # A sibling already ran the re-auth for this generation. If it FAILED
+                # (e.g. MFA), re-raise its cached error instead of recursing to loop 2
+                # -- where _check_headers would see the token-less auth create() left
+                # behind and fire our OWN login (another OTP). Collapsing the FAILING
+                # burst to one attempt is the whole point on a 2FA account.
+                if self._reauth_error is not None and self._reauth_error_gen == gen_at_send:
+                    raise self._reauth_error
+                return  # a sibling already re-authenticated; reuse its fresh tokens
+            try:
+                await self.create()
+                await self.auth.authenticate()
+            except BaseException as err:
+                # Advance the generation and cache the error so the siblings above
+                # skip their own login and reuse this one. create() has already reset
+                # self._auth to a token-less HonAuth, so leaving the gen unbumped would
+                # let every sibling re-login through loop-2 _check_headers.
+                self._reauth_error = err
+                self._reauth_error_gen = gen_at_send
+                self._refresh_gen += 1
+                raise
+            self._reauth_error = None
+            self._refresh_token = self.auth.refresh_token
+            self._refresh_gen += 1
+
+    @staticmethod
+    def _is_html_challenge(response: aiohttp.ClientResponse) -> bool:
+        # A 403 whose body is HTML is a WAF/Cloudflare challenge or captive portal,
+        # not an hOn auth rejection (the hOn API answers auth failures with JSON).
+        content_type = getattr(response, "content_type", "") or ""
+        return content_type in ("text/html", "application/xhtml+xml")
+
     @asynccontextmanager
     async def _intercept(
         self, method, url: Any, *args: Any, loop: int = 0, **kwargs: Any
@@ -180,6 +234,17 @@ class HonConnection:
             # flag stays True for the whole period). For a POST /commands/v1/send that
             # means the command is delivered TWICE. Token expiry is already handled
             # BEFORE the request in _check_headers; here we only recover a rejection.
+            if response.status == 403 and self._is_html_challenge(response):
+                # A Cloudflare/WAF HTML 403 is a TRANSIENT edge hiccup, not bad
+                # credentials: routing it through refresh -> re-auth -> NativeAuthError
+                # would open a spurious reauth (and, with 2FA on, prompt for a new OTP).
+                # Attach DECODE_ERROR (requires_reauth=False) so the coordinator retries
+                # via UpdateFailed instead, exactly like the non-JSON body branch below.
+                # hOn's real auth-403s carry a JSON body and still follow the ladder.
+                _LOGGER.info("addhOn: HTML 403 (edge challenge), transient retry")
+                err = NativeAuthError("Decode Error (status 403)")
+                err.error_code = DECODE_ERROR
+                raise err
             if response.status in (401, 403) and loop == 0:
                 _LOGGER.info("addhOn: rejected (%s), refresh+retry", response.status)
                 await self._refresh_after_rejection(refresh_gen)
@@ -187,7 +252,7 @@ class HonConnection:
                     yield result
             elif response.status in (401, 403) and loop == 1:
                 _LOGGER.warning("addhOn: re-auth after %s", response.status)
-                await self.create()
+                await self._reauth_after_rejection(refresh_gen)
                 async with self._intercept(method, url, *args, loop=2, **kwargs) as result:
                     yield result
             elif loop >= 2 and (

--- a/custom_components/addhon/client/transport/connection.py
+++ b/custom_components/addhon/client/transport/connection.py
@@ -195,6 +195,16 @@ class HonConnection:
             try:
                 await self.create()
                 await self.auth.authenticate()
+            except asyncio.CancelledError:
+                # A cancellation is specific to THIS task, not a shared auth failure:
+                # caching it in _reauth_error would re-raise it into sibling requests
+                # (the branch above) that were never cancelled. Still advance the
+                # generation -- create() already reset self._auth to a token-less
+                # HonAuth, so an unbumped gen would let every sibling re-login through
+                # loop-2 _check_headers -- but do NOT store it; re-raise so only this
+                # task unwinds.
+                self._refresh_gen += 1
+                raise
             except BaseException as err:
                 # Advance the generation and cache the error so the siblings above
                 # skip their own login and reuse this one. create() has already reset

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -447,6 +447,16 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             target = AC_SWING_V_ON
         else:
             target = fixed_vertical_value(allowed)
+            if target == AC_SWING_V_ON:
+                # No genuine fixed (non-swing) position exists for this model, so
+                # fixed_vertical_value fell back to the swing-ON code (8). Sending it
+                # for an OFF request would START oscillation -- the opposite of what
+                # was asked. Refuse instead of transmitting the wrong command.
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="swing_position_not_allowed",
+                    translation_placeholders={"position": str(target), "allowed": str(allowed)},
+                )
         if allowed and target not in allowed:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -24,6 +24,7 @@ from .const import (
     AC_TEMP_PARAM,
     AC_MODE_PARAM,
     AC_FAN_PARAM,
+    AC_ON_OFF_PARAM,
     AC_ATTR_ON_OFF,
     AC_ATTR_CURRENT_TEMP,
     AC_ATTR_FAN_SPEED,
@@ -32,6 +33,9 @@ from .const import (
     AC_SWING_V_ON,
     AC_SWING_MODE_ON,
     AC_SWING_MODE_OFF,
+    AC_PROGRAM_MAP,
+    AC_PROGRAM_SIMPLE_START,
+    PROGRAM_PARAM_NAMES,
 )
 from .debug_utils import command_names, redact_id
 from .ac_command import (
@@ -40,7 +44,12 @@ from .ac_command import (
     param_allowed_values,
     settings_param,
 )
-from .hon_commands import param_range
+from .hon_commands import async_send_command, param_range, param_values
+from .program_options import async_send_program, startprogram_command
+
+# startProgram/stopProgram are the two program-based AC write commands (see
+# AC_PROGRAM_MAP in const.py). The names are stable across program category swaps.
+STOPPROGRAM_COMMAND = "stopProgram"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -301,8 +310,87 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         _LOGGER.debug("Climate debug: swing_mode windDirectionVertical=%s -> %s", val, mode)
         return mode
 
+    def _is_program_based(self) -> bool:
+        """True for AC models that drive power/mode via startProgram/stopProgram.
+
+        Two AC write models exist (see AC_PROGRAM_MAP in const.py):
+        - settings-based (e.g. AS35PBPHRA-PRE): the `settings` command carries
+          onOffStatus + machMode, so power/mode are written into `settings`.
+        - program-based (e.g. AD71S2SM3FA(H)): the `settings` command has NO
+          onOffStatus; ON goes through startProgram (program enum, onOffStatus fixed
+          "1") and OFF through stopProgram (onOffStatus fixed "0"). Writing
+          onOffStatus/machMode into `settings` on such a model raises
+          "Parameter(s) not found" before the request ever reaches the cloud, which
+          is exactly why every on/off/mode command looked "ignored".
+
+        The gate: NO onOffStatus among the settings params AND a startProgram command
+        exists. Temperature/fan stay on the settings path in BOTH models (tempSel /
+        windSpeed live on `settings` either way), so only power/mode is rerouted.
+        """
+        if settings_param(self._appliance, AC_ON_OFF_PARAM) is not None:
+            return False
+        return startprogram_command(self._appliance) is not None
+
+    def _startprogram_programs(self) -> list[str]:
+        """Program codes the device declares in its startProgram enum, or [].
+
+        Reads the `program`/`prCode` parameter's .values off the startProgram
+        command. Used to capability-gate a mapped program BEFORE sending it.
+        """
+        command = startprogram_command(self._appliance)
+        params = getattr(command, "parameters", None) if command is not None else None
+        if not isinstance(params, dict):
+            return []
+        for pname in PROGRAM_PARAM_NAMES:
+            param = params.get(pname)
+            if param is not None:
+                return param_values(param)
+        return []
+
+    def _program_for_mode(self, hvac_mode: HVACMode) -> str:
+        """Map a (non-OFF) HVAC mode to its startProgram code, capability-gated.
+
+        FAN_ONLY special-cases to iot_fan (NOT iot_fan_only). Raises
+        program_not_supported when the mode has no program mapping, or when the
+        mapped program is absent from the device's live startProgram enum -- never
+        silently no-op nor fall back to the settings path (which lacks onOffStatus).
+        Called BEFORE the send try-block so the specific key is not rewrapped.
+        """
+        program_code = AC_PROGRAM_MAP.get(hvac_mode.value)
+        if program_code is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="program_not_supported",
+                translation_placeholders={"program": str(hvac_mode.value)},
+            )
+        self._assert_program_available(program_code)
+        return program_code
+
+    def _assert_program_available(self, program_code: str) -> None:
+        """Guard: raise program_not_supported if the device's startProgram enum is
+        readable AND does not declare `program_code`. When the enum is unreadable
+        (empty) we let it through (the engine enum setter still rejects a bad value),
+        mirroring the hvac_modes/fan_modes full-list fallback."""
+        available = self._startprogram_programs()
+        if available and program_code not in available:
+            _LOGGER.debug(
+                "Climate debug: program %s not in startProgram enum %s",
+                program_code,
+                available,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="program_not_supported",
+                translation_placeholders={"program": str(program_code)},
+            )
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Send the mode change, converting the HVACMode into the exact hOn numeric code."""
+        """Send the mode change.
+
+        Settings-based model: onOffStatus (+ machMode) into the `settings` command,
+        exactly as before. Program-based model: OFF -> stopProgram; a concrete mode ->
+        startProgram with the mapped iot_<mode> program.
+        """
         appliance = self._appliance
         client = self._hon_client
         # Both checks BEFORE the try: a missing appliance/client must surface the
@@ -313,10 +401,34 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="appliance_or_client_unavailable",
             )
+        program_based = self._is_program_based()
+        # Resolve + capability-gate the program BEFORE the try, so a
+        # program_not_supported surfaces with its own key (like the swing gate) rather
+        # than being rewrapped into command_error by the except below.
+        program_code = None
+        if program_based and hvac_mode != HVACMode.OFF:
+            program_code = self._program_for_mode(hvac_mode)
         try:
             if hvac_mode == HVACMode.OFF:
-                _LOGGER.debug("Climate debug: set_hvac_mode OFF -> onOffStatus=0")
-                await self._send_command_in_executor(client, appliance, {"onOffStatus": "0"})
+                if program_based:
+                    # Program-based OFF: stopProgram carries the mandatory fixed
+                    # onOffStatus="0"; the engine serializes it, no override needed.
+                    _LOGGER.debug("Climate debug: set_hvac_mode OFF -> stopProgram")
+                    await async_send_command(
+                        self.hass, client, appliance, STOPPROGRAM_COMMAND, {}
+                    )
+                else:
+                    _LOGGER.debug("Climate debug: set_hvac_mode OFF -> onOffStatus=0")
+                    await self._send_command_in_executor(
+                        client, appliance, {"onOffStatus": "0"}
+                    )
+            elif program_based:
+                _LOGGER.debug(
+                    "Climate debug: set_hvac_mode %s -> startProgram %s",
+                    hvac_mode,
+                    program_code,
+                )
+                await async_send_program(self.hass, client, appliance, program_code)
             else:
                 # HVACMode is a StrEnum: .value returns the string directly ("cool", "heat", etc.)
                 mode_str = hvac_mode.value
@@ -345,8 +457,10 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
         """Turn the AC back on, restoring its last mode.
 
         HA convention for TURN_ON is to resume the previous operating state, not
-        force a fixed mode. We send only onOffStatus=1: the device keeps its stored
-        machMode, so it resumes the last mode (the old code forced COOL).
+        force a fixed mode. Settings-based model: send only onOffStatus=1, so the
+        device keeps its stored machMode and resumes the last mode (the old code
+        forced COOL). Program-based model: send startProgram iot_simple_start, the
+        program the device uses to resume its last mode.
         """
         appliance = self._appliance
         client = self._hon_client
@@ -355,9 +469,23 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="appliance_or_client_unavailable",
             )
+        program_based = self._is_program_based()
+        # Capability-gate simple-start BEFORE the try (same reasoning as set_hvac_mode).
+        if program_based:
+            self._assert_program_available(AC_PROGRAM_SIMPLE_START)
         try:
-            _LOGGER.debug("Climate debug: turn_on -> onOffStatus=1 (mode preserved)")
-            await self._send_command_in_executor(client, appliance, {"onOffStatus": "1"})
+            if program_based:
+                _LOGGER.debug(
+                    "Climate debug: turn_on -> startProgram %s", AC_PROGRAM_SIMPLE_START
+                )
+                await async_send_program(
+                    self.hass, client, appliance, AC_PROGRAM_SIMPLE_START
+                )
+            else:
+                _LOGGER.debug("Climate debug: turn_on -> onOffStatus=1 (mode preserved)")
+                await self._send_command_in_executor(
+                    client, appliance, {"onOffStatus": "1"}
+                )
             await self._async_request_command_refresh()
         except Exception as err:
             _LOGGER.error("Climate: turn_on error: %s", err, exc_info=True)

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -226,6 +226,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
+        if reauth_entry is None:
+            # The entry was removed while the reauth flow was open: abort cleanly
+            # instead of raising AttributeError on reauth_entry.data below. Use a
+            # dedicated reason -- reauth_account_mismatch ("credentials must belong to
+            # the same account") would be a misleading message for a missing entry.
+            return self.async_abort(reason="reauth_entry_not_found")
         email = reauth_entry.data["email"]
 
         if user_input is not None:

--- a/custom_components/addhon/const.py
+++ b/custom_components/addhon/const.py
@@ -125,6 +125,12 @@ AC_ATTR_TEMP         = "settings.tempSel"
 AC_TEMP_PARAM        = "tempSel"
 AC_MODE_PARAM        = "machMode"
 AC_FAN_PARAM         = "windSpeed"
+# Bare power-flag parameter NAME inside the "settings" command (distinct from the
+# dotted read-side AC_ATTR_ON_OFF below). It is present in `settings` ONLY on the
+# settings-based AC write model (e.g. AS35PBPHRA-PRE); its ABSENCE is the signal of
+# the program-based write model (e.g. AD71S2SM3FA(H)) whose power/mode go through
+# startProgram/stopProgram instead. Used as the write-path capability gate.
+AC_ON_OFF_PARAM      = "onOffStatus"
 # tempIndoor / tempOutdoor are DIRECT attributes (not in settings), confirmed from diagnostics
 AC_ATTR_CURRENT_TEMP     = "tempIndoor"
 AC_ATTR_OUTDOOR_TEMP     = "tempOutdoor"
@@ -175,6 +181,30 @@ AC_FAN_MAP = {
     "1": "high",
 }
 AC_FAN_MAP_REVERSE = {v: k for k, v in AC_FAN_MAP.items()}
+
+# --- Program-based AC write model (e.g. AD71S2SM3FA(H)) ------------------------
+# Two AC write models exist in the hOn fleet:
+#   1) settings-based (AS35PBPHRA-PRE): the `settings` command carries onOffStatus +
+#      machMode, so power/mode are written directly into `settings`.
+#   2) program-based (AD71S2SM3FA(H)): the `settings` command has NO onOffStatus (and
+#      no machMode power semantics); power/mode are driven by a startProgram command
+#      (program enum + onOffStatus fixed "1") for ON and a stopProgram (onOffStatus
+#      fixed "0") for OFF.
+# This map routes an HA HVAC mode to the startProgram program code for model (2). Keys
+# are the SAME HA mode strings AC_MODE_MAP already produces, so it composes with the
+# read side. FAN_ONLY (HVACMode.FAN_ONLY.value == "fan_only") special-cases to
+# "iot_fan", NOT "iot_fan_only" -- a naive "iot_" + mode.value would be wrong. OFF is
+# handled via stopProgram (not a program), so it is intentionally not a key here.
+AC_PROGRAM_MAP = {
+    "auto": "iot_auto",
+    "cool": "iot_cool",
+    "dry": "iot_dry",
+    "heat": "iot_heat",
+    "fan_only": "iot_fan",
+}
+# turn_on (resume last mode) uses this program on the program-based model. It is not
+# an HVAC-mode key: HA TURN_ON means "resume", which the device maps to simple-start.
+AC_PROGRAM_SIMPLE_START = "iot_simple_start"
 
 # --- AC fan-direction position selects (discussion #37) -----------------------
 # windDirectionVertical / windDirectionHorizontal are PER-MODEL position ENUMS. The two

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -32,7 +32,7 @@ from .const import (
     DOMAIN,
     PROGRAM_PARAM_NAMES,
 )
-from .debug_utils import redact_id
+from .debug_utils import _MAC_RE, redact_id
 from .hon_commands import SETTINGS_COMMANDS, param_range, param_values
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ _TO_REDACT = frozenset(
         # (leaks the full MAC despite mac/macAddress being redacted), mobileId is the
         # phone-install id of whoever issued the last command (often a third party).
         "transactionid",
+        "transaction_id",
         "mobileid",
         "mobile_id",
     }
@@ -177,14 +178,16 @@ def _jsonable(value):
     encoder raises ``TypeError`` on them. Unwrap a ``.value`` if present (one level),
     else stringify, so the dump never carries an unserializable object.
     """
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if value is None or isinstance(value, (bool, int, float)):
         return value
+    if isinstance(value, str):
+        return _MAC_RE.sub(_REDACTED, value)
     if hasattr(value, "value"):
         inner = value.value
-        if inner is None or isinstance(inner, (str, int, float, bool)):
+        if inner is None or isinstance(inner, (bool, int, float)):
             return inner
-        return str(inner)
-    return str(value)
+        return _MAC_RE.sub(_REDACTED, str(inner))
+    return _MAC_RE.sub(_REDACTED, str(value))
 
 
 def _redact(value):
@@ -220,12 +223,19 @@ def _param_schema(param) -> dict:
         "category": getattr(param, "category", None),
         "mandatory": getattr(param, "mandatory", None),
     }
-    enum = param_values(param)
-    if enum:
-        schema["enum"] = enum
+    # Check range FIRST and emit ONLY min/max/step for a range param. param_values()
+    # calls `.values`, which on a HonParameterRange ENUMERATES the whole grid (up to
+    # _MAX_RANGE_VALUES = 100000 strings) synchronously on the event loop -- a huge,
+    # redundant dump for what min/max/step already describe. program_options makes the
+    # same rule explicit ("never call .values on a HonParameterRange"). enum is only
+    # meaningful for enum/fixed params, where param_range() returns None.
     rng = param_range(param)
     if rng is not None:
         schema["min"], schema["max"], schema["step"] = rng
+    else:
+        enum = param_values(param)
+        if enum:
+            schema["enum"] = enum
     return schema
 
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -216,7 +216,8 @@ def _param_value(param):
 
 
 def _param_schema(param) -> dict:
-    """Full schema of one command parameter: value + enum + range + metadata."""
+    """Schema of one command parameter: value + metadata, plus range (min/max/step)
+    for a range param OR enum as a fallback only when the param is not a range."""
     schema: dict = {
         "value": _param_value(param),
         "typology": getattr(param, "typology", None),

--- a/custom_components/addhon/hon_commands.py
+++ b/custom_components/addhon/hon_commands.py
@@ -20,6 +20,7 @@ import logging
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
+from .param_rollback import restore_params, snapshot_params
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,18 +134,10 @@ async def async_send_command(
                 )
             # Snapshot of the complete internal state of EVERY parameter BEFORE pre_send.
             # Assigning a trigger parameter fires the rules, which mutate the siblings
-            # (value AND values/min/max). On a pre_send or send() failure we restore by
-            # copying __dict__ DIRECTLY, without going through the setters: this way we
-            # do NOT re-fire the rules and we also restore values/min/max. A rollback
-            # via setter would leave the .values restricted and would raise on
-            # revalidation -> corrupted state that would contaminate later sends. The
-            # parameters REPLACE the lists (never mutated in-place), so a shallow copy
-            # of __dict__ is enough.
-            snapshots: dict = {
-                key: dict(attr.__dict__)
-                for key, attr in command_params.items()
-                if hasattr(attr, "__dict__")
-            }
+            # (value AND values/min/max); on a pre_send or send() failure we restore the
+            # full pre-mutation state via the shared param_rollback helper (copies
+            # __dict__ directly, so rules are not re-fired and values/min/max come back).
+            snapshots = snapshot_params(command_params)
             try:
                 if pre_send is not None:
                     pre_send(command_params)
@@ -153,12 +146,7 @@ async def async_send_command(
                     _LOGGER.debug("Command %s: '%s' = %s", command_name, key, value)
                 await command.send()
             except Exception:
-                for key, snap in snapshots.items():
-                    attr = command_params.get(key)
-                    if attr is None or not hasattr(attr, "__dict__"):
-                        continue
-                    attr.__dict__.clear()
-                    attr.__dict__.update(snap)
+                restore_params(command_params, snapshots)
                 raise
             _LOGGER.debug(
                 "Command %s: send completed (params=%s)", command_name, list(params)

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.7.2"
+  "version": "5.8.0"
 }

--- a/custom_components/addhon/param_rollback.py
+++ b/custom_components/addhon/param_rollback.py
@@ -1,0 +1,43 @@
+"""Shared snapshot/restore of engine parameter state for send-path rollback.
+
+Assigning a value to a HonParameter (or applying a program) mutates the parameter
+IN PLACE -- not only ``.value`` but also ``.values``/``.min``/``.max`` when the
+assignment fires the command rules. If the subsequent ``command.send()`` fails we
+must restore the FULL pre-mutation state, and do it by copying ``__dict__``
+DIRECTLY (not via the setter) so the rules are NOT re-fired and the restricted
+lists are restored too. A setter-based rollback would leave ``.values`` narrowed
+and raise on revalidation, corrupting state that then contaminates later sends.
+
+Centralized here so every send path (``hon_commands.async_send_command``,
+``button``, ``switch``, ``program_options``) rolls back identically instead of
+keeping four copies that could drift apart on future edge-case fixes.
+"""
+from __future__ import annotations
+
+
+def snapshot_params(params) -> dict:
+    """Shallow-copy the ``__dict__`` of every parameter in ``params``, keyed by name.
+
+    Returns ``{}`` when ``params`` is not a dict. Parameters without a ``__dict__``
+    are skipped (nothing to restore for them). The lists inside a parameter are
+    REPLACED on mutation (never edited in place), so a shallow copy is enough.
+    """
+    if not isinstance(params, dict):
+        return {}
+    return {k: dict(p.__dict__) for k, p in params.items() if hasattr(p, "__dict__")}
+
+
+def restore_params(params, snapshot) -> None:
+    """Restore each snapshotted parameter's ``__dict__`` into ``params`` in place.
+
+    Copies ``__dict__`` directly (bypassing the setter) so rules are NOT re-fired
+    and ``values``/``min``/``max`` are restored too. No-op for a non-dict ``params``
+    or a parameter that has since disappeared / lost its ``__dict__``.
+    """
+    if not isinstance(params, dict):
+        return
+    for key, saved in snapshot.items():
+        param = params.get(key)
+        if param is not None and hasattr(param, "__dict__"):
+            param.__dict__.clear()
+            param.__dict__.update(saved)

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -35,6 +35,7 @@ from .base_entity import HonBaseEntity
 from .const import DOMAIN, PROGRAM_PARAM_NAMES, PROGRAM_PENDING_OPTIONS
 from .debug_utils import redact_id
 from .hon_commands import get_command, get_commands, param_range, param_values
+from .param_rollback import restore_params, snapshot_params
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,11 +92,7 @@ async def async_send_program(hass, client, appliance, program_code: str) -> None
             # poll. The command-pointer reset below is the load-bearing undo for the swap;
             # the param-__dict__ restore covers the value-mutating (prCode) case.
             original_command = command
-            snapshots: dict = {
-                key: dict(attr.__dict__)
-                for key, attr in params.items()
-                if hasattr(attr, "__dict__")
-            }
+            snapshots = snapshot_params(params)
             try:
                 applied = False
                 for pname in PROGRAM_PARAM_NAMES:
@@ -119,15 +116,10 @@ async def async_send_program(hass, client, appliance, program_code: str) -> None
                     command = refreshed
                 await command.send()
             except Exception:
-                # Restore the pre-swap parameter state (copy __dict__ directly, bypassing
-                # the setters so a value-mutating param does not re-fire its rules) and
+                # Restore the pre-swap parameter state (shared helper copies __dict__
+                # directly, so a value-mutating param does not re-fire its rules) and
                 # reset the swapped command pointer to the original.
-                for key, snap in snapshots.items():
-                    attr = params.get(key)
-                    if attr is None or not hasattr(attr, "__dict__"):
-                        continue
-                    attr.__dict__.clear()
-                    attr.__dict__.update(snap)
+                restore_params(params, snapshots)
                 commands[STARTPROGRAM_COMMAND] = original_command
                 raise
             _LOGGER.debug(

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .base_entity import HonBaseEntity
+from .base_entity import HonBaseEntity, coordinator_data_map
 from .const import (
     AC_ATTR_SWING_H,
     AC_ATTR_SWING_V,
@@ -218,7 +218,7 @@ async def async_setup_entry(
     coordinator = entry_data["coordinator"]
     client = entry_data["client"]
     entities = []
-    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    data_map = coordinator_data_map(coordinator)
     for appliance_id, data in data_map.items():
         appliance = data.get("appliance")
         app_type = data.get("type")

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -218,7 +218,8 @@ async def async_setup_entry(
     coordinator = entry_data["coordinator"]
     client = entry_data["client"]
     entities = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         appliance = data.get("appliance")
         app_type = data.get("type")
         _LOGGER.debug(
@@ -321,8 +322,23 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         if appliance is not None:
             self._program_map = self._load_programs(appliance)
 
-        self._program_reverse: dict[str, str] = {v: k for k, v in self._program_map.items()}
-        self._attr_options = list(self._program_reverse.keys())
+        # Disambiguate collided labels: two program CODES sharing a display label would
+        # otherwise collapse in the reverse map, leaving one program unreachable from the
+        # UI and mapping current_option of the lost code onto the survivor's code. Suffix
+        # ONLY the colliding labels with their raw code so every code stays selectable and
+        # the reverse map is injective (mirrors HonProgramOptionSelect). Unique labels are
+        # untouched, keeping their translatable string.
+        label_counts: dict[str, int] = {}
+        for label in self._program_map.values():
+            label_counts[label] = label_counts.get(label, 0) + 1
+        self._program_display: dict[str, str] = {
+            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
+            for code, label in self._program_map.items()
+        }
+        self._program_reverse: dict[str, str] = {
+            display: code for code, display in self._program_display.items()
+        }
+        self._attr_options = list(self._program_display.values())
         _LOGGER.debug(
             "Select debug: initialized '%s' id=%s programs=%d map=%s",
             redact_id(self._attr_unique_id, appliance_id),
@@ -449,7 +465,7 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         #    until the user starts the cycle with the "Avvia programma" button.
         pending = self._coordinator_store(PROGRAM_PENDING_STORE).get(self._appliance_id)
         if pending is not None:
-            label = self._program_map.get(str(pending))
+            label = self._program_display.get(str(pending))
             if label is not None:
                 _LOGGER.debug(
                     "Select debug: current_option uses pending id=%s code=%s label=%s",
@@ -495,9 +511,9 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
                     "Select debug: current_option key '%s' token code=%s label=%s",
                     key,
                     token,
-                    self._program_map[token],
+                    self._program_display[token],
                 )
-                return self._program_map[token]
+                return self._program_display[token]
             if token in self._program_reverse:
                 _LOGGER.debug(
                     "Select debug: current_option key '%s' token label=%s",

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -35,7 +35,12 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .base_entity import HonAccountCoordinatorEntity, HonAccountEntity, HonBaseEntity
+from .base_entity import (
+    HonAccountCoordinatorEntity,
+    HonAccountEntity,
+    HonBaseEntity,
+    coordinator_data_map,
+)
 from .const import (
     APPLIANCE_AC,
     APPLIANCE_DW,
@@ -834,7 +839,7 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[SensorEntity] = []
-    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    data_map = coordinator_data_map(coordinator)
     for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -834,7 +834,8 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
     entities: list[SensorEntity] = []
-    for appliance_id, data in coordinator.data.items():
+    data_map = coordinator.data if isinstance(coordinator.data, dict) else {}
+    for appliance_id, data in data_map.items():
         app_type = data.get("type", "")
         attributes = data.get("attributes", {})
         attributes = attributes if isinstance(attributes, dict) else {}

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -25,6 +25,7 @@ from .const import (
     WM_ATTR_STATUS,
 )
 from .debug_utils import redact_id
+from .param_rollback import restore_params, snapshot_params
 from .program_options import (
     HonProgramOptionEntity,
     normalize_code,
@@ -272,9 +273,10 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
                     )
                     if isinstance(params, dict) and "pause" in params:
                         pause_param = params["pause"]
-                        if hasattr(pause_param, "__dict__"):
-                            restore_pause["param"] = pause_param
-                            restore_pause["snap"] = dict(pause_param.__dict__)
+                        # Snapshot only the pause param (shared helper, keyed dict form)
+                        # so a send failure restores it without re-firing rules.
+                        restore_pause["params"] = params
+                        restore_pause["snap"] = snapshot_params({"pause": pause_param})
                         previous = getattr(pause_param, "value", None)
                         pause_param.value = pause_value
                         _LOGGER.debug(
@@ -296,11 +298,7 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             _LOGGER.info("Pause: %s sent", command_name)
             await self._async_request_command_refresh()
         except Exception as err:
-            param = restore_pause.get("param")
-            snap = restore_pause.get("snap")
-            if param is not None and isinstance(snap, dict):
-                param.__dict__.clear()
-                param.__dict__.update(snap)
+            restore_params(restore_pause.get("params"), restore_pause.get("snap", {}))
             _LOGGER.error("Pause %s: Error: %s", command_name, err, exc_info=True)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -252,6 +252,10 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             redact_id(self._appliance_id),
             _command_names(appliance),
         )
+        # Rollback state: the pause param is mutated in memory before send; on a send
+        # failure restore it so the switch does not report a local pause/resume the
+        # cloud never accepted until the next poll. Populated inside _inner.
+        restore_pause: dict = {}
         try:
             def _do():
                 async def _inner():
@@ -267,8 +271,12 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
                         _param_snapshot(params),
                     )
                     if isinstance(params, dict) and "pause" in params:
-                        previous = getattr(params["pause"], "value", None)
-                        params["pause"].value = pause_value
+                        pause_param = params["pause"]
+                        if hasattr(pause_param, "__dict__"):
+                            restore_pause["param"] = pause_param
+                            restore_pause["snap"] = dict(pause_param.__dict__)
+                        previous = getattr(pause_param, "value", None)
+                        pause_param.value = pause_value
                         _LOGGER.debug(
                             "Switch debug: pause parameter set to %s (previous=%s)",
                             pause_value,
@@ -280,6 +288,7 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
                             command_name,
                         )
                     await command.send()
+                    restore_pause.clear()  # sent: nothing to roll back
                     _LOGGER.debug("Switch debug: command '%s' send completed", command_name)
                 client.run_command_sync(_inner())
 
@@ -287,6 +296,11 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
             _LOGGER.info("Pause: %s sent", command_name)
             await self._async_request_command_refresh()
         except Exception as err:
+            param = restore_pause.get("param")
+            snap = restore_pause.get("snap")
+            if param is not None and isinstance(snap, dict):
+                param.__dict__.clear()
+                param.__dict__.update(snap)
             _LOGGER.error("Pause %s: Error: %s", command_name, err, exc_info=True)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -53,6 +53,7 @@
       "already_configured": "This hOn account is already configured.",
       "reauth_successful": "Re-authentication was successful.",
       "reauth_account_mismatch": "The new credentials must belong to the same hOn account.",
+      "reauth_entry_not_found": "The configuration entry no longer exists. Please add the integration again.",
       "mfa_no_challenge": "The two-factor session expired. Please start again."
     }
   },

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -816,6 +816,9 @@
     "program_not_found": {
       "message": "Program \"{program}\" was not found."
     },
+    "program_not_supported": {
+      "message": "Program \"{program}\" is not supported by this device."
+    },
     "refresh_after_command_failed": {
       "message": "Refresh after the command failed."
     },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -816,6 +816,9 @@
     "program_not_found": {
       "message": "Programma \"{program}\" non trovato."
     },
+    "program_not_supported": {
+      "message": "Programma \"{program}\" non supportato da questo apparecchio."
+    },
     "refresh_after_command_failed": {
       "message": "Aggiornamento dopo il comando non riuscito."
     },

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -53,6 +53,7 @@
       "already_configured": "Questo account hOn è già configurato.",
       "reauth_successful": "Ri-autenticazione completata.",
       "reauth_account_mismatch": "Le nuove credenziali devono appartenere allo stesso account hOn.",
+      "reauth_entry_not_found": "La voce di configurazione non esiste più. Aggiungi di nuovo l'integrazione.",
       "mfa_no_challenge": "La sessione di verifica in due passaggi è scaduta. Riprova da capo."
     }
   },

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -174,6 +174,59 @@ def _climate_failing(params: dict):
     return entity, settings, coordinator
 
 
+# Golden startProgram `program` enum from the real program-based AC (AD71S2SM3FA(H)
+# diagnostics dump), NOT imported from const: a map mutation must be caught here.
+_PROGRAM_ENUM = [
+    "iot_10_heating",
+    "iot_auto",
+    "iot_cool",
+    "iot_dry",
+    "iot_fan",
+    "iot_heat",
+    "iot_simple_start",
+    "iot_uv",
+    "iot_uv_and_auto",
+    "iot_uv_and_cool",
+    "iot_uv_and_dry",
+    "iot_uv_and_fan",
+    "iot_uv_and_heat",
+]
+
+
+def _program_climate(program_enum: list | None = None, *, with_onoff: bool = False):
+    """Build a program-based AC: `settings` WITHOUT onOffStatus + startProgram/stopProgram.
+
+    This is the AD71S2SM3FA(H) write model: power/mode are driven by startProgram
+    (program enum, onOffStatus fixed "1") and stopProgram (onOffStatus fixed "0"),
+    NOT by onOffStatus/machMode in `settings`. temp/fan still live on `settings`.
+
+    ``with_onoff=True`` adds onOffStatus to `settings` to reproduce the AS35-style
+    settings-based model even though startProgram/stopProgram also exist: the gate
+    must then stay on the settings path (regression guard).
+
+    Returns (entity, settings_cmd, start_cmd, stop_cmd, coordinator).
+    """
+    enum = list(_PROGRAM_ENUM if program_enum is None else program_enum)
+    settings_params = {
+        "tempSel": Param("26"),
+        "machMode": Param("1", values=["0", "1", "2", "4", "6"]),
+        "windSpeed": Param("5", values=["5", "3", "2", "1"]),
+    }
+    if with_onoff:
+        settings_params["onOffStatus"] = Param("0")
+    settings = RecordingCommand(settings_params)
+    start = RecordingCommand(
+        {"onOffStatus": Param("1"), "program": Param(enum[0], values=enum)}
+    )
+    stop = RecordingCommand({"onOffStatus": Param("0")})
+    coordinator = FakeCoordinator(
+        _ac({"settings": settings, "startProgram": start, "stopProgram": stop})
+    )
+    entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+    entity.hass = FakeHass()
+    return entity, settings, start, stop, coordinator
+
+
 class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
     """climate.HaierClimateEntity send semantics."""
 
@@ -496,6 +549,159 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
             getattr(ctx.exception, "translation_key", None),
         )
         self.assertEqual(0, settings.send_calls)
+
+
+class AcClimateProgramWritePathTest(unittest.IsolatedAsyncioTestCase):
+    """Program-based AC (AD71S2SM3FA(H)): power/mode via startProgram/stopProgram.
+
+    Its `settings` command has NO onOffStatus, so the old settings path raised
+    "Parameter(s) not found" for on/off/mode -- every such command looked ignored.
+    Here on/off/mode must route to startProgram (ON) / stopProgram (OFF), while
+    temp/fan stay on `settings` (tempSel/windSpeed exist there). Assertions verify
+    the ACTUAL command sent (start vs stop vs settings) AND the program value.
+    """
+
+    async def test_turn_on_sends_startprogram_simple_start(self) -> None:
+        entity, settings, start, stop, coord = _program_climate()
+        await entity.async_turn_on()
+        # turn_on = resume last mode -> iot_simple_start on startProgram, NOT settings.
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual(
+            {"onOffStatus": "1", "program": "iot_simple_start"}, start.sent
+        )
+        self.assertEqual(0, stop.send_calls)
+        self.assertEqual(0, settings.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_set_hvac_mode_sends_mapped_program(self) -> None:
+        # Golden mode->program from the AD71 startProgram enum.
+        cases = [
+            (HVACMode.COOL, "iot_cool"),
+            (HVACMode.HEAT, "iot_heat"),
+            (HVACMode.AUTO, "iot_auto"),
+            (HVACMode.DRY, "iot_dry"),
+            (HVACMode.FAN_ONLY, "iot_fan"),
+        ]
+        for mode, program in cases:
+            with self.subTest(mode=mode):
+                entity, settings, start, stop, _ = _program_climate()
+                await entity.async_set_hvac_mode(mode)
+                self.assertEqual(1, start.send_calls)
+                self.assertEqual(
+                    {"onOffStatus": "1", "program": program}, start.sent
+                )
+                self.assertEqual(0, stop.send_calls)
+                self.assertEqual(0, settings.send_calls)
+
+    async def test_fan_only_maps_to_iot_fan_not_iot_fan_only(self) -> None:
+        # HVACMode.FAN_ONLY.value == "fan_only" but the program is iot_fan: a naive
+        # "iot_" + value would send iot_fan_only (absent from the enum). This locks
+        # the special case explicitly.
+        entity, _, start, _, _ = _program_climate()
+        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+        self.assertEqual("iot_fan", start.sent["program"])
+        self.assertNotEqual("iot_fan_only", start.sent["program"])
+
+    async def test_set_hvac_mode_off_sends_stopprogram(self) -> None:
+        entity, settings, start, stop, coord = _program_climate()
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        # OFF -> stopProgram (mandatory fixed onOffStatus="0" serialized by the engine).
+        self.assertEqual(1, stop.send_calls)
+        self.assertEqual({"onOffStatus": "0"}, stop.sent)
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, settings.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_turn_off_delegates_to_stopprogram(self) -> None:
+        entity, settings, start, stop, _ = _program_climate()
+        await entity.async_turn_off()
+        self.assertEqual(1, stop.send_calls)
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, settings.send_calls)
+
+    async def test_set_temperature_uses_settings_not_program(self) -> None:
+        entity, settings, start, stop, coord = _program_climate()
+        await entity.async_set_temperature(temperature=24)
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual("24", settings.sent["tempSel"])
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, stop.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_set_fan_mode_uses_settings_not_program(self) -> None:
+        entity, settings, start, stop, _ = _program_climate()
+        await entity.async_set_fan_mode("high")  # golden windSpeed high=1
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual("1", settings.sent["windSpeed"])
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, stop.send_calls)
+
+    async def test_mode_absent_from_enum_raises_without_send(self) -> None:
+        # startProgram enum lacks iot_dry: requesting DRY must raise
+        # program_not_supported and send NOTHING (no silent fallback to settings).
+        enum = ["iot_auto", "iot_cool", "iot_heat", "iot_fan", "iot_simple_start"]
+        entity, settings, start, stop, coord = _program_climate(enum)
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_hvac_mode(HVACMode.DRY)
+        self.assertEqual(
+            "program_not_supported", getattr(ctx.exception, "translation_key", None)
+        )
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, settings.send_calls)
+        self.assertEqual(0, coord.refreshes)
+
+    async def test_program_send_failure_raises_command_error(self) -> None:
+        # startProgram send fails -> command_error, no refresh (rollback path).
+        settings = RecordingCommand(
+            {"tempSel": Param("26"), "windSpeed": Param("5", values=["5", "1"])}
+        )
+        start = FailingCommand(
+            {"onOffStatus": Param("1"), "program": Param("iot_auto", values=_PROGRAM_ENUM)}
+        )
+        stop = RecordingCommand({"onOffStatus": Param("0")})
+        coordinator = FakeCoordinator(
+            _ac({"settings": settings, "startProgram": start, "stopProgram": stop})
+        )
+        entity = climate.HaierClimateEntity(coordinator, "ac-1", FakeClient())
+        entity.hass = FakeHass()
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual(
+            "command_error", getattr(ctx.exception, "translation_key", None)
+        )
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+
+
+class AcClimateSettingsRegressionTest(unittest.IsolatedAsyncioTestCase):
+    """Regression: an AS35-style settings-with-onOffStatus model keeps the settings
+    write path for on/off/mode EVEN IF startProgram/stopProgram also exist. The gate
+    keys on onOffStatus being present in `settings`, so it must never reroute here.
+    """
+
+    async def test_turn_on_uses_settings_onoffstatus(self) -> None:
+        entity, settings, start, stop, coord = _program_climate(with_onoff=True)
+        await entity.async_turn_on()
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, stop.send_calls)
+        self.assertEqual(1, coord.refreshes)
+
+    async def test_set_mode_uses_settings_machmode(self) -> None:
+        entity, settings, start, stop, _ = _program_climate(with_onoff=True)
+        await entity.async_set_hvac_mode(HVACMode.HEAT)  # golden machMode heat=4
+        self.assertEqual("4", settings.sent["machMode"])
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, stop.send_calls)
+
+    async def test_off_uses_settings_onoffstatus(self) -> None:
+        entity, settings, start, stop, _ = _program_climate(with_onoff=True)
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        self.assertEqual("0", settings.sent["onOffStatus"])
+        self.assertEqual(0, stop.send_calls)
+        self.assertEqual(0, start.send_calls)
 
 
 class AcClimateReadPathTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -342,6 +342,38 @@ class DiagnosticsValuesTest(unittest.TestCase):
         self.assertEqual(machmode["enum"], ["0", "1", "2"])
         self.assertEqual(machmode["value"], "1")
 
+    def test_range_param_schema_omits_enumerated_grid(self):
+        # A real HonParameterRange exposes BOTH min/max/step AND a .values property
+        # that ENUMERATES the whole grid (up to 100k strings). _param_schema must
+        # emit only min/max/step and never dump that grid into `enum`.
+        grid = [str(v) for v in range(0, 1401, 100)]
+        param = FakeParam(value="1000", typology="range", rng=(0, 1400, 100), values=grid)
+        schema = diagnostics._param_schema(param)
+        self.assertEqual((schema["min"], schema["max"], schema["step"]), (0, 1400, 100))
+        self.assertNotIn("enum", schema)
+
+    def test_mac_in_value_under_benign_key_is_masked(self):
+        # Identity that lands in a string VALUE under a non-redacted key (an event
+        # payload, a transactionId-shaped value under a benign name) must still be
+        # masked, matching the log path (debug_utils.redact_identity).
+        out = diagnostics._redact(
+            {"someInfo": "3c-71-bf-bd-32-2c_1699999999",
+             "nested": {"note": "mac 3C:71:BF:BD:32:2C here"}}
+        )
+        dumped = json.dumps(out)
+        self.assertNotIn("3c-71-bf-bd-32-2c", dumped)
+        self.assertNotIn("3C:71:BF:BD:32:2C", dumped)
+        self.assertEqual(out["someInfo"], "***_1699999999")
+
+    def test_mac_in_value_wrapped_object_is_masked(self):
+        # _jsonable also unwraps a HonAttribute/HonParameter-like object via `.value`;
+        # a MAC carried inside that `.value` must be masked too, so wrapping it does
+        # not smuggle the identity into the dump in cleartext.
+        out = diagnostics._redact({"deviceInfo": FakeWrapper("mac 3C:71:BF:BD:32:2C")})
+        dumped = json.dumps(out)
+        self.assertNotIn("3C:71:BF:BD:32:2C", dumped)
+        self.assertEqual(out["deviceInfo"], "mac ***")
+
 
 class DiagnosticsCoverageTest(unittest.TestCase):
     def test_unmapped_bare_attribute_surfaces(self):

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import sys
 import unittest
+from copy import copy
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -359,6 +360,100 @@ class ClusterBehaviorTest(unittest.TestCase):
 
     def test_favourite_added(self) -> None:
         self.assertIn("MyFav", _native_snapshot()["rich_favourites_categories"])
+
+    def test_favourite_does_not_corrupt_base_program(self) -> None:
+        # Regression: `_add_favourites` shallow-copied the base command, sharing its
+        # `_parameters` dict AND parameter objects. Applying MyFav (tempSel=7 on
+        # SUPER_COOL) then mutated the REAL super_cool program -> it got tempSel=7 and
+        # a favourite="1" flag, and `HonParameterProgram.ids` (which drops favourites)
+        # hid it entirely. HonCommand.__copy__ now isolates the parameters.
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS, favourites=_RICH_FAVOURITES))
+        start = app.commands["startProgram"]
+        base = start.categories["super_cool"]  # the real program, not the MyFav copy
+        # base keeps its own default, untouched by the favourite's tempSel=7
+        self.assertEqual(float(base.parameters["tempSel"].value), 5.0)
+        # base is NOT flagged as a favourite...
+        self.assertNotIn("favourite", base.parameters)
+        # ...so it still appears in the selectable program ids (prCode 1 -> super_cool)
+        self.assertEqual(start.parameters["program"].ids.get(1), "super_cool")
+        # the favourite itself is a distinct command carrying tempSel=7 + favourite=1
+        fav = start.categories["MyFav"]
+        self.assertEqual(float(fav.parameters["tempSel"].value), 7.0)
+        self.assertEqual(str(fav.parameters["favourite"].value), "1")
+
+    def test_favourite_copy_rules_do_not_corrupt_base(self) -> None:
+        # Regression: isolating `_parameters` in __copy__ was not enough. A shallow-copied
+        # parameter SHARED its trigger table with the base, and every rule callback closed
+        # over the BASE command. Applying a favourite sets values on the copy (see
+        # command_loader._update_base_command_with_data), which fires check_trigger -> the
+        # rule ran against the BASE program and mutated it. __copy__ now gives the copy its
+        # own trigger tables + rule sets bound to itself.
+        attrs = {
+            "parameters": {
+                "mode": _enum("cold", ["cold", "hot"]),
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "28"}}}})},
+        }
+        base = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        fav = copy(base)
+        # Applying the favourite fires the rule ON THE COPY: mode=hot -> temp=28.
+        fav.parameters["mode"].value = "hot"
+        self.assertEqual(fav.parameters["temp"].value, 28)  # the copy IS constrained
+        # ...and the base program keeps its own default, uncorrupted.
+        self.assertEqual(base.parameters["temp"].value, 20)  # bug: became 28
+        self.assertEqual(base.parameters["mode"].value, "cold")
+        # White-box: the copy's rule set is a distinct object bound to the copy, and the
+        # copied parameter's trigger table is not shared with the base.
+        self.assertIsNot(fav._rules[0], base._rules[0])
+        self.assertIsNot(fav.parameters["mode"]._triggers, base.parameters["mode"]._triggers)
+
+    def test_malformed_fixed_value_rule_skipped_at_runtime(self) -> None:
+        # A rule whose fixedValue is non-numeric for a RANGE target must NOT raise out
+        # of the runtime trigger (the range setter rejects "x" with ValueError). The
+        # rule is skipped and the parameter keeps its value; setup is not aborted.
+        attrs = {
+            "parameters": {
+                "mode": _enum("cold", ["cold", "hot"]),
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "not-a-number"}}}})},
+        }
+        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        cmd.parameters["mode"].value = "hot"  # fires the bad rule -> must be swallowed
+        self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
+
+    def test_malformed_fixed_value_rule_skipped_at_construction(self) -> None:
+        # Same malformed rule, but the trigger value equals the param DEFAULT, so the
+        # immediate-fire runs during construction (patch()). Building the command must
+        # not raise -- the ValueError from _apply_fixed used to abort the whole load.
+        attrs = {
+            "parameters": {
+                "mode": _enum("hot", ["cold", "hot"]),  # default already == trigger
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "not-a-number"}}}})},
+        }
+        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())  # must not raise
+        self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
+
+    def test_copy_rebinds_program_param_backrefs(self) -> None:
+        # A HonParameterProgram carries `_command` (the base command); its value-setter
+        # does `self._command.category = value` (swapping appliance.commands). A shallow
+        # copy shares that back-reference, so a write on the copy's program parameter
+        # could reach the base. __copy__ now rebinds `_command`/`_programs` to the copy.
+        from custom_components.addhon.client.engine.parameter.program import (
+            HonParameterProgram,
+        )
+
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS, favourites=_RICH_FAVOURITES))
+        base = app.commands["startProgram"].categories["super_cool"]
+        self.assertIsInstance(base.parameters["program"], HonParameterProgram)
+        fav = copy(base)
+        fav_prog = fav.parameters["program"]
+        self.assertIs(fav_prog._command, fav)       # rebound to the copy...
+        self.assertIsNot(fav_prog._command, base)   # ...not the base command
+        self.assertIs(fav_prog._programs, fav.categories)
 
     def test_favourites_malformed_do_not_crash(self) -> None:
         # Stale/malformed favourites payloads must not stop the loader.

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -281,6 +281,49 @@ class ApplyDebugOptionsTest(unittest.TestCase):
             logging.getLogger("custom_components.addhon").level, logging.NOTSET
         )
 
+    def test_options_listener_skips_when_toggles_unchanged(self) -> None:
+        # HA fires update listeners on ANY entry write (e.g. a refresh-token rotation),
+        # not only options changes. With the toggles unchanged the listener must NOT
+        # re-apply/reset the levels, so a debug level raised at runtime survives.
+        import asyncio
+
+        from custom_components.addhon import (
+            _DEBUG_OPTS_KEY,
+            _async_options_updated,
+            _debug_opts,
+        )
+        from custom_components.addhon.const import DOMAIN
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: False})
+
+        class _Hass:
+            data = {DOMAIN: {entry.entry_id: {_DEBUG_OPTS_KEY: _debug_opts(entry)}}}
+
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        asyncio.run(_async_options_updated(_Hass(), entry))
+        # unchanged toggles -> level preserved, NOT reset to NOTSET
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.DEBUG
+        )
+
+    def test_options_listener_applies_when_toggles_changed(self) -> None:
+        # A genuine options change (baseline debug ON, now OFF) still re-applies live.
+        import asyncio
+
+        from custom_components.addhon import _DEBUG_OPTS_KEY, _async_options_updated
+        from custom_components.addhon.const import DOMAIN
+
+        entry = _FakeEntry({CONF_ENABLE_DEBUG: False})
+
+        class _Hass:
+            data = {DOMAIN: {entry.entry_id: {_DEBUG_OPTS_KEY: (True, False)}}}
+
+        logging.getLogger("custom_components.addhon").setLevel(logging.DEBUG)
+        asyncio.run(_async_options_updated(_Hass(), entry))
+        self.assertEqual(
+            logging.getLogger("custom_components.addhon").level, logging.NOTSET
+        )
+
 
 class ResetHelperTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -290,6 +290,28 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("program", added[0]._attr_translation_key)
         self.assertEqual(["Cotone", "Sintetici"], added[0]._attr_options)
 
+    async def test_duplicate_program_labels_stay_distinct(self) -> None:
+        # Two program CODES sharing a display label must both stay selectable and map
+        # back to their OWN code, instead of collapsing (one code unreachable, the other
+        # mis-selected). Colliding labels get a "(code)" suffix; unique ones untouched.
+        from custom_components.addhon.select import HonProgramSelect
+
+        start = RecordingCommand(
+            {"program": Param(values={"1": "Eco", "2": "Eco", "3": "Cotone"})}
+        )
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        self.assertEqual(["Eco (1)", "Eco (2)", "Cotone"], entity._attr_options)
+        await entity.async_select_option("Eco (1)")
+        self.assertEqual({"washer-1": "1"}, coordinator.pending_programs)
+        await entity.async_select_option("Eco (2)")
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
+        # current_option reflects the pending disambiguated option (must be in options)
+        self.assertEqual("Eco (2)", entity.current_option)
+        self.assertIn(entity.current_option, entity._attr_options)
+
     async def test_select_option_records_pending_without_starting(self) -> None:
         from custom_components.addhon.select import HonProgramSelect
 
@@ -457,6 +479,61 @@ class ProgramSelectTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("2", old_cmd.parameters["program"].value)  # program applied
         # The fixed parameters were applied to the NEW (swapped) command, not the stale one.
         self.assertEqual("Y", new_cmd.parameters["prStr"].value)
+
+    async def test_start_button_rolls_back_swap_on_send_failure(self) -> None:
+        # If send() fails AFTER the program apply swapped the active command, the button
+        # must roll back: restore appliance.commands[name] to the original command and
+        # undo the parameter mutations, so the appliance does not keep pointing at a
+        # program the cloud never accepted. Pending program is kept for retry.
+        from homeassistant.exceptions import HomeAssistantError
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        appliance = types.SimpleNamespace(commands={})
+
+        class FailingCommand(RecordingCommand):
+            async def send(self) -> None:
+                self.send_calls += 1
+                raise RuntimeError("cloud rejected")
+
+        new_cmd = FailingCommand({"prStr": Param("X")})
+
+        class ProgramSwapParam:
+            def __init__(self) -> None:
+                self._value = None
+
+            @property
+            def value(self):
+                return self._value
+
+            @value.setter
+            def value(self, v) -> None:
+                self._value = v
+                appliance.commands["startProgram"] = new_cmd  # category swap
+
+        old_cmd = RecordingCommand({"program": ProgramSwapParam()})
+        appliance.commands["startProgram"] = old_cmd
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": "2"}
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+            command_parameters={"prStr": "Y"},
+        )
+        self._attach(button)
+
+        with self.assertRaises(HomeAssistantError):
+            await button.async_press()
+
+        # rolled back to the ORIGINAL command and its pre-apply parameter state
+        self.assertIs(old_cmd, appliance.commands["startProgram"])
+        self.assertIsNone(old_cmd.parameters["program"].value)
+        self.assertEqual("X", new_cmd.parameters["prStr"].value)  # fixed mutation undone
+        # pending program NOT consumed: the user can retry
+        self.assertEqual({"washer-1": "2"}, coordinator.pending_programs)
 
     async def test_stop_button_ignores_pending_program(self) -> None:
         from custom_components.addhon.button import HonProgramCommandButton

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -273,6 +273,80 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(auth.refresh_calls, 1)
         self.assertEqual(auth.authenticate_calls, 0)
 
+    def test_concurrent_reauth_single_flight(self) -> None:
+        # The loop-1 re-auth is now single-flighted under the same lock+generation as
+        # the refresh: a burst that all reach loop 1 collapses to ONE create() +
+        # authenticate(). Before, each request's create() reset self._auth to a
+        # token-less HonAuth, so the loop-2 _check_headers of every sibling fired its
+        # OWN full login on the shared session (colliding cookie jars / multiple OTPs).
+        created = {"n": 0}
+
+        class SlowFakeAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                await asyncio.sleep(0)  # yield so siblings pile up on the lock
+                self.cognito_token, self.id_token, self.refresh_token = "COG", "IDT", "RT"
+
+        auth = SlowFakeAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            created["n"] += 1
+            return conn  # a real re-login repopulates the same connection's auth
+
+        conn.create = _fake_create
+
+        async def run():
+            gen = conn._refresh_gen  # all three "sent" at the same generation
+            await asyncio.gather(
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+            )
+
+        asyncio.run(run())
+        self.assertEqual(auth.authenticate_calls, 1)  # one re-login, not three
+        self.assertEqual(created["n"], 1)             # one create(), not three
+        self.assertEqual(conn._refresh_gen, 1)        # advanced exactly once
+
+    def test_concurrent_reauth_single_flight_on_failure(self) -> None:
+        # A FAILING loop-1 re-auth (e.g. MFAChallengeRequired) must also collapse to
+        # ONE attempt: without caching the error + advancing the generation, each
+        # queued sibling would run its own create()+authenticate() -- N sequential
+        # logins / OTP prompts on a 2FA account exactly when the login is failing.
+        created = {"n": 0}
+
+        class SlowFailAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                await asyncio.sleep(0)  # yield so siblings pile up on the lock
+                raise NativeAuthError("2FA challenge required")
+
+        auth = SlowFailAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            created["n"] += 1
+            return conn
+
+        conn.create = _fake_create
+
+        async def run():
+            gen = conn._refresh_gen  # all three "sent" at the same generation
+            return await asyncio.gather(
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                conn._reauth_after_rejection(gen),
+                return_exceptions=True,
+            )
+
+        results = asyncio.run(run())
+        self.assertEqual(auth.authenticate_calls, 1)  # one attempt, not three
+        self.assertEqual(created["n"], 1)             # one create(), not three
+        # every caller surfaces the SAME auth error (the siblings reuse the cached one)
+        self.assertTrue(all(isinstance(r, NativeAuthError) for r in results))
+        self.assertEqual(conn._refresh_gen, 1)        # advanced once, even on failure
+
     def test_retry_on_403_refreshes(self) -> None:
         # Same branch as the 401 (the code treats them identically) but made explicit
         # to avoid regressions on the 403 (CodeRabbit nitpick).
@@ -618,6 +692,59 @@ class InterceptCloudErrorRoutingTest(unittest.TestCase):
         self.assertIs(ctx.exception.error_code, DECODE_ERROR)
         self.assertFalse(DECODE_ERROR.requires_reauth)
         self.assertEqual(auth.authenticate_calls, 0)  # no spurious full re-login
+
+    def test_html_403_is_transient_not_reauth(self) -> None:
+        # A 403 whose body is HTML (Cloudflare/WAF challenge, captive portal) is a
+        # transient edge hiccup, NOT an hOn auth rejection. It must carry DECODE_ERROR
+        # (coordinator retries via UpdateFailed) and never enter the refresh -> reauth
+        # ladder, which on a 2FA account would open a spurious OTP prompt.
+        class HtmlResp(FakeResp):
+            content_type = "text/html"
+
+        class HtmlSession(FakeSession):
+            def _resp(self, url, **kw):
+                self.calls.append(kw.get("headers", {}))
+                return HtmlResp(403)
+
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, HtmlSession([]))
+        conn._refresh_token = "RT"
+
+        async def run():
+            async with conn.get("https://x/api"):
+                pass
+
+        with self.assertRaises(NativeAuthError) as ctx:
+            asyncio.run(run())
+        self.assertIs(ctx.exception.error_code, DECODE_ERROR)
+        self.assertFalse(DECODE_ERROR.requires_reauth)
+        self.assertEqual(auth.refresh_calls, 0)       # not routed to refresh
+        self.assertEqual(auth.authenticate_calls, 0)  # nor to a full reauth
+        self.assertEqual(len(conn._session.calls), 1)  # raised, not retried in-band
+
+    def test_json_403_still_climbs_the_reauth_ladder(self) -> None:
+        # A NON-HTML 403 that persists must still follow refresh (loop 0) -> full
+        # re-auth (loop 1) -> retry, so a genuine auth rejection is never masked by
+        # the HTML-challenge shortcut. FakeResp has no content_type -> not HTML.
+        auth = FakeAuth()
+        auth.cognito_token, auth.id_token = "C", "I"
+        conn = _conn(auth, FakeSession([403, 403, 200]))
+        conn._refresh_token = "RT"
+
+        async def _fake_create():
+            return conn  # a real re-login repopulates the same connection's auth
+
+        conn.create = _fake_create
+
+        async def run():
+            async with conn.get("https://x/api") as resp:
+                return resp.status
+
+        status = asyncio.run(run())
+        self.assertEqual(status, 200)
+        self.assertEqual(auth.refresh_calls, 1)       # loop 0 refresh
+        self.assertEqual(auth.authenticate_calls, 1)  # loop 1 full reauth
 
     def test_5xx_json_body_raises_retryable_not_success(self) -> None:
         # A 502 whose body decodes as JSON must NOT be yielded as a good response


### PR DESCRIPTION
Automated release PR for `v5.8.0`.

<!-- release-tag: v5.8.0 -->

## Summary by Sourcery

Improve the addhon integration’s reliability, AC program handling, command/program execution, auth/transport behavior, diagnostics privacy, and debug options, and bump the integration to v5.8.0.

New Features:
- Add explicit support for program-based AC write models that drive power and mode via startProgram/stopProgram rather than settings.
- Disambiguate duplicate washer program labels in the program select entity so each program code remains uniquely selectable.

Bug Fixes:
- Fix AC climate control for program-based models by routing on/off and hvac_mode to startProgram/stopProgram while keeping temperature and fan on settings.
- Ensure settings-based AC models continue to use the settings write path even when program commands are present (regression guard).
- Single-flight concurrent full re-auth attempts so request bursts do not trigger multiple logins or OTP prompts, including in failure cases.
- Treat HTML 403 responses as transient edge challenges instead of auth failures so they don’t trigger refresh/re-auth ladders.
- Prevent favourites and their rule copies from mutating base program commands or sharing trigger tables, keeping base programs pristine.
- Guard malformed fixed-value rules so they are skipped at construction and runtime instead of raising and breaking command loading.
- Rebind HonParameterProgram back-references when copying commands so writes on copies cannot affect the base command.
- Roll back command swaps and parameter mutations on failed program start button sends so local state matches what the cloud accepted.
- Roll back pause parameter changes on failed switch sends so local pause state is not desynchronized from the cloud.
- Avoid dumping huge enumerated grids for range parameters in diagnostics and only emit min/max/step.
- Mask MAC addresses and similar identities even when they appear in non-redacted value fields or wrapped objects in diagnostics.
- Normalize trigger comparison in parameter base so default values that match string triggers still fire initial rules.
- Make entity availability robust when attributes are missing or string-encoded and ensure coordinator data type checks before iteration.
- Handle non-numeric or empty applianceModelId values defensively to avoid ValueError.
- Abort config reauth flows cleanly when the target entry has been removed instead of failing later.
- Guard coordinator.data accesses in select, binary_sensor, and sensor setup when data is not a dict.
- Fix auth cookie clearing to actually drop cookies for the auth host instead of being a no-op, avoiding stale SSO cookie reuse.
- Ensure the debug options update listener only re-applies log levels when toggles change, preserving runtime-set debug levels.

Enhancements:
- Add capability gating and detailed error reporting for unsupported AC programs and swing positions, aligning with translation keys.
- Introduce helper utilities for program capability discovery and async program sending in the AC climate component.
- Enhance diagnostics schema generation and identity redaction to better mirror runtime behavior and logging privacy guarantees.
- Refine rule attachment and rebinding in the engine so copied commands carry isolated triggers and configuration rules.
- Improve base entity availability handling to share the same normalization logic as other attributes.
- Make options flow debug handling track and store current toggle state for later change detection.

Build:
- Update the integration manifest version from 5.7.2 to 5.8.0.

Tests:
- Add comprehensive tests for program-based AC write paths, including program mapping, OFF handling, error cases, and regression behavior for settings-based models.
- Add transport connection tests covering single-flighted concurrent re-auth, HTML vs JSON 403 behavior, and retry ladders.
- Add engine cluster tests to validate favourites isolation, rule copying behavior, malformed rule tolerance, and program parameter rebinding.
- Extend program select tests to cover duplicate-label disambiguation and rollback behavior on failed program command sends.
- Add options flow tests ensuring debug level updates only occur when toggles actually change.
- Expand diagnostics tests to cover range schema generation without enums and MAC masking in values and wrapped objects.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more appliance control modes, including program-based AC power/mode handling and improved program selection.
  * Diagnostics now better hide sensitive device details in shared reports.

* **Bug Fixes**
  * Improved reliability when changing settings or starting programs, including safer rollback if a command fails.
  * Fixed re-authentication and login handling so recovery is more stable.
  * Prevented crashes from unexpected device data and improved availability/status accuracy.

* **Chores**
  * Updated the integration version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release bundles a large set of targeted bug fixes and one new feature: explicit support for program-based AC models (e.g. AD71S2SM3FA(H)) that drive power and mode via `startProgram`/`stopProgram` rather than the `settings` command. All other fixes address concrete defects in auth, engine state isolation, rollback behaviour, diagnostics privacy, and platform setup guards.

- **Program-based AC write path** (`climate.py`, `const.py`, `program_options.py`): adds `_is_program_based()` capability gate; routes ON/mode to `startProgram` and OFF to `stopProgram`, while temperature and fan remain on `settings`. Regression guard ensures settings-based models keep their existing path even when startProgram/stopProgram are present.
- **Single-flight concurrent re-auth** (`connection.py`): introduces `_reauth_after_rejection` with generation-keyed error caching so a burst of failing requests collapses to one `create()`+`authenticate()` instead of triggering N logins/OTP prompts; HTML 403s are redirected to the `DECODE_ERROR` transient path.
- **Engine state isolation and rollback** (`commands.py`, `rules.py`, `param_rollback.py`, `hon_commands.py`, `button.py`, `switch.py`): `HonCommand.__copy__` gives favourites isolated parameter dicts and rebound trigger tables; `HonRuleSet.rebound` re-attaches triggers against the copy; shared `snapshot_params`/`restore_params` helpers centralise rollback for all send paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all fixes address well-defined defects, each has a targeted test, and no regressions were found across the settings-based and program-based AC paths.

The changes are surgical and backed by comprehensive tests covering the new program-based AC write path, concurrent re-auth single-flighting (including the failure case), engine favourite isolation, rollback behaviour, and diagnostics privacy. The auth cookie-clear fix and the select disambiguation are straightforward corrections with no observable side-effects on the existing flows. No unguarded mutation paths, missing rollback cases, or logic inversions were identified during review.

No files require special attention. The most complex change is connection.py's _reauth_after_rejection, which is well-commented and covered by two dedicated concurrency tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/climate.py | Adds program-based AC write path with capability gating; settings-based regression guard verified; swing-position fallback now raises instead of sending wrong oscillation code. |
| custom_components/addhon/client/transport/connection.py | Single-flight concurrent re-auth via generation-keyed error cache; HTML 403 short-circuited to DECODE_ERROR; logic correct for success, failure, and CancelledError cases. |
| custom_components/addhon/client/engine/commands.py | HonCommand.__copy__ now isolates _parameters, resets trigger tables, rebinds HonParameterProgram back-references, and rebound rule sets — correctly prevents favourite mutation from corrupting base commands. |
| custom_components/addhon/client/engine/rules.py | patch() refactored into _attach_triggers/_apply_config_rules; new rebound() creates an isolated HonRuleSet bound to a copied command; malformed fixedValue rules caught and logged instead of aborting appliance setup. |
| custom_components/addhon/param_rollback.py | New shared snapshot_params/restore_params helpers centralise __dict__-level parameter rollback; correctly bypasses setters so rules are not re-fired on restore. |
| custom_components/addhon/client/transport/auth.py | clear() now correctly derives the auth host via urlsplit().netloc (fixing the no-op clear_domain('') bug); introduce path appends trailing '&' to capture the last fragment field and gates on t.complete before committing tokens. |
| custom_components/addhon/select.py | Duplicate-label disambiguation via _program_display ensures every program code is uniquely selectable; all current_option lookups updated to use disambiguated labels. |
| custom_components/addhon/button.py | Adds rollback dict to capture pre-swap command pointer and two-phase parameter snapshots; correctly restores in reverse order on send failure. |
| custom_components/addhon/diagnostics.py | _param_schema now emits min/max/step for range params instead of enumerating the full grid; _jsonable applies _MAC_RE redaction to all string values including wrapped objects. |
| custom_components/addhon/__init__.py | _async_options_updated now stores current debug toggle state and skips re-apply when only non-debug data (e.g. token rotation) changed, preserving runtime-set log levels. |
| custom_components/addhon/client/engine/parameter/base.py | add_trigger now normalises both sides with str().lower() to match check_trigger semantics; reset_triggers() creates a fresh dict (not .clear()) to avoid emptying the shared trigger table on copy. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `custom_components/addhon/select.py`, line 477-482 ([link](https://github.com/tis24dev/addhon/blob/97e5f1c322415b67b6c27aa575b70e271085f9dd/custom_components/addhon/select.py#L477-L482)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> After the disambiguation refactor, `_program_map` (code → original label) still appears in the "pending code not in map" debug message. Since users now see disambiguated labels from `_program_display`, logging `_program_display` would make it easier to cross-reference the debug output with what the UI actually shows.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fselect.py%0ALine%3A%20477-482%0A%0AComment%3A%0AAfter%20the%20disambiguation%20refactor%2C%20%60_program_map%60%20%28code%20%E2%86%92%20original%20label%29%20still%20appears%20in%20the%20%22pending%20code%20not%20in%20map%22%20debug%20message.%20Since%20users%20now%20see%20disambiguated%20labels%20from%20%60_program_display%60%2C%20logging%20%60_program_display%60%20would%20make%20it%20easier%20to%20cross-reference%20the%20debug%20output%20with%20what%20the%20UI%20actually%20shows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20_LOGGER.debug%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Select%20debug%3A%20current_option%20pending%20id%3D%25s%20code%3D%25s%20not%20present%20in%20map%3D%25s%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20redact_id%28self._appliance_id%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20pending%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self._program_display%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=48&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fselect.py%0ALine%3A%20477-482%0A%0AComment%3A%0AAfter%20the%20disambiguation%20refactor%2C%20%60_program_map%60%20%28code%20%E2%86%92%20original%20label%29%20still%20appears%20in%20the%20%22pending%20code%20not%20in%20map%22%20debug%20message.%20Since%20users%20now%20see%20disambiguated%20labels%20from%20%60_program_display%60%2C%20logging%20%60_program_display%60%20would%20make%20it%20easier%20to%20cross-reference%20the%20debug%20output%20with%20what%20the%20UI%20actually%20shows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20_LOGGER.debug%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Select%20debug%3A%20current_option%20pending%20id%3D%25s%20code%3D%25s%20not%20present%20in%20map%3D%25s%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20redact_id%28self._appliance_id%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20pending%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self._program_display%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=48&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20custom_components%2Faddhon%2Fselect.py%0ALine%3A%20477-482%0A%0AComment%3A%0AAfter%20the%20disambiguation%20refactor%2C%20%60_program_map%60%20%28code%20%E2%86%92%20original%20label%29%20still%20appears%20in%20the%20%22pending%20code%20not%20in%20map%22%20debug%20message.%20Since%20users%20now%20see%20disambiguated%20labels%20from%20%60_program_display%60%2C%20logging%20%60_program_display%60%20would%20make%20it%20easier%20to%20cross-reference%20the%20debug%20output%20with%20what%20the%20UI%20actually%20shows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20_LOGGER.debug%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Select%20debug%3A%20current_option%20pending%20id%3D%25s%20code%3D%25s%20not%20present%20in%20map%3D%25s%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20redact_id%28self._appliance_id%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20pending%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self._program_display%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tis24dev%2Faddhon&pr=48&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor: address CodeRabbit nitpicks on..."](https://github.com/tis24dev/addhon/commit/8155b73055d53d4287ba09481f370eb73662c0df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42034021)</sub>

<!-- /greptile_comment -->