### PR TITLE
Fix auth and MQTT startup resilience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install test and runtime dependencies
         run: |
+          # Home Assistant supplies aiohttp, so it is intentionally absent from the
+          # integration manifest; standalone CI must install it explicitly.
           python -m pip install --upgrade pip pytest aiohttp
           python - <<'PY'
           import json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,20 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+      - name: Install test and runtime dependencies
+        run: |
+          python -m pip install --upgrade pip pytest aiohttp
+          python - <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          with open("custom_components/addhon/manifest.json", encoding="utf-8") as file:
+              requirements = json.load(file)["requirements"]
+          subprocess.check_call(
+              [sys.executable, "-m", "pip", "install", *requirements]
+          )
+          PY
 
       - name: Run tests
         run: python -m pytest tests/ -q

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -253,7 +253,9 @@ class NativeHon:
                 # asyncio.CancelledError inherits BaseException on supported Python.
                 self._mqtt_client = None
                 _LOGGER.warning(
-                    "MQTT startup failed; continuing with HTTP polling: %s", error
+                    "MQTT startup failed; continuing with HTTP polling: %s",
+                    error,
+                    exc_info=True,
                 )
         # Setup done: clear the phase so a later (non-setup) loop timeout is not
         # mis-attributed to a setup step.

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -244,7 +244,17 @@ class NativeHon:
                     await self._create_appliance(appliance.copy(), zone=zone + 1)
             await self._create_appliance(appliance)
         if self._enable_mqtt and not self._mqtt_client:
-            self._mqtt_client = await self._make_mqtt()
+            try:
+                self._mqtt_client = await self._make_mqtt()
+            except Exception as error:  # noqa: BLE001 - realtime is optional
+                # MQTT is an acceleration channel; the HTTP poller remains the source
+                # of truth. An AWS token/transport outage must therefore not make the
+                # whole config entry unavailable. Cancellation still propagates because
+                # asyncio.CancelledError inherits BaseException on supported Python.
+                self._mqtt_client = None
+                _LOGGER.warning(
+                    "MQTT startup failed; continuing with HTTP polling: %s", error
+                )
         # Setup done: clear the phase so a later (non-setup) loop timeout is not
         # mis-attributed to a setup step.
         self._setup_phase = ""

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -338,11 +338,20 @@ class HonAuth:
             headers=self._ua({"id-token": self.id_token}),
             json=device_payload,
         ) as resp:
+            if resp.status != 200:
+                self._phase("api_auth", status=resp.status, cognito_token=False)
+                # Preserve the HTTP status in the exception: the setup classifier uses
+                # it to distinguish retryable server/rate-limit failures from an actual
+                # credentials problem. Without it, every 5xx looked like invalid auth
+                # and unnecessarily opened Home Assistant's reauth/2FA flow.
+                raise NativeAuthError(f"api_auth: status {resp.status}")
             data = await resp.json(content_type=None)
         self.cognito_token = data.get("cognitoUser", {}).get("Token", "")
         if not self.cognito_token:
             self._phase("api_auth", status=resp.status, cognito_token=False)
-            raise NativeAuthError("api_auth: no cognito token")
+            raise NativeAuthError(
+                f"api_auth: no cognito token (status {resp.status})"
+            )
         self._phase("api_auth", status=resp.status, cognito_token=True)
 
     async def authenticate(self) -> None:

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -534,6 +534,35 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.mqtt_calls, [])
         self.assertIsNone(nh._mqtt_client)
 
+    def test_mqtt_start_failure_keeps_http_polling_available(self) -> None:
+        h = _Harness(self, [])
+        h.install()
+
+        async def mqtt_boom(_hon):
+            raise ConnectionError("AWS token service status 503")
+
+        self._patch(NativeHon, "_make_mqtt", mqtt_boom)
+        nh = self._nh_with_api(h, enable_mqtt=True)
+        with self.assertLogs(session_mod._LOGGER, level="WARNING") as logs:
+            _run(nh.setup())
+
+        self.assertIsNone(nh._mqtt_client)
+        self.assertEqual(nh._setup_phase, "")
+        self.assertIn("continuing with HTTP polling", "\n".join(logs.output))
+
+    def test_mqtt_start_cancellation_still_propagates(self) -> None:
+        h = _Harness(self, [])
+        h.install()
+
+        async def mqtt_cancelled(_hon):
+            raise asyncio.CancelledError()
+
+        self._patch(NativeHon, "_make_mqtt", mqtt_cancelled)
+        nh = self._nh_with_api(h, enable_mqtt=True)
+        with self.assertRaises(asyncio.CancelledError):
+            _run(nh.setup())
+        self.assertIsNone(nh._mqtt_client)
+
     def test_minimal_skips_per_appliance_loads_and_mqtt(self) -> None:
         # #30: config-flow validation builds + counts the appliances but does NOT run
         # the per-appliance load_commands/attributes/statistics, and never starts MQTT.

--- a/tests/test_session_protocol_live.py
+++ b/tests/test_session_protocol_live.py
@@ -26,7 +26,7 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[1]
 
 
-def _deps_available() -> bool:
+def _probe_dependencies() -> tuple[bool, str]:
     # Probe in a clean interpreter. Other test modules deliberately install fake
     # aiohttp/awscrt packages in this process during collection; inspecting
     # sys.modules/find_spec here consequently skipped this live test even when all
@@ -38,13 +38,19 @@ def _deps_available() -> bool:
         text=True,
         timeout=30,
     )
-    return result.returncode == 0
+    detail = (result.stderr or result.stdout).strip()
+    return result.returncode == 0, detail
 
 
 class LiveSessionProtocolTest(unittest.TestCase):
     def test_real_hon_satisfies_honsession(self) -> None:
