### PR TITLE
Release v5.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate with hassfest
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c
 
   hacs:
     name: hacs
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate with HACS
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa
         with:
           category: integration
           # Brand icons ship in custom_components/addhon/brand/ (HA 2026.3 brands

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ controls where they have been mapped.
 ### Tested on real hardware
 
 - **AC Unit:** Haier AS35PBPHRA-PRE
+- **AC Unit:** Haier AD71S2SM3FA(H)
 - **Washing Machine:** Haier HW80-B14959TU1IT
 - **Washing Machine:** Candy TCA286TM5-S
 - **Tumble Dryer:** Haier HD100-C367GU1-IT

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -396,8 +396,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # _async_register_services).
     _apply_debug_options(entry, reset_when_off=False)
 
-    # FIX: the key saved by the config_flow is "email", not "username"
-    email = entry.data.get("email")
+    # Current entries store "email"; tolerate and migrate older/corrupt entries that
+    # still carry the old "username" key so setup can recover without a reinstall.
+    email = entry.data.get("email") or entry.data.get("username")
     password = entry.data.get("password")
     # Persisted refresh token (added for 2FA): runtime refreshes instead of doing a
     # full login, so an account with email-OTP is not re-challenged on every restart.
@@ -419,6 +420,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Remove and reconfigure the integration."
         )
         return False
+    if "email" not in entry.data and entry.data.get("username"):
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "email": email}
+        )
 
     hon_client = HonClient(email=email, password=password, refresh_token=refresh_token)
 

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -421,9 +421,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
     if "email" not in entry.data and entry.data.get("username"):
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, "email": email}
-        )
+        # Drop the legacy "username" key in the same update so the migrated entry
+        # data carries only "email" (no stale key left for diagnostics/iteration).
+        migrated = {k: v for k, v in entry.data.items() if k != "username"}
+        migrated["email"] = email
+        hass.config_entries.async_update_entry(entry, data=migrated)
 
     hon_client = HonClient(email=email, password=password, refresh_token=refresh_token)
 

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -110,7 +110,11 @@ class HonBaseEntity(CoordinatorEntity):
 
     @property
     def _appliance_data(self) -> dict:
-        return self.coordinator.data.get(self._appliance_id, {})
+        data = self.coordinator.data
+        if not isinstance(data, dict):
+            return {}
+        entry = data.get(self._appliance_id, {})
+        return entry if isinstance(entry, dict) else {}
 
     @property
     def _attributes(self) -> dict:

--- a/custom_components/addhon/base_entity.py
+++ b/custom_components/addhon/base_entity.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -15,14 +16,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def coordinator_data_map(coordinator) -> dict:
-    """The coordinator's per-appliance data dict, or ``{}`` if not yet a dict.
+    """The coordinator's per-appliance data map, or ``{}`` if not yet a mapping.
 
     Shared guard for the platform setup loops (sensor / binary_sensor / select):
     ``coordinator.data`` can be ``None`` before the first successful refresh, so
