### PR TITLE
fix: dev-review robustness fixes (config-rule load guard, range option enumeration, AC direction select)

### DIFF
--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -235,11 +235,26 @@ class HonRuleSet:
                 continue
             if not (param := self._command.parameters.get(param_key)):
                 continue
-            if fixed_value := action.get("fixedValue", ""):
-                self._apply_fixed(param, fixed_value)
-            elif action.get("typology") == "enum":
-                self._apply_enum(
-                    param, HonRule(dollar_key, str(device_value), param_key, action)
+            # Same guard as the runtime trigger path (_add_trigger.apply): a malformed
+            # config rule (non-numeric/off-grid fixedValue on a range, or a bad enum
+            # value) must skip ONLY that rule, never abort the whole command build.
+            # patch() runs in HonCommand.__init__ and command_loader does NOT wrap the
+            # construction, so an escaping ValueError/TypeError would drop every command
+            # -- and thus every entity -- of the device.
+            try:
+                if fixed_value := action.get("fixedValue", ""):
+                    self._apply_fixed(param, fixed_value)
+                elif action.get("typology") == "enum":
+                    self._apply_enum(
+                        param, HonRule(dollar_key, str(device_value), param_key, action)
+                    )
+            except (ValueError, TypeError) as err:
+                _LOGGER.debug(
+                    "addhOn: skipping unapplicable config rule for '%s' (%s=%s): %s",
+                    param_key,
+                    dollar_key,
+                    device_value,
+                    err,
                 )
 
     def patch(self) -> None:

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -160,6 +160,12 @@ class HonRuleSet:
         if isinstance(param, HonParameterEnum) and set(param.values) != {str(value)}:
             param.values = [str(value)]
             param.value = str(value)
+            # Return so we do NOT fall through to the trailing `param.value = str(value)`:
+            # a second set would fire the value trigger a second time, and (were a cascade
+            # ever to rewrite this param's own values) could raise AFTER the first set
+            # already succeeded -- past the point _rollback can undo the cascade's effect
+            # on sibling params. One validated set keeps the skip/rollback contract exact.
+            return
         elif isinstance(param, HonParameterRange):
             numeric = float(value)
             if numeric < param.min:
@@ -185,12 +191,32 @@ class HonRuleSet:
             # Degenerate case, not verifiable offline -> deferred to live-AC.
             param.value = default_value
 
+    @staticmethod
+    def _rollback(param: HonParameter, snapshot: dict[str, Any]) -> None:
+        """Restore ``param`` to a pre-apply ``__dict__`` snapshot so a SKIPPED malformed
+        rule leaves NO partial mutation.
+
+        ``_apply_fixed`` can widen ``min``/``max`` and ``_apply_enum`` can replace
+        ``values`` BEFORE the value setter raises, so catching the error alone would keep
+        the narrowed/widened bounds or swapped options while the old value stays in place
+        -- the entity would then expose the wrong range/options or reject the device's
+        current value. Copy ``__dict__`` directly (same mechanism as ``param_rollback`` on
+        the send path): it bypasses the setter, so no trigger re-fires, and every mutated
+        field (``min``/``max``/``values``/``_value``) reverts together. The value setters
+        validate BEFORE assigning ``_value`` (range ``_on_grid`` / enum membership) and no
+        apply re-sets the value after a successful set (see ``_apply_fixed``'s early
+        return), so a raise is never preceded by a cascade into sibling params -- the
+        single-param snapshot is a complete rollback."""
+        param.__dict__.clear()
+        param.__dict__.update(snapshot)
+
     def _add_trigger(self, parameter: HonParameter, data: HonRule) -> None:
         def apply(rule: HonRule) -> None:
             if not self._extra_rules_matches(rule):
                 return
             if not (param := self._command.parameters.get(rule.param_key)):
                 return
+            snapshot = dict(param.__dict__)
             try:
                 if fixed_value := rule.param_data.get("fixedValue", ""):
                     self._apply_fixed(param, fixed_value)
@@ -202,8 +228,10 @@ class HonRuleSet:
                 # immediate-fire in `HonParameter.add_trigger` runs at construction
                 # time, so an escaping ValueError from `_apply_fixed` (e.g. float("x")
                 # or an off-step value rejected by the range setter) would fail setup
-                # for every entity of the device. Log and skip the bad rule instead;
-                # the runtime path already tolerates this via the entity write-path.
+                # for every entity of the device. Roll the param back (a partial
+                # mutation is worse than an untouched one) then log and skip the bad
+                # rule; the runtime path already tolerates this via the entity write-path.
+                self._rollback(param, snapshot)
                 _LOGGER.debug(
                     "addhOn: skipping unapplicable rule for '%s' (trigger %s=%s): %s",
                     rule.param_key,
@@ -240,7 +268,9 @@ class HonRuleSet:
             # value) must skip ONLY that rule, never abort the whole command build.
             # patch() runs in HonCommand.__init__ and command_loader does NOT wrap the
             # construction, so an escaping ValueError/TypeError would drop every command
-            # -- and thus every entity -- of the device.
+            # -- and thus every entity -- of the device. Snapshot first so a rule that
+            # raises mid-apply is rolled back, not left with partial bounds/options.
+            snapshot = dict(param.__dict__)
             try:
                 if fixed_value := action.get("fixedValue", ""):
                     self._apply_fixed(param, fixed_value)
@@ -249,6 +279,7 @@ class HonRuleSet:
                         param, HonRule(dollar_key, str(device_value), param_key, action)
                     )
             except (ValueError, TypeError) as err:
+                self._rollback(param, snapshot)
                 _LOGGER.debug(
                     "addhOn: skipping unapplicable config rule for '%s' (%s=%s): %s",
                     param_key,

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -28,11 +28,11 @@ so the entity is never created (auto-removes the fixed toggles on the user's mod
 from __future__ import annotations
 
 import logging
-from decimal import Decimal
 
 from homeassistant.exceptions import HomeAssistantError
 
 from .base_entity import HonBaseEntity
+from .client.engine.parameter.range import HonParameterRange
 from .const import DOMAIN, PROGRAM_PARAM_NAMES, PROGRAM_PENDING_OPTIONS
 from .debug_utils import redact_id
 from .hon_commands import get_command, get_commands, param_range, param_values
@@ -167,15 +167,6 @@ def _num_str(value) -> str:
     return str(int(number)) if number.is_integer() else str(number)
 
 
-def _grid_decimals(number: float) -> int:
-    """Fractional-digit count of a numeric value (0.1 -> 1, 1 -> 0).
-
-    Mirrors HonParameterRange._decimals; used to round the enumerated grid points to the
-    lo/step precision so a decimal step renders "20.7", not "20.700000000000003"."""
-    exponent = Decimal(str(float(number))).normalize().as_tuple().exponent
-    return -exponent if isinstance(exponent, int) and exponent < 0 else 0
-
-
 def normalize_code(value) -> str | None:
     """Normalize a raw device/schema value to its canonical option code.
 
@@ -234,7 +225,9 @@ def option_choices(param, drop: tuple[str, ...] = ()) -> list[str]:
         # "20.700000000000003". The +1e-9 only absorbs the i*step rounding drift; a step
         # that overshoots the max (e.g. 0..10 step 20) still emits a single value, never
         # one beyond hi. Bounded by _MAX_RANGE_CHOICES so a malformed range cannot loop.
-        ndigits = max(_grid_decimals(lo), _grid_decimals(step))
+        # Reuse HonParameterRange._decimals (single source of truth for grid precision)
+        # so this matches range.py.values' rounding and the tokens keep round-tripping.
+        ndigits = max(HonParameterRange._decimals(lo), HonParameterRange._decimals(step))
         for index in range(_MAX_RANGE_CHOICES):
             current = round(lo + index * step, ndigits)
             if current > hi + 1e-9:

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -28,6 +28,7 @@ so the entity is never created (auto-removes the fixed toggles on the user's mod
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -166,6 +167,15 @@ def _num_str(value) -> str:
     return str(int(number)) if number.is_integer() else str(number)
 
 
+def _grid_decimals(number: float) -> int:
+    """Fractional-digit count of a numeric value (0.1 -> 1, 1 -> 0).
+
+    Mirrors HonParameterRange._decimals; used to round the enumerated grid points to the
+    lo/step precision so a decimal step renders "20.7", not "20.700000000000003"."""
+    exponent = Decimal(str(float(number))).normalize().as_tuple().exponent
+    return -exponent if isinstance(exponent, int) and exponent < 0 else 0
+
+
 def normalize_code(value) -> str | None:
     """Normalize a raw device/schema value to its canonical option code.
 
@@ -217,16 +227,21 @@ def option_choices(param, drop: tuple[str, ...] = ()) -> list[str]:
         if step <= 0:
             return []
         out: list[str] = []
-        current = lo
-        count = 0
-        # Tight upper bound (+1e-9 only for float-accumulation drift, NOT step/2): a step
-        # that overshoots the max (e.g. 0..10 step 20) must NOT emit a value beyond hi.
-        while current <= hi + 1e-9 and count < _MAX_RANGE_CHOICES:
+        # Index-based enumeration (lo + i*step), NOT a `+= step` accumulator: the
+        # accumulator compounds float error on decimal steps and can DROP the final grid
+        # point -- the exact defect range.py.values was rewritten to avoid. Each point is
+        # rounded to the lo/step precision so a decimal step renders "20.7", not
+        # "20.700000000000003". The +1e-9 only absorbs the i*step rounding drift; a step
+        # that overshoots the max (e.g. 0..10 step 20) still emits a single value, never
+        # one beyond hi. Bounded by _MAX_RANGE_CHOICES so a malformed range cannot loop.
+        ndigits = max(_grid_decimals(lo), _grid_decimals(step))
+        for index in range(_MAX_RANGE_CHOICES):
+            current = round(lo + index * step, ndigits)
+            if current > hi + 1e-9:
+                break
             token = _num_str(current)
             if token not in drop and token not in out:
                 out.append(token)
-            current += step
-            count += 1
         return out
     return option_value_set(param, drop)
 

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -67,6 +67,24 @@ _REF_MODE_FLAG_TO_PROGRAM: dict[str, str] = {
 _LOGGER = logging.getLogger(__name__)
 
 
+def disambiguate_labels(base: dict[str, str]) -> dict[str, str]:
+    """Make a ``code -> label`` map collision-safe for a select's options.
+
+    Two codes sharing a display label would collapse in the reverse map, leaving one code
+    unreachable from the UI and mapping the lost code's current_option onto the survivor.
+    Suffix ONLY the colliding labels with their code so every code stays selectable and the
+    reverse map is injective; unique labels are untouched (they keep their translatable
+    string). Insertion order is preserved. Shared by every select that builds options from a
+    code/label map (program, program-option, AC direction) so the behavior can't drift."""
+    counts: dict[str, int] = {}
+    for label in base.values():
+        counts[label] = counts.get(label, 0) + 1
+    return {
+        code: (f"{label} ({code})" if counts[label] > 1 else label)
+        for code, label in base.items()
+    }
+
+
 @dataclass(frozen=True, kw_only=True)
 class HonProgramOptionSelectDescription:
     """A categorical program option rendered as a select (#35).
@@ -322,19 +340,11 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         if appliance is not None:
             self._program_map = self._load_programs(appliance)
 
-        # Disambiguate collided labels: two program CODES sharing a display label would
-        # otherwise collapse in the reverse map, leaving one program unreachable from the
-        # UI and mapping current_option of the lost code onto the survivor's code. Suffix
-        # ONLY the colliding labels with their raw code so every code stays selectable and
-        # the reverse map is injective (mirrors HonProgramOptionSelect). Unique labels are
-        # untouched, keeping their translatable string.
-        label_counts: dict[str, int] = {}
-        for label in self._program_map.values():
-            label_counts[label] = label_counts.get(label, 0) + 1
-        self._program_display: dict[str, str] = {
-            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
-            for code, label in self._program_map.items()
-        }
+        # Disambiguate collided labels so every program CODE stays selectable and the
+        # reverse map is injective (two codes sharing a display label would otherwise
+        # collapse, leaving one program unreachable and mapping current_option of the lost
+        # code onto the survivor). See disambiguate_labels.
+        self._program_display: dict[str, str] = disambiguate_labels(self._program_map)
         self._program_reverse: dict[str, str] = {
             display: code for code, display in self._program_display.items()
         }
@@ -603,16 +613,9 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
         # Collision-aware disambiguation (PR #38 / Greptile P2): when two EXPOSED raw codes
         # share a label (DRY_LEVEL_LABELS_TD maps e.g. 1 & 12 both to "iron_dry"), suffixing
         # ONLY the colliding ones with their raw code keeps every code selectable and keeps
-        # the reverse map injective (otherwise one raw would be unreachable). Non-colliding
-        # labels are untouched, so the common case keeps its translatable `state.<key>`; a
-        # suffixed colliding key has no translation and renders literally (rare-model-only).
-        label_counts: dict[str, int] = {}
-        for label in base_keys.values():
-            label_counts[label] = label_counts.get(label, 0) + 1
-        self._raw_to_key: dict[str, str] = {
-            raw: (f"{label} ({raw})" if label_counts[label] > 1 else label)
-            for raw, label in base_keys.items()
-        }
+        # the reverse map injective. Non-colliding labels keep their translatable
+        # `state.<key>`; a suffixed colliding key renders literally (rare-model-only).
+        self._raw_to_key: dict[str, str] = disambiguate_labels(base_keys)
         self._key_to_raw: dict[str, str] = {key: raw for raw, key in self._raw_to_key.items()}
         # One distinct option per exposed raw code (keys are now unique; order preserved).
         self._attr_options = list(self._raw_to_key.values())
@@ -893,17 +896,11 @@ class HonAcDirectionSelect(HonBaseEntity, SelectEntity):
                 continue
             base_keys[code] = label_map.get(code, code)
         # Collision-aware disambiguation (mirrors HonProgramOptionSelect): if two codes
-        # share a label, suffix the colliding ones with their raw code so every code stays
-        # selectable and _key_to_raw never drops one. The current FAN_DIR maps are
-        # injective (numeric fallbacks), so this is a no-op today; it removes the latent
-        # duplicate-option / lossy-reverse trap if a map ever gains a shared label.
-        label_counts: dict[str, int] = {}
-        for label in base_keys.values():
-            label_counts[label] = label_counts.get(label, 0) + 1
-        self._raw_to_key: dict[str, str] = {
-            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
-            for code, label in base_keys.items()
-        }
+        # share a label, suffix the colliding ones so every code stays selectable and
+        # _key_to_raw never drops one. The current FAN_DIR maps are injective (numeric
+        # fallbacks), so this is a no-op today; it removes the latent duplicate-option /
+        # lossy-reverse trap if a map ever gains a shared label. See disambiguate_labels.
+        self._raw_to_key: dict[str, str] = disambiguate_labels(base_keys)
         self._key_to_raw: dict[str, str] = {
             key: raw for raw, key in self._raw_to_key.items()
         }

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -886,12 +886,24 @@ class HonAcDirectionSelect(HonBaseEntity, SelectEntity):
         # unknown. For the real per-model enums (clean small integers) this is a no-op.
         # param_allowed_values([]/None) yields [] (gated-out params never reach here).
         # Mirrors HonProgramOptionSelect / option_value_set, which already normalize.
-        self._raw_to_key: dict[str, str] = {}
+        base_keys: dict[str, str] = {}
         for raw in param_allowed_values(param):
             code = normalize_code(raw)
             if code is None:
                 continue
-            self._raw_to_key[code] = label_map.get(code, code)
+            base_keys[code] = label_map.get(code, code)
+        # Collision-aware disambiguation (mirrors HonProgramOptionSelect): if two codes
+        # share a label, suffix the colliding ones with their raw code so every code stays
+        # selectable and _key_to_raw never drops one. The current FAN_DIR maps are
+        # injective (numeric fallbacks), so this is a no-op today; it removes the latent
+        # duplicate-option / lossy-reverse trap if a map ever gains a shared label.
+        label_counts: dict[str, int] = {}
+        for label in base_keys.values():
+            label_counts[label] = label_counts.get(label, 0) + 1
+        self._raw_to_key: dict[str, str] = {
+            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
+            for code, label in base_keys.items()
+        }
         self._key_to_raw: dict[str, str] = {
             key: raw for raw, key in self._raw_to_key.items()
         }

--- a/tests/test_ac_fan_direction_select.py
+++ b/tests/test_ac_fan_direction_select.py
@@ -350,5 +350,28 @@ class AcFanDirectionI18nTest(unittest.TestCase):
             )
 
 
+class DisambiguateLabelsTest(unittest.TestCase):
+    """The shared collision helper backing every code/label select (program,
+    program-option, AC direction): only colliding labels get suffixed, so the reverse
+    map stays injective while unique (translatable) labels are untouched."""
+
+    def test_no_collision_is_identity(self) -> None:
+        base = {"1": "low", "2": "mid", "3": "high"}
+        self.assertEqual(select.disambiguate_labels(base), base)
+
+    def test_collision_suffixes_only_the_colliding_labels(self) -> None:
+        # 1 and 12 both map to "iron_dry"; "auto" is unique.
+        out = select.disambiguate_labels({"1": "iron_dry", "12": "iron_dry", "0": "auto"})
+        self.assertEqual(out, {"1": "iron_dry (1)", "12": "iron_dry (12)", "0": "auto"})
+        # Every code stays selectable and the reverse map loses nothing.
+        self.assertEqual(len(set(out.values())), len(out))
+        self.assertEqual({v: k for k, v in out.items()},
+                         {"iron_dry (1)": "1", "iron_dry (12)": "12", "auto": "0"})
+
+    def test_insertion_order_preserved(self) -> None:
+        base = {"c": "x", "a": "x", "b": "y"}
+        self.assertEqual(list(select.disambiguate_labels(base)), ["c", "a", "b"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -639,6 +639,28 @@ class ConfigRuleTest(unittest.TestCase):
         self.assertEqual(c.parameters["remoteActionable"].value, 1)
         self.assertEqual(c.parameters["remoteVisible"].value, 0)
 
+    def test_malformed_config_rule_rolls_back_partial_mutation(self) -> None:
+        # A fixedValue BEYOND max AND off the min/step grid widens the range's max
+        # (numeric > max) BEFORE the value setter rejects it as off-grid. Skipping the
+        # rule is not enough: without a rollback the param is left with the widened max
+        # and the old value, so the entity would expose a wrong range. The guard must
+        # restore the pre-apply state; a sibling well-formed rule still fires.
+        bad = json.loads(json.dumps(_AC_SELF_CLEAN))
+        bad["ancillaryParameters"]["programRules"]["fixedValue"] = {
+            "remoteActionable": {
+                "$installationType": {"1toN": {"fixedValue": "1.5", "typology": "fixed"}}},
+            "remoteVisible": {
+                "$installationType": {"1toN": {"fixedValue": "0", "typology": "fixed"}}},
+        }
+        c = NaCommand("c", bad, _ConfigApp("1toN"),
+                      category_name="PROGRAMS.AC.IOT_SELF_CLEAN")
+        ra = c.parameters["remoteActionable"]
+        # Rolled back: max is the original 1 (NOT the transiently-widened 1.5) and the
+        # value is untouched. The sibling well-formed config rule still applied (-> 0).
+        self.assertEqual(ra.max, 1)
+        self.assertEqual(ra.value, 1)
+        self.assertEqual(c.parameters["remoteVisible"].value, 0)
+
 
 class _HassStub:
     async def async_add_executor_job(self, fn, *a):

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -617,6 +617,28 @@ class ConfigRuleTest(unittest.TestCase):
         c = self._build(None)  # field absent -> does not fire (fallback like the app)
         self.assertEqual(c.parameters["remoteActionable"].value, 1)
 
+    def test_malformed_config_rule_skipped_not_aborting_build(self) -> None:
+        # A $installationType config rule whose fixedValue is non-numeric for a RANGE
+        # target must NOT raise out of HonCommand construction: patch() runs in
+        # __init__ and the loader does not wrap it, so an escaping ValueError would drop
+        # every command -- and thus every entity -- of the device. The bad rule is
+        # skipped per-iteration (like the runtime trigger path) while a sibling good
+        # config rule still fires.
+        bad = json.loads(json.dumps(_AC_SELF_CLEAN))
+        bad["ancillaryParameters"]["programRules"]["fixedValue"] = {
+            "remoteActionable": {
+                "$installationType": {"1toN": {"fixedValue": "not-a-number",
+                                               "typology": "fixed"}}},
+            "remoteVisible": {
+                "$installationType": {"1toN": {"fixedValue": "0", "typology": "fixed"}}},
+        }
+        c = NaCommand("c", bad, _ConfigApp("1toN"),
+                      category_name="PROGRAMS.AC.IOT_SELF_CLEAN")
+        # Construction did not raise; all params built; the malformed rule was skipped
+        # (target keeps its default 1) but the sibling good rule still applied (-> 0).
+        self.assertEqual(c.parameters["remoteActionable"].value, 1)
+        self.assertEqual(c.parameters["remoteVisible"].value, 0)
+
 
 class _HassStub:
     async def async_add_executor_job(self, fn, *a):

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -266,6 +266,24 @@ class GateTest(unittest.TestCase):
         self.assertEqual(option_choices(RangeParam(12, 14, 1)), ["12", "13", "14"])
         self.assertEqual(option_choices(RangeParam(0, 360, 360)), ["0", "360"])
 
+    def test_option_choices_decimal_step_keeps_last_point_no_drift(self) -> None:
+        # Regression: the old `current += step` accumulator drifted on decimal steps
+        # ("20.700000000000003") and could drop the final grid point. Index-based
+        # enumeration rounds each point to the lo/step precision -> clean tokens, last
+        # point kept, distinct half-degree points not collapsed.
+        from custom_components.addhon.program_options import option_choices
+
+        toks = option_choices(RangeParam(20.0, 25.0, 0.1))
+        self.assertEqual(len(toks), 51)
+        self.assertEqual(toks[0], "20")
+        self.assertEqual(toks[-1], "25")
+        self.assertNotIn("20.700000000000003", toks)
+        self.assertTrue(all("." not in t or len(t.split(".")[1]) <= 1 for t in toks))
+        self.assertEqual(
+            option_choices(RangeParam(16.5, 20.5, 1.0)),
+            ["16.5", "17.5", "18.5", "19.5", "20.5"],
+        )
+
     def test_option_choices_drops_sentinels(self) -> None:
         from custom_components.addhon.const import DRY_LEVEL_SENTINELS
         from custom_components.addhon.program_options import option_choices


### PR DESCRIPTION
## Summary

Three fixes found during a review of `dev`, plus regression tests pinning the two behavioral ones. All fixes are behavior-preserving on covered paths; the full suite stays green.

### 1. `client/engine/rules.py` - guard config-rule application (medium)

`_apply_config_rules` applied `fixedValue`/enum rules **without** the `try/except (ValueError, TypeError)` the runtime trigger path (`_add_trigger.apply`) uses. `patch()` runs inside `HonCommand.__init__`, and `command_loader` does not wrap the construction, so a non-numeric / off-grid `fixedValue` on a range target (or a bad enum value) in a `$installationType` config rule raised `ValueError` all the way up through `load_commands`, dropping **every** command - and thus every entity - of the device.

The config-rule apply is now wrapped in the same guard: a malformed rule is skipped and logged, exactly like the trigger path. Reachable on multi-split ACs (`unitConfiguration` = `1to2`/`1toN`); the single validated 1to1 AC has no matching branch, which is why it wasn't caught before.

### 2. `program_options.py` - index-based range option enumeration (low)

`option_choices` enumerated a range's reachable values with a `current += step` accumulator - the same pattern `range.py.values` was rewritten to avoid. On a decimal step the accumulator compounds float error and emits drifted tokens (e.g. `"25.00000000000007"`) that no longer round-trip against the device's clean enum/range value, and it can drop the final grid point. Switched to index-based `lo + i*step`, rounded to the lo/step precision. Integer-step ranges are unchanged (golden-safe); decimal-step categorical options now render cleanly and keep the last point.

### 3. `select.py` - AC fan-direction select label collisions (low / defensive)

`HonAcDirectionSelect` built `_raw_to_key` / `_attr_options` without the collision disambiguation its sibling `HonProgramOptionSelect` already has: two raw codes mapping to the same label would produce duplicate options and a lossy `_key_to_raw`. Not reachable with the current injective `FAN_DIR_*` maps, but colliding labels are now suffixed with their raw code to remove the latent trap for future label-map edits.

## Testing

- `python3 -m pytest -q` → **1043 passed, 1 skipped** (was 1041 on base; +2 regression tests added here).
- New regression tests:
  - `test_malformed_config_rule_skipped_not_aborting_build` (fix #1) - verified **red on the pre-fix `rules.py`** (`ValueError` escaping `HonCommand.__init__`), green with the guard; also asserts a sibling well-formed config rule still fires.
  - `test_option_choices_decimal_step_keeps_last_point_no_drift` (fix #2) - decimal steps keep the final grid point, emit clean tokens, and do not collapse distinct half-degree points.

## Update: review feedback addressed

Follow-up commits addressing the bot review comments; full suite now **1047 passed, 1 skipped** (+4 tests).

- **Greptile P1 (partial state on a skipped rule).** The guard caught the error but could leave the target param partially mutated (`_apply_fixed` widens `min`/`max`, `_apply_enum` replaces `values`, before the value setter raises). The apply is now snapshotted and rolled back on failure via a shared `_rollback` helper (copies `__dict__` directly, like `param_rollback` on the send path, so no trigger re-fires), applied to both the config-rule and runtime-trigger paths. Also added the missing `return` in the enum branch of `_apply_fixed` to drop a redundant double value-set, which closes the only cascade-then-raise path. New test `test_malformed_config_rule_rolls_back_partial_mutation` (verified red pre-fix: `1.5 != 1`).
- **Sourcery (`_grid_decimals` duplicates `HonParameterRange._decimals`).** Dropped the local helper and reuse the engine's canonical `_decimals` (byte-identical on the float inputs `option_choices` sees), keeping grid precision aligned with `range.py.values`.
- **Sourcery (label disambiguation duplicated across selects).** Extracted `disambiguate_labels(base)` and call it from all three selects (`HonProgramSelect`, `HonProgramOptionSelect`, `HonAcDirectionSelect`); behavior is byte-identical, just DRY. Unit-tested.

Fix #3 now consolidates the label-collision logic into that shared helper rather than adding a third copy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens rule handling and option rendering for addhOn entities. The main changes are:

- Config-rule application now skips malformed fixed or enum rules without aborting command construction.
- Failed rule application now restores the target parameter snapshot.
- Range-backed program options now enumerate by index to avoid decimal drift.
- Select label collision handling is shared across program, option, and AC direction selects.
- Tests cover malformed config rules, rollback behavior, decimal range choices, and label disambiguation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/rules.py | Adds guarded rule application with parameter rollback when fixed or enum rule values cannot be applied. |
| custom_components/addhon/program_options.py | Uses index-based range enumeration so decimal-step option lists keep clean values and endpoints. |
| custom_components/addhon/select.py | Shares collision-safe label disambiguation across select entities that map raw codes to display options. |

<sub>Reviews (3): Last reviewed commit: ["refactor(select): extract shared disambi..."](https://github.com/tis24dev/addhon/commit/a83f125ef2e4c3a11c702451a78f1fa9545cfe73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42302818)</sub>

<!-- /greptile_comment -->