-        if not _deps_available():
-            self.skipTest("aiohttp/awscrt/yarl not available: skipping the real Hon check")
+        available, detail = _probe_dependencies()
+        if not available:
+            suffix = f" ({detail})" if detail else ""
+            self.skipTest(
+                "aiohttp/awscrt/yarl not available: skipping the real Hon check"
+                f"{suffix}"
+            )
         script = textwrap.dedent(
             f"""
             import sys, types, importlib.util

--- a/tests/test_session_protocol_live.py
+++ b/tests/test_session_protocol_live.py
@@ -17,7 +17,6 @@ trick pre-registers empty packages to skip the heavy integration __init__).
 """
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import sys
 import textwrap
@@ -28,20 +27,18 @@ _ROOT = Path(__file__).resolve().parents[1]
 
 
 def _deps_available() -> bool:
-    # Importing the real Hon requires aiohttp AND awscrt (hon.py imports mqtt.py
-    # which does `from awscrt import mqtt5`). Both are needed or the subprocess
-    # would fail the import instead of skipping. Robust against modules STUBBED by
-    # other tests (another test module may register a fake `aiohttp` in
-    # sys.modules: find_spec on a module without __spec__ raises ValueError, and a
-    # real module always has spec.origin) -> when in doubt: not available, skip.
-    for name in ("aiohttp", "awscrt", "yarl"):
-        try:
-            spec = importlib.util.find_spec(name)
-        except (ValueError, ImportError):
-            return False
-        if spec is None or spec.origin is None:
-            return False
-    return True
+    # Probe in a clean interpreter. Other test modules deliberately install fake
+    # aiohttp/awscrt packages in this process during collection; inspecting
+    # sys.modules/find_spec here consequently skipped this live test even when all
+    # real dependencies were installed. The protocol assertion already runs in a
+    # subprocess, so its dependency gate must use the same isolation boundary.
+    result = subprocess.run(
+        [sys.executable, "-c", "import aiohttp, awscrt, yarl"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode == 0
 
 
 class LiveSessionProtocolTest(unittest.TestCase):

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -214,7 +214,14 @@ class NativeAuthFlowTest(unittest.TestCase):
         responses = _happy_responses()
         responses[-1] = FakeResp(json={"cognitoUser": {}})  # no Token
         auth = self._auth(responses)
-        with self.assertRaises(NativeAuthError):
+        with self.assertRaisesRegex(NativeAuthError, r"status 200"):
+            asyncio.run(auth.authenticate())
+
+    def test_api_auth_server_error_preserves_status_for_retry_routing(self) -> None:
+        responses = _happy_responses()
+        responses[-1] = FakeResp(status=503, json={})
+        auth = self._auth(responses)
+        with self.assertRaisesRegex(NativeAuthError, r"api_auth: status 503"):
             asyncio.run(auth.authenticate())
 
     def test_progressive_login_without_href_raises(self) -> None:

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -214,7 +214,9 @@ class NativeAuthFlowTest(unittest.TestCase):
         responses = _happy_responses()
         responses[-1] = FakeResp(json={"cognitoUser": {}})  # no Token
         auth = self._auth(responses)
-        with self.assertRaisesRegex(NativeAuthError, r"status 200"):
+        with self.assertRaisesRegex(
+            NativeAuthError, r"api_auth: no cognito token \(status 200\)"
+        ):
             asyncio.run(auth.authenticate())
 
     def test_api_auth_server_error_preserves_status_for_retry_routing(self) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Improve session startup resilience by preserving API auth error statuses, making MQTT startup failures non-fatal, and ensuring live protocol tests run with real runtime dependencies.

Bug Fixes:
- Preserve API auth HTTP status codes in raised errors so transient 5xx/429 responses are routed to retry rather than triggering reauthentication.
- Handle MQTT client startup failures by falling back to HTTP polling instead of failing the entire session while still propagating cancellations.

Enhancements:
- Gate the live NativeHon session protocol test using a clean subprocess import probe so it only skips when real runtime dependencies are missing.

CI:
- Install pytest and manifest-declared runtime dependencies (including aiohttp) in CI before running tests.

Tests:
- Add regression tests for API auth status handling and MQTT startup failure/cancellation behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves auth failure routing and keeps the session usable when optional MQTT startup fails. The main changes are:

- Preserve API-auth HTTP status codes in raised errors.
- Continue with HTTP polling when MQTT startup fails.
- Let setup cancellation propagate during MQTT startup.
- Install runtime dependencies in CI before tests run.
- Probe the live session protocol in a clean subprocess.
- Add tests for auth status handling and MQTT startup behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/session.py | MQTT startup failures now leave the session on HTTP polling while cancellation still propagates. |
| custom_components/addhon/client/transport/auth.py | API-auth errors now include response status so retryable server and rate-limit failures route correctly. |
| .github/workflows/ci.yml | CI now installs pytest, aiohttp, and manifest runtime dependencies before running tests. |
| tests/test_session_protocol_live.py | The live protocol test now checks dependencies in a clean subprocess. |
| tests/test_native_session.py | Tests now cover MQTT startup failure fallback and cancellation propagation. |
| tests/test_transport_auth.py | Tests now cover API-auth status preservation and missing-token error text. |

<sub>Reviews (2): Last reviewed commit: ["Improve runtime failure diagnostics"](https://github.com/tis24dev/addhon/commit/7511bb327a6cbaadfdfb9b0712e69185494cf76d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43759127)</sub>

<!-- /greptile_comment -->