-    every platform coerces it to a dict before iterating. Centralized here so the
-    guard stays consistent instead of being inlined identically in each platform.
+    every platform coerces it before iterating. Centralized here so the guard
+    stays consistent instead of being inlined identically in each platform. The
+    check is ``Mapping`` (not ``dict``) so any mapping-typed coordinator payload
+    is honored rather than silently dropped.
     """
-    return coordinator.data if isinstance(coordinator.data, dict) else {}
+    return coordinator.data if isinstance(coordinator.data, Mapping) else {}
 
 
 def account_device_info(entry, sw_version: str | None = None) -> DeviceInfo:
@@ -110,8 +113,11 @@ class HonBaseEntity(CoordinatorEntity):
 
     @property
     def _appliance_data(self) -> dict:
+        # Guard ``data`` as a Mapping (not strictly ``dict``) so a mapping-typed
+        # coordinator payload isn't silently reduced to no appliances; the entry
+        # itself is still returned only when it's a plain dict (the read contract).
         data = self.coordinator.data
-        if not isinstance(data, dict):
+        if not isinstance(data, Mapping):
             return {}
         entry = data.get(self._appliance_id, {})
         return entry if isinstance(entry, dict) else {}

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -160,6 +160,12 @@ class HonRuleSet:
         if isinstance(param, HonParameterEnum) and set(param.values) != {str(value)}:
             param.values = [str(value)]
             param.value = str(value)
+            # Return so we do NOT fall through to the trailing `param.value = str(value)`:
+            # a second set would fire the value trigger a second time, and (were a cascade
+            # ever to rewrite this param's own values) could raise AFTER the first set
+            # already succeeded -- past the point _rollback can undo the cascade's effect
+            # on sibling params. One validated set keeps the skip/rollback contract exact.
+            return
         elif isinstance(param, HonParameterRange):
             numeric = float(value)
             if numeric < param.min:
@@ -185,12 +191,32 @@ class HonRuleSet:
             # Degenerate case, not verifiable offline -> deferred to live-AC.
             param.value = default_value
 
+    @staticmethod
+    def _rollback(param: HonParameter, snapshot: dict[str, Any]) -> None:
+        """Restore ``param`` to a pre-apply ``__dict__`` snapshot so a SKIPPED malformed
+        rule leaves NO partial mutation.
+
+        ``_apply_fixed`` can widen ``min``/``max`` and ``_apply_enum`` can replace
+        ``values`` BEFORE the value setter raises, so catching the error alone would keep
+        the narrowed/widened bounds or swapped options while the old value stays in place
+        -- the entity would then expose the wrong range/options or reject the device's
+        current value. Copy ``__dict__`` directly (same mechanism as ``param_rollback`` on
+        the send path): it bypasses the setter, so no trigger re-fires, and every mutated
+        field (``min``/``max``/``values``/``_value``) reverts together. The value setters
+        validate BEFORE assigning ``_value`` (range ``_on_grid`` / enum membership) and no
+        apply re-sets the value after a successful set (see ``_apply_fixed``'s early
+        return), so a raise is never preceded by a cascade into sibling params -- the
+        single-param snapshot is a complete rollback."""
+        param.__dict__.clear()
+        param.__dict__.update(snapshot)
+
     def _add_trigger(self, parameter: HonParameter, data: HonRule) -> None:
         def apply(rule: HonRule) -> None:
             if not self._extra_rules_matches(rule):
                 return
             if not (param := self._command.parameters.get(rule.param_key)):
                 return
+            snapshot = dict(param.__dict__)
             try:
                 if fixed_value := rule.param_data.get("fixedValue", ""):
                     self._apply_fixed(param, fixed_value)
@@ -202,8 +228,10 @@ class HonRuleSet:
                 # immediate-fire in `HonParameter.add_trigger` runs at construction
                 # time, so an escaping ValueError from `_apply_fixed` (e.g. float("x")
                 # or an off-step value rejected by the range setter) would fail setup
-                # for every entity of the device. Log and skip the bad rule instead;
-                # the runtime path already tolerates this via the entity write-path.
+                # for every entity of the device. Roll the param back (a partial
+                # mutation is worse than an untouched one) then log and skip the bad
+                # rule; the runtime path already tolerates this via the entity write-path.
+                self._rollback(param, snapshot)
                 _LOGGER.debug(
                     "addhOn: skipping unapplicable rule for '%s' (trigger %s=%s): %s",
                     rule.param_key,
@@ -235,11 +263,29 @@ class HonRuleSet:
                 continue
             if not (param := self._command.parameters.get(param_key)):
                 continue
-            if fixed_value := action.get("fixedValue", ""):
-                self._apply_fixed(param, fixed_value)
-            elif action.get("typology") == "enum":
-                self._apply_enum(
-                    param, HonRule(dollar_key, str(device_value), param_key, action)
+            # Same guard as the runtime trigger path (_add_trigger.apply): a malformed
+            # config rule (non-numeric/off-grid fixedValue on a range, or a bad enum
+            # value) must skip ONLY that rule, never abort the whole command build.
+            # patch() runs in HonCommand.__init__ and command_loader does NOT wrap the
+            # construction, so an escaping ValueError/TypeError would drop every command
+            # -- and thus every entity -- of the device. Snapshot first so a rule that
+            # raises mid-apply is rolled back, not left with partial bounds/options.
+            snapshot = dict(param.__dict__)
+            try:
+                if fixed_value := action.get("fixedValue", ""):
+                    self._apply_fixed(param, fixed_value)
+                elif action.get("typology") == "enum":
+                    self._apply_enum(
+                        param, HonRule(dollar_key, str(device_value), param_key, action)
+                    )
+            except (ValueError, TypeError) as err:
+                self._rollback(param, snapshot)
+                _LOGGER.debug(
+                    "addhOn: skipping unapplicable config rule for '%s' (%s=%s): %s",
+                    param_key,
+                    dollar_key,
+                    device_value,
+                    err,
                 )
 
     def patch(self) -> None:

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -452,7 +452,12 @@ class NativeMqttClient:
             mqtt5.SubscribePacket([mqtt5.Subscription(topic)])
         )
         try:
-            await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
+            # Fast-path already-resolved futures. This avoids a tiny wait_for timeout
+            # racing the event-loop callback that copies the concurrent Future result.
+            if future.done():
+                future.result()
+            else:
+                await asyncio.wait_for(asyncio.wrap_future(future), _SUBSCRIBE_TIMEOUT)
         except asyncio.TimeoutError as err:
             # Attribute the stall to a stable code. No identity in the message
             # (the topic embeds the MAC) -> the bare timeout str only.

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.8.0"
+  "version": "5.8.1"
 }

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -32,6 +32,7 @@ import logging
 from homeassistant.exceptions import HomeAssistantError
 
 from .base_entity import HonBaseEntity
+from .client.engine.parameter.range import HonParameterRange
 from .const import DOMAIN, PROGRAM_PARAM_NAMES, PROGRAM_PENDING_OPTIONS
 from .debug_utils import redact_id
 from .hon_commands import get_command, get_commands, param_range, param_values
@@ -217,16 +218,23 @@ def option_choices(param, drop: tuple[str, ...] = ()) -> list[str]:
         if step <= 0:
             return []
         out: list[str] = []
-        current = lo
-        count = 0
-        # Tight upper bound (+1e-9 only for float-accumulation drift, NOT step/2): a step
-        # that overshoots the max (e.g. 0..10 step 20) must NOT emit a value beyond hi.
-        while current <= hi + 1e-9 and count < _MAX_RANGE_CHOICES:
+        # Index-based enumeration (lo + i*step), NOT a `+= step` accumulator: the
+        # accumulator compounds float error on decimal steps and can DROP the final grid
+        # point -- the exact defect range.py.values was rewritten to avoid. Each point is
+        # rounded to the lo/step precision so a decimal step renders "20.7", not
+        # "20.700000000000003". The +1e-9 only absorbs the i*step rounding drift; a step
+        # that overshoots the max (e.g. 0..10 step 20) still emits a single value, never
+        # one beyond hi. Bounded by _MAX_RANGE_CHOICES so a malformed range cannot loop.
+        # Reuse HonParameterRange._decimals (single source of truth for grid precision)
+        # so this matches range.py.values' rounding and the tokens keep round-tripping.
+        ndigits = max(HonParameterRange._decimals(lo), HonParameterRange._decimals(step))
+        for index in range(_MAX_RANGE_CHOICES):
+            current = round(lo + index * step, ndigits)
+            if current > hi + 1e-9:
+                break
             token = _num_str(current)
             if token not in drop and token not in out:
                 out.append(token)
-            current += step
-            count += 1
         return out
     return option_value_set(param, drop)
 

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -67,6 +67,24 @@ _REF_MODE_FLAG_TO_PROGRAM: dict[str, str] = {
 _LOGGER = logging.getLogger(__name__)
 
 
+def disambiguate_labels(base: dict[str, str]) -> dict[str, str]:
+    """Make a ``code -> label`` map collision-safe for a select's options.
+
+    Two codes sharing a display label would collapse in the reverse map, leaving one code
+    unreachable from the UI and mapping the lost code's current_option onto the survivor.
+    Suffix ONLY the colliding labels with their code so every code stays selectable and the
+    reverse map is injective; unique labels are untouched (they keep their translatable
+    string). Insertion order is preserved. Shared by every select that builds options from a
+    code/label map (program, program-option, AC direction) so the behavior can't drift."""
+    counts: dict[str, int] = {}
+    for label in base.values():
+        counts[label] = counts.get(label, 0) + 1
+    return {
+        code: (f"{label} ({code})" if counts[label] > 1 else label)
+        for code, label in base.items()
+    }
+
+
 @dataclass(frozen=True, kw_only=True)
 class HonProgramOptionSelectDescription:
     """A categorical program option rendered as a select (#35).
@@ -322,19 +340,11 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
         if appliance is not None:
             self._program_map = self._load_programs(appliance)
 
-        # Disambiguate collided labels: two program CODES sharing a display label would
-        # otherwise collapse in the reverse map, leaving one program unreachable from the
-        # UI and mapping current_option of the lost code onto the survivor's code. Suffix
-        # ONLY the colliding labels with their raw code so every code stays selectable and
-        # the reverse map is injective (mirrors HonProgramOptionSelect). Unique labels are
-        # untouched, keeping their translatable string.
-        label_counts: dict[str, int] = {}
-        for label in self._program_map.values():
-            label_counts[label] = label_counts.get(label, 0) + 1
-        self._program_display: dict[str, str] = {
-            code: (f"{label} ({code})" if label_counts[label] > 1 else label)
-            for code, label in self._program_map.items()
-        }
+        # Disambiguate collided labels so every program CODE stays selectable and the
+        # reverse map is injective (two codes sharing a display label would otherwise
+        # collapse, leaving one program unreachable and mapping current_option of the lost
+        # code onto the survivor). See disambiguate_labels.
+        self._program_display: dict[str, str] = disambiguate_labels(self._program_map)
         self._program_reverse: dict[str, str] = {
             display: code for code, display in self._program_display.items()
         }
@@ -603,16 +613,9 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
         # Collision-aware disambiguation (PR #38 / Greptile P2): when two EXPOSED raw codes
         # share a label (DRY_LEVEL_LABELS_TD maps e.g. 1 & 12 both to "iron_dry"), suffixing
         # ONLY the colliding ones with their raw code keeps every code selectable and keeps
-        # the reverse map injective (otherwise one raw would be unreachable). Non-colliding
-        # labels are untouched, so the common case keeps its translatable `state.<key>`; a
-        # suffixed colliding key has no translation and renders literally (rare-model-only).
-        label_counts: dict[str, int] = {}
-        for label in base_keys.values():
-            label_counts[label] = label_counts.get(label, 0) + 1
-        self._raw_to_key: dict[str, str] = {
-            raw: (f"{label} ({raw})" if label_counts[label] > 1 else label)
-            for raw, label in base_keys.items()
-        }
+        # the reverse map injective. Non-colliding labels keep their translatable
+        # `state.<key>`; a suffixed colliding key renders literally (rare-model-only).
+        self._raw_to_key: dict[str, str] = disambiguate_labels(base_keys)
         self._key_to_raw: dict[str, str] = {key: raw for raw, key in self._raw_to_key.items()}
         # One distinct option per exposed raw code (keys are now unique; order preserved).
         self._attr_options = list(self._raw_to_key.values())
@@ -886,12 +889,18 @@ class HonAcDirectionSelect(HonBaseEntity, SelectEntity):
         # unknown. For the real per-model enums (clean small integers) this is a no-op.
         # param_allowed_values([]/None) yields [] (gated-out params never reach here).
         # Mirrors HonProgramOptionSelect / option_value_set, which already normalize.
-        self._raw_to_key: dict[str, str] = {}
+        base_keys: dict[str, str] = {}
         for raw in param_allowed_values(param):
             code = normalize_code(raw)
             if code is None:
                 continue
-            self._raw_to_key[code] = label_map.get(code, code)
+            base_keys[code] = label_map.get(code, code)
+        # Collision-aware disambiguation (mirrors HonProgramOptionSelect): if two codes
+        # share a label, suffix the colliding ones so every code stays selectable and
+        # _key_to_raw never drops one. The current FAN_DIR maps are injective (numeric
+        # fallbacks), so this is a no-op today; it removes the latent duplicate-option /
+        # lossy-reverse trap if a map ever gains a shared label. See disambiguate_labels.
+        self._raw_to_key: dict[str, str] = disambiguate_labels(base_keys)
         self._key_to_raw: dict[str, str] = {
             key: raw for raw, key in self._raw_to_key.items()
         }

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -1112,6 +1112,12 @@ class HonLastRefreshSensor(HonAccountCoordinatorEntity, SensorEntity):
     def _now():
         # Lazy dt import: keeps the test stubs (which import this module but never
         # drive a coordinator update) free of a homeassistant.util.dt stub.
+        from datetime import UTC
+
         from homeassistant.util import dt as dt_util
 
+        now = getattr(dt_util, "now", None)
+        if callable(now):
+            return now(UTC)
+        # Test stubs and older HA shims may only provide utcnow().
         return dt_util.utcnow()

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -1110,14 +1110,11 @@ class HonLastRefreshSensor(HonAccountCoordinatorEntity, SensorEntity):
 
     @staticmethod
     def _now():
-        # Lazy dt import: keeps the test stubs (which import this module but never
-        # drive a coordinator update) free of a homeassistant.util.dt stub.
+        # Lazy dt import: keeps test stubs that import this module (but never drive a
+        # coordinator update) free of a homeassistant.util.dt stub. now(UTC) returns a
+        # tz-aware UTC datetime (the TIMESTAMP device class requires aware values).
         from datetime import UTC
 
         from homeassistant.util import dt as dt_util
 
-        now = getattr(dt_util, "now", None)
-        if callable(now):
-            return now(UTC)
-        # Test stubs and older HA shims may only provide utcnow().
-        return dt_util.utcnow()
+        return dt_util.now(UTC)

--- a/tests/test_ac_fan_direction_select.py
+++ b/tests/test_ac_fan_direction_select.py
@@ -350,5 +350,28 @@ class AcFanDirectionI18nTest(unittest.TestCase):
             )
 
 
+class DisambiguateLabelsTest(unittest.TestCase):
+    """The shared collision helper backing every code/label select (program,
+    program-option, AC direction): only colliding labels get suffixed, so the reverse
+    map stays injective while unique (translatable) labels are untouched."""
+
+    def test_no_collision_is_identity(self) -> None:
+        base = {"1": "low", "2": "mid", "3": "high"}
+        self.assertEqual(select.disambiguate_labels(base), base)
+
+    def test_collision_suffixes_only_the_colliding_labels(self) -> None:
+        # 1 and 12 both map to "iron_dry"; "auto" is unique.
+        out = select.disambiguate_labels({"1": "iron_dry", "12": "iron_dry", "0": "auto"})
+        self.assertEqual(out, {"1": "iron_dry (1)", "12": "iron_dry (12)", "0": "auto"})
+        # Every code stays selectable and the reverse map loses nothing.
+        self.assertEqual(len(set(out.values())), len(out))
+        self.assertEqual({v: k for k, v in out.items()},
+                         {"iron_dry (1)": "1", "iron_dry (12)": "12", "auto": "0"})
+
+    def test_insertion_order_preserved(self) -> None:
+        base = {"c": "x", "a": "x", "b": "y"}
+        self.assertEqual(list(select.disambiguate_labels(base)), ["c", "a", "b"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_debug_panel.py
+++ b/tests/test_debug_panel.py
@@ -144,13 +144,13 @@ def _install_stubs() -> None:
         const, "EntityCategory", type("EntityCategory", (), {"CONFIG": "config", "DIAGNOSTIC": "diagnostic"})
     )
 
-    # dt_util.utcnow(): the timestamp source for HonLastRefreshSensor (lazy-imported
+    # dt_util.now(UTC): the timestamp source for HonLastRefreshSensor (lazy-imported
     # in production so most stubs need not provide it). Our lifecycle tests DO drive
     # a coordinator update, so supply a tz-aware UTC clock (TIMESTAMP must be aware).
     util = _mod("homeassistant.util")
     dt = _mod("homeassistant.util.dt")
-    if not hasattr(dt, "utcnow"):
-        dt.utcnow = lambda: datetime.datetime.now(datetime.timezone.utc)
+    if not hasattr(dt, "now"):
+        dt.now = lambda tz=None: datetime.datetime.now(tz or datetime.timezone.utc)
     util.dt = dt
 
     ha.config_entries = config_entries

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -617,6 +617,50 @@ class ConfigRuleTest(unittest.TestCase):
         c = self._build(None)  # field absent -> does not fire (fallback like the app)
         self.assertEqual(c.parameters["remoteActionable"].value, 1)
 
+    def test_malformed_config_rule_skipped_not_aborting_build(self) -> None:
+        # A $installationType config rule whose fixedValue is non-numeric for a RANGE
+        # target must NOT raise out of HonCommand construction: patch() runs in
+        # __init__ and the loader does not wrap it, so an escaping ValueError would drop
+        # every command -- and thus every entity -- of the device. The bad rule is
+        # skipped per-iteration (like the runtime trigger path) while a sibling good
+        # config rule still fires.
+        bad = json.loads(json.dumps(_AC_SELF_CLEAN))
+        bad["ancillaryParameters"]["programRules"]["fixedValue"] = {
+            "remoteActionable": {
+                "$installationType": {"1toN": {"fixedValue": "not-a-number",
+                                               "typology": "fixed"}}},
+            "remoteVisible": {
+                "$installationType": {"1toN": {"fixedValue": "0", "typology": "fixed"}}},
+        }
+        c = NaCommand("c", bad, _ConfigApp("1toN"),
+                      category_name="PROGRAMS.AC.IOT_SELF_CLEAN")
+        # Construction did not raise; all params built; the malformed rule was skipped
+        # (target keeps its default 1) but the sibling good rule still applied (-> 0).
+        self.assertEqual(c.parameters["remoteActionable"].value, 1)
+        self.assertEqual(c.parameters["remoteVisible"].value, 0)
+
+    def test_malformed_config_rule_rolls_back_partial_mutation(self) -> None:
+        # A fixedValue BEYOND max AND off the min/step grid widens the range's max
+        # (numeric > max) BEFORE the value setter rejects it as off-grid. Skipping the
+        # rule is not enough: without a rollback the param is left with the widened max
+        # and the old value, so the entity would expose a wrong range. The guard must
+        # restore the pre-apply state; a sibling well-formed rule still fires.
+        bad = json.loads(json.dumps(_AC_SELF_CLEAN))
+        bad["ancillaryParameters"]["programRules"]["fixedValue"] = {
+            "remoteActionable": {
+                "$installationType": {"1toN": {"fixedValue": "1.5", "typology": "fixed"}}},
+            "remoteVisible": {
+                "$installationType": {"1toN": {"fixedValue": "0", "typology": "fixed"}}},
+        }
+        c = NaCommand("c", bad, _ConfigApp("1toN"),
+                      category_name="PROGRAMS.AC.IOT_SELF_CLEAN")
+        ra = c.parameters["remoteActionable"]
+        # Rolled back: max is the original 1 (NOT the transiently-widened 1.5) and the
+        # value is untouched. The sibling well-formed config rule still applied (-> 0).
+        self.assertEqual(ra.max, 1)
+        self.assertEqual(ra.value, 1)
+        self.assertEqual(c.parameters["remoteVisible"].value, 0)
+
 
 class _HassStub:
     async def async_add_executor_job(self, fn, *a):

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -266,6 +266,24 @@ class GateTest(unittest.TestCase):
         self.assertEqual(option_choices(RangeParam(12, 14, 1)), ["12", "13", "14"])
         self.assertEqual(option_choices(RangeParam(0, 360, 360)), ["0", "360"])
 
+    def test_option_choices_decimal_step_keeps_last_point_no_drift(self) -> None:
+        # Regression: the old `current += step` accumulator drifted on decimal steps
+        # ("20.700000000000003") and could drop the final grid point. Index-based
+        # enumeration rounds each point to the lo/step precision -> clean tokens, last
+        # point kept, distinct half-degree points not collapsed.
+        from custom_components.addhon.program_options import option_choices
+
+        toks = option_choices(RangeParam(20.0, 25.0, 0.1))
+        self.assertEqual(len(toks), 51)
+        self.assertEqual(toks[0], "20")
+        self.assertEqual(toks[-1], "25")
+        self.assertNotIn("20.700000000000003", toks)
+        self.assertTrue(all("." not in t or len(t.split(".")[1]) <= 1 for t in toks))
+        self.assertEqual(
+            option_choices(RangeParam(16.5, 20.5, 1.0)),
+            ["16.5", "17.5", "18.5", "19.5", "20.5"],
+        )
+
     def test_option_choices_drops_sentinels(self) -> None:
         from custom_components.addhon.const import DRY_LEVEL_SENTINELS
         from custom_components.addhon.program_options import option_choices

--- a/tests/test_transport_connection.py
+++ b/tests/test_transport_connection.py
@@ -347,6 +347,59 @@ class ConnectionTest(unittest.TestCase):
         self.assertTrue(all(isinstance(r, NativeAuthError) for r in results))
         self.assertEqual(conn._refresh_gen, 1)        # advanced once, even on failure
 
+    def test_reauth_cancelled_not_cached_advances_generation(self) -> None:
+        # A CancelledError during the single-flight re-auth is specific to THIS task,
+        # not a shared auth failure. Unlike a NativeAuthError (cached above so siblings
+        # reuse it), it must NOT land in _reauth_error -- otherwise the sibling branch
+        # would re-raise a cancellation into requests that were never cancelled. It
+        # still advances the generation (create() reset auth to token-less) and re-raises.
+        class CancelAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                raise asyncio.CancelledError()
+
+        auth = CancelAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            return conn
+
+        conn.create = _fake_create
+
+        with self.assertRaises(asyncio.CancelledError):
+            asyncio.run(conn._reauth_after_rejection(conn._refresh_gen))
+        self.assertIsNone(conn._reauth_error)   # cancellation NOT cached
+        self.assertEqual(conn._refresh_gen, 1)  # generation still advanced
+
+    def test_reauth_cancelled_not_inherited_by_sibling(self) -> None:
+        # Counterpart to test_concurrent_reauth_single_flight_on_failure: a NativeAuthError
+        # is cached and re-raised into siblings, but a CancelledError is not. A sibling
+        # "sent" at the pre-cancel generation must fall through to reuse (return), not
+        # inherit the cancellation, since a cancellation belongs only to its own task.
+        class CancelAuth(FakeAuth):
+            async def authenticate(self) -> None:
+                self.authenticate_calls += 1
+                raise asyncio.CancelledError()
+
+        auth = CancelAuth()
+        conn = _conn(auth, FakeSession([]))
+
+        async def _fake_create():
+            return conn
+
+        conn.create = _fake_create
+
+        async def run():
+            gen = conn._refresh_gen  # both "sent" at the same generation
+            with self.assertRaises(asyncio.CancelledError):
+                await conn._reauth_after_rejection(gen)  # the cancelled task unwinds
+            await conn._reauth_after_rejection(gen)      # the sibling returns quietly
+
+        asyncio.run(run())
+        self.assertIsNone(conn._reauth_error)
+        self.assertEqual(auth.authenticate_calls, 1)  # sibling did NOT re-login
+        self.assertEqual(conn._refresh_gen, 1)
+
     def test_retry_on_403_refreshes(self) -> None:
         # Same branch as the 401 (the code treats them identically) but made explicit
         # to avoid regressions on the 403 (CodeRabbit nitpick).


### PR DESCRIPTION
Automated release PR for `v5.8.1`.

<!-- release-tag: v5.8.1 -->

## Summary by Sourcery

Release patch version 5.8.1 with robustness fixes for rule application, option generation, and authentication, plus small UX and CI updates.

Bug Fixes:
- Prevent double-setting and inconsistent rollback when applying fixed and enum rules to Hon parameters, ensuring malformed rules are skipped without partial mutations.
- Handle legacy config entries that still store credentials under a 'username' key by reading and migrating them to 'email'.
- Return timezone-aware UTC timestamps for last-refresh sensors to satisfy TIMESTAMP device class requirements.
- Avoid races when awaiting already-resolved MQTT subscription futures to prevent spurious timeouts.
- Guard against non-dict coordinator data in base entities to avoid crashes when accessing appliance attributes.
- Ensure CancelledError in re-auth flows is not cached or propagated to sibling requests, while still advancing the refresh generation.
- Generate range-based program options using index-based enumeration to avoid floating-point drift and missing final grid points, especially for decimal steps.

Enhancements:
- Introduce a shared label-disambiguation helper for select entities so options with duplicate labels remain uniquely selectable while preserving unique labels.
- Refine config-rule application logic to snapshot and rollback parameter state on errors, keeping entities' ranges and options consistent.
- Extend engine tests for malformed config rules and collision handling, and add tests for decimal range option generation and auth cancellation semantics.

CI:
- Pin hassfest and HACS GitHub Actions to specific commit SHAs for more reproducible CI runs.

Documentation:
- Document support for an additional tested Haier AC unit model in the README.

Tests:
- Add tests covering malformed config rules, rollback behavior, decimal-step option choice generation, label disambiguation for selects, and CancelledError handling in re-auth flows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v5.8.1 release with several robustness fixes.

- Safer config-rule application with rollback on malformed rules.
- Legacy `username` config entries migrated to `email`.
- Timezone-aware last-refresh timestamps.
- More reliable MQTT subscribe handling.
- Range option generation without decimal drift.
- Collision-safe labels for select options.
- Pinned CI actions and updated release metadata.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/sensor.py | Updates the last-refresh sensor to return an aware UTC timestamp on the supported runtime. |
| custom_components/addhon/client/engine/rules.py | Adds rollback around skipped malformed rule applications. |
| custom_components/addhon/program_options.py | Generates range choices with index-based enumeration to avoid decimal drift. |
| custom_components/addhon/select.py | Shares collision-safe label handling across select entities. |
| custom_components/addhon/__init__.py | Reads and migrates legacy config entries that still use `username`. |

<sub>Reviews (2): Last reviewed commit: ["fix(base\_entity): guard coordinator.data..."](https://github.com/tis24dev/addhon/commit/2259e5a5047958ac9092d6f3838408b01661668f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42335180)</sub>

<!-- /greptile_comment -->