### PR TITLE
Release v5.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,22 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+      - name: Install test and runtime dependencies
+        run: |
+          # Home Assistant supplies aiohttp, so it is intentionally absent from the
+          # integration manifest; standalone CI must install it explicitly.
+          python -m pip install --upgrade pip pytest aiohttp
+          python - <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          with open("custom_components/addhon/manifest.json", encoding="utf-8") as file:
+              requirements = json.load(file)["requirements"]
+          subprocess.check_call(
+              [sys.executable, "-m", "pip", "install", *requirements]
+          )
+          PY
 
       - name: Run tests
         run: python -m pytest tests/ -q

--- a/custom_components/addhon/ac_command.py
+++ b/custom_components/addhon/ac_command.py
@@ -35,6 +35,25 @@ def settings_param(appliance, name):
     return None
 
 
+# Self-clean flags. On the settings write path these must be 0 whenever HA starts or
+# resumes an operating mode: the Haier app's startProgram payload always carries
+# selfCleaningStatus=0 for a normal mode, and on single-split (1to1) installs the
+# fixed-0 programRule is inert, so a mode command could otherwise ship machMode together
+# with a cached selfCleaningStatus=1 and the unit runs the fan with the compressor off.
+AC_SELF_CLEAN_PARAMS = ("selfCleaningStatus", "selfCleaning56Status")
+
+
+def with_self_clean_off(appliance, params: dict) -> dict:
+    """Return a copy of `params` with the self-clean flags forced to '0', for the flags
+    the device exposes on its settings command. Capability-gated (an absent flag is not
+    injected). setdefault so a caller that set the flag itself is never overridden."""
+    out = dict(params)
+    for name in AC_SELF_CLEAN_PARAMS:
+        if settings_param(appliance, name) is not None:
+            out.setdefault(name, "0")
+    return out
+
+
 def param_allowed_values(param) -> list[str]:
     """Allowed values (as strings) of an enum parameter, or [] if not an enum."""
     values = getattr(param, "values", None)

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -244,19 +244,11 @@ class NativeHon:
                     await self._create_appliance(appliance.copy(), zone=zone + 1)
             await self._create_appliance(appliance)
         if self._enable_mqtt and not self._mqtt_client:
-            try:
-                self._mqtt_client = await self._make_mqtt()
-            except Exception as error:  # noqa: BLE001 - realtime is optional
-                # MQTT is an acceleration channel; the HTTP poller remains the source
-                # of truth. An AWS token/transport outage must therefore not make the
-                # whole config entry unavailable. Cancellation still propagates because
-                # asyncio.CancelledError inherits BaseException on supported Python.
-                self._mqtt_client = None
-                _LOGGER.warning(
-                    "MQTT startup failed; continuing with HTTP polling: %s",
-                    error,
-                    exc_info=True,
-                )
+            # NativeMqttClient owns MQTT recovery. On a retryable AWS token/transport
+            # outage create() returns a retained, temporarily-disconnected client whose
+            # watchdog retries in the background; unexpected programming/configuration
+            # errors still propagate instead of being silently converted to polling-only.
+            self._mqtt_client = await self._make_mqtt()
         # Setup done: clear the phase so a later (non-setup) loop timeout is not
         # mis-attributed to a setup step.
         self._setup_phase = ""

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -244,7 +244,19 @@ class NativeHon:
                     await self._create_appliance(appliance.copy(), zone=zone + 1)
             await self._create_appliance(appliance)
         if self._enable_mqtt and not self._mqtt_client:
-            self._mqtt_client = await self._make_mqtt()
+            try:
+                self._mqtt_client = await self._make_mqtt()
+            except Exception as error:  # noqa: BLE001 - realtime is optional
+                # MQTT is an acceleration channel; the HTTP poller remains the source
+                # of truth. An AWS token/transport outage must therefore not make the
+                # whole config entry unavailable. Cancellation still propagates because
+                # asyncio.CancelledError inherits BaseException on supported Python.
+                self._mqtt_client = None
+                _LOGGER.warning(
+                    "MQTT startup failed; continuing with HTTP polling: %s",
+                    error,
+                    exc_info=True,
+                )
         # Setup done: clear the phase so a later (non-setup) loop timeout is not
         # mis-attributed to a setup step.
         self._setup_phase = ""

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -338,11 +338,20 @@ class HonAuth:
             headers=self._ua({"id-token": self.id_token}),
             json=device_payload,
         ) as resp:
+            if resp.status != 200:
+                self._phase("api_auth", status=resp.status, cognito_token=False)
+                # Preserve the HTTP status in the exception: the setup classifier uses
+                # it to distinguish retryable server/rate-limit failures from an actual
+                # credentials problem. Without it, every 5xx looked like invalid auth
+                # and unnecessarily opened Home Assistant's reauth/2FA flow.
+                raise NativeAuthError(f"api_auth: status {resp.status}")
             data = await resp.json(content_type=None)
         self.cognito_token = data.get("cognitoUser", {}).get("Token", "")
         if not self.cognito_token:
             self._phase("api_auth", status=resp.status, cognito_token=False)
-            raise NativeAuthError("api_auth: no cognito token")
+            raise NativeAuthError(
+                f"api_auth: no cognito token (status {resp.status})"
+            )
         self._phase("api_auth", status=resp.status, cognito_token=True)
 
     async def authenticate(self) -> None:

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -38,7 +38,21 @@ from awsiot import mqtt5_client_builder  # type: ignore[import-untyped]
 from .device import MOBILE_ID
 from .values import AWS_AUTHORIZER, AWS_ENDPOINT
 from ...debug_utils import redact_id, redact_identity, redact_topic
-from ...error_codes import HonCodedError, MQTT_SUBSCRIBE_TIMEOUT
+from ...error_codes import (
+    AWS_TOKEN_FAILED,
+    CONNECTION_REFUSED,
+    DECODE_ERROR,
+    DNS_FAILURE,
+    MQTT_CONNECT_TIMEOUT,
+    MQTT_SUBSCRIBE_TIMEOUT,
+    NETWORK_TIMEOUT,
+    RATE_LIMITED,
+    SERVER_ERROR,
+    TLS_FAILURE,
+    UNKNOWN,
+    HonCodedError,
+    classify,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +77,71 @@ _RECONNECT_BACKOFF_CAP = 60
 # to a full rebuild PROMPTLY -- skipping the _RECONNECT_AFTER_FAILED_TICKS grace wait,
 # since this connection is already known dead. Reset to 0 on ANY successful subscribe.
 _MAX_RESUBSCRIBE_FAILURES = 3
+
+# Only operational failures are allowed to make the initial MQTT connection
+# polling-only while the watchdog retries. UNKNOWN is deliberately absent: an
+# ImportError, TypeError, AttributeError or invalid builder contract is a code/config
+# regression and must fail setup visibly instead of being hidden forever.
+_RETRYABLE_STARTUP_CODES = frozenset(
+    {
+        AWS_TOKEN_FAILED,
+        MQTT_CONNECT_TIMEOUT,
+        NETWORK_TIMEOUT,
+        DNS_FAILURE,
+        TLS_FAILURE,
+        CONNECTION_REFUSED,
+        RATE_LIMITED,
+        SERVER_ERROR,
+        DECODE_ERROR,
+    }
+)
+
+
+class MqttStartupUnavailable(HonCodedError):
+    """Retryable failure before the MQTT client's watchdog could be started."""
+
+
+_STRUCTURAL_ERRORS = (
+    AssertionError,
+    AttributeError,
+    ImportError,
+    IndexError,
+    KeyError,
+    NameError,
+    TypeError,
+)
+
+
+def _is_structural_error(error: BaseException) -> bool:
+    """True for deterministic code/schema errors which retry cannot repair."""
+    if isinstance(error, _STRUCTURAL_ERRORS):
+        return True
+    # JSONDecodeError and UnicodeDecodeError are ValueErrors but represent unreadable
+    # cloud responses, not deterministic builder/schema faults.
+    return isinstance(error, ValueError) and not isinstance(
+        error, (json.JSONDecodeError, UnicodeDecodeError)
+    )
+
+
+def _retryable_startup_code(error: BaseException):
+    """Return a stable retry code, or None for a fail-fast setup error."""
+    if _is_structural_error(error):
+        return None
+    code = classify(error, phase="aws_token")
+    if code in _RETRYABLE_STARTUP_CODES:
+        return code
+    # awscrt surfaces native connection/runtime failures through one generic class.
+    # Invalid argument/state errors are deterministic builder-contract faults; other
+    # CRT failures are operational and should use the existing MQTT connect code.
+    if type(error).__name__ == "AwsCrtError":
+        crt_name = str(getattr(error, "name", "")).upper()
+        if any(
+            marker in crt_name
+            for marker in ("INVALID_ARGUMENT", "INVALID_STATE", "ALREADY_STARTED")
+        ):
+            return None
+        return MQTT_CONNECT_TIMEOUT
+    return None
 
 
 def _subscribed_topics(appliance) -> list:
@@ -135,7 +214,26 @@ class NativeMqttClient:
     async def create(self) -> "NativeMqttClient":
         try:
             self._set_setup_phase("mqtt_connect")
-            await self._start()
+            try:
+                await self._start()
+            except Exception as err:
+                code = _retryable_startup_code(err)
+                if code is None:
+                    raise
+                # MQTT is an acceleration channel; HTTP polling remains the source of
+                # truth. Retain THIS NativeMqttClient and start its existing watchdog so
+                # a temporary AWS-token outage heals without a config-entry reload. Stop
+                # a partially-created native client first: it owns sockets/worker threads
+                # and cannot be left beside the later watchdog-created generation.
+                await self.stop()
+                await self._start_watchdog()
+                _LOGGER.warning(
+                    "[%s] MQTT startup deferred; continuing with HTTP polling and "
+                    "retrying in the background",
+                    code.label,
+                    exc_info=True,
+                )
+                return self
             gen = self._generation
             self._set_setup_phase("mqtt_subscribe")
             await self._subscribe_missing()
@@ -161,6 +259,23 @@ class NativeMqttClient:
             raise
         return self
 
+    def _stop_client(self) -> None:
+        """Stop and clear only the native client, leaving watchdog ownership alone."""
+        client, self._client = self._client, None
+        self._connection = False
+        self._subscribed_topics_set = set()
+        if client is None:
+            return
+        # Invalidate callbacks BEFORE stop(): awscrt shutdown is asynchronous and can
+        # emit a queued success/failure after stop. Without the bump that late event is
+        # still "current" and can resurrect a false connected state on a client we no
+        # longer own, causing the watchdog to skip recovery (especially with zero topics).
+        self._generation += 1
+        try:
+            client.stop()
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("addhOn: MQTT client stop failed: %s", err)
+
     async def stop(self) -> None:
         """Stop watchdog (cancel+await) and then the awscrt client. Idempotent."""
         if self._watchdog_task is not None:
@@ -172,12 +287,7 @@ class NativeMqttClient:
             except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.debug("addhOn: awaiting MQTT watchdog cancel failed: %s", err)
             self._watchdog_task = None
-        if self._client is not None:
-            try:
-                self._client.stop()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("addhOn: MQTT client stop failed: %s", err)
-            self._client = None
+        self._stop_client()
 
     # -- lifecycle callbacks ---------------------------------------------------
     # The callbacks that write self._connection are registered (in _start) bound to the
@@ -388,12 +498,10 @@ class NativeMqttClient:
         # without stopping the previous one leaks its native AWS IoT connection
         # (socket + worker threads are NOT released by GC, only by .stop()), so a
         # sustained disconnection would spawn a new orphan client every cycle.
-        if self._client is not None:
-            try:
-                self._client.stop()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
-            self._client = None
+        # _stop_client invalidates the old generation BEFORE stop(), so even a success
+        # callback synchronously/late emitted by native shutdown cannot resurrect a
+        # false connected state during the rebuild.
+        self._stop_client()
         # A fresh client carries over no subscriptions: clear the set here (the caller
         # -- create() or the watchdog rebuild path -- re-populates it only after the
         # subscribe succeeds). Rebind (atomic) rather than .clear().
@@ -406,19 +514,19 @@ class NativeMqttClient:
         # healthy), but a rebuild whose subscribe then fails would leave a
         # stale connected-but-unsubscribed state on a client that is not actually up yet,
         # sending the next tick down the in-place re-subscribe path against a dead client
-        # instead of rebuilding. The only late callback the stopped client can still emit
-        # is a disconnection (-> False), never a spurious success, and the generation bump
-        # below rejects every other stale event; so this reset cannot be flipped True.
+        # instead of rebuilding. _stop_client already invalidated every old callback;
+        # this reset establishes the initial state for the new generation.
         self._connection = False
         # Tag this client's state-mutating callbacks with a fresh generation so a late
         # event from the client just stopped cannot flip self._connection (see
         # _is_stale_generation).
         self._generation += 1
         generation = self._generation
+        signature = await self._load_aws_signature()
         self._client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=AWS_ENDPOINT,
             auth_authorizer_name=AWS_AUTHORIZER,
-            auth_authorizer_signature=await self._api.load_aws_token(),
+            auth_authorizer_signature=signature,
             auth_token_key_name="token",
             auth_token_value=self._api.auth.id_token,
             # AWS-IoT requires a UNIQUE MQTT clientId (awsiot docs). Keep the EXACT
@@ -440,6 +548,31 @@ class NativeMqttClient:
             on_publish_received=self._on_message,
         )
         self.client.start()
+
+    async def _load_aws_signature(self) -> str:
+        """Load the custom-authorizer signature and type retryable startup errors.
+
+        This is the only synchronous network step before the awscrt client exists.
+        Once ``client.start()`` succeeds, awscrt owns broker reconnects and our
+        watchdog owns token refresh/rebuilds. Keeping the boundary here prevents a
+        broad ``except Exception`` from hiding builder/programming regressions.
+        """
+        try:
+            signature = await self._api.load_aws_token()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            code = _retryable_startup_code(err)
+            if code is not None:
+                raise MqttStartupUnavailable(
+                    code, "MQTT startup is temporarily unavailable"
+                ) from err
+            raise
+        if not signature:
+            raise MqttStartupUnavailable(
+                AWS_TOKEN_FAILED, "AWS IoT token response was empty"
+            )
+        return signature
 
     def _all_topics(self) -> set[str]:
         """Union of the subscribe topics of every appliance (the target set)."""
@@ -638,16 +771,31 @@ class NativeMqttClient:
                 backoff = 0  # rebuild succeeded
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception as err:
                 # Only the REBUILD path (load_aws_token / _start / the rebuild's
                 # _subscribe_missing) can land here now: the in-place re-subscribe uses
                 # _subscribe_missing(), which swallows a per-topic HonCodedError (the
                 # blackout escalation is driven inline by resubscribe_failures, not by a
                 # raise). Back off (capped, reset on recovery) so a persistent 5xx from
                 # the AWS authorizer is not hammered every tick.
+                code = _retryable_startup_code(err)
+                if code is None and _is_structural_error(err):
+                    # A deterministic code/schema error cannot heal. Stop the partial
+                    # transport and surface it loudly; do not spin forever. Non-
+                    # structural UNKNOWN runtime failures retain the old watchdog
+                    # resilience below, because terminating the supervisor would make
+                    # realtime permanently dead for this session.
+                    self._stop_client()
+                    _LOGGER.error(
+                        "MQTT watchdog stopped after a structural recovery error",
+                        exc_info=True,
+                    )
+                    return
+                code = code or UNKNOWN
                 backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
                 _LOGGER.warning(
-                    "MQTT watchdog: reconnect failed, retrying in %ss",
+                    "[%s] MQTT watchdog: reconnect failed, retrying in %ss",
+                    code.label,
                     _WATCHDOG_INTERVAL + backoff,
                     exc_info=True,
                 )

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -46,6 +46,7 @@ from .ac_command import (
     fixed_vertical_value,
     param_allowed_values,
     settings_param,
+    with_self_clean_off,
 )
 from .hon_commands import async_send_command, param_range, param_values
 from .program_options import async_send_program, startprogram_command
@@ -445,7 +446,11 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
                 )
 
                 await self._send_command_in_executor(
-                    client, appliance, {"onOffStatus": "1", "machMode": str(mode_key)}
+                    client,
+                    appliance,
+                    with_self_clean_off(
+                        appliance, {"onOffStatus": "1", "machMode": str(mode_key)}
+                    ),
                 )
             await self._async_request_command_refresh()
         except Exception as err:
@@ -487,7 +492,7 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
             else:
                 _LOGGER.debug("Climate debug: turn_on -> onOffStatus=1 (mode preserved)")
                 await self._send_command_in_executor(
-                    client, appliance, {"onOffStatus": "1"}
+                    client, appliance, with_self_clean_off(appliance, {"onOffStatus": "1"})
                 )
             await self._async_request_command_refresh()
         except Exception as err:

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 from dataclasses import dataclass
 
 CODE_PREFIX = "ADDHON"
@@ -182,15 +183,22 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
 
     Order is most-specific-first. A carried code wins; then rate-limit/5xx (which
     must beat the auth-named-class rule, like the existing classifier); then
-    timeouts (attributed to ``phase`` when known); then TLS/DNS/refused; then the
-    native auth-step messages; finally the coarse buckets via the existing
-    ``hon_client`` predicates.
+    timeouts (attributed to ``phase`` when known); then explicit auth rejections,
+    TLS/DNS/refused and native auth-step messages; finally broad transport types
+    and the coarse buckets via the existing ``hon_client`` predicates.
     """
     code = getattr(err, "error_code", None)
     if isinstance(code, HonErrorCode):
         return code
 
+    # Decode types are unambiguous even when their ordinary messages do not contain
+    # "decode error". Broad connection types are deliberately handled later: their
+    # messages may still carry a more-specific 5xx or explicit auth rejection.
+    if isinstance(err, (json.JSONDecodeError, UnicodeDecodeError)):
+        return DECODE_ERROR
+
     name = type(err).__name__.lower()
+    class_names = " ".join(cls.__name__.lower() for cls in type(err).__mro__)
     text = str(err).lower()
     hay = f"{text} {name}"
 
@@ -213,6 +221,45 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return SERVER_ERROR
     if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
         return phase_timeout_code(phase)
+
+    # A transport-shaped exception can wrap a real HTTP/token rejection. Detect only
+    # explicit rejection markers here (not a bare "auth"/"token", which may merely be
+    # an endpoint name) so bad credentials propagate to HA reauth instead of being
+    # converted to MQTT polling-only retries. Retryable 429/5xx/timeouts above retain
+    # priority, including NativeAuthError("api_auth: status 503").
+    auth_rejected = (
+        "unauthorized" in hay
+        or any(
+            marker in hay
+            for marker in (
+                "http 401",
+                "http 403",
+                "status 401",
+                "status 403",
+                "status=401",
+                "status=403",
+                "token rejected",
+                "rejected token",
+                "invalid token",
+                "token invalid",
+                "expired token",
+                "token expired",
+                "invalid credential",
+                "credential rejected",
+            )
+        )
+    )
+    if auth_rejected:
+        if "api_auth" in hay:
+            return AUTH_API_AUTH
+        if "get_token" in hay or "token page" in hay or "progressive" in hay:
+            return AUTH_GET_TOKEN
+        if "login page" in hay or "introduce" in hay or "no fwuid" in hay:
+            return AUTH_INTRODUCE
+        if "login:" in hay or "can't login" in hay or "login failed" in hay:
+            return AUTH_LOGIN
+        return INVALID_CREDENTIALS
+
     # TLS/certificate: key off the exception CLASS NAME or explicit certificate text,
     # NOT a bare "ssl" in the message. aiohttp's ClientConnectorError __str__ ALWAYS
     # contains "ssl:default" for ANY HTTPS connect failure (a plain outage, not a TLS
@@ -239,6 +286,8 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         or "network is unreachable" in text
     ):
         return CONNECTION_REFUSED
+    if "clientpayloaderror" in class_names:
+        return DECODE_ERROR
     if "decode error" in hay:
         return DECODE_ERROR
     if "api_auth" in hay:
@@ -251,6 +300,23 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return AUTH_LOGIN
     if "appliance" in hay and "empty" in hay:
         return APPLIANCE_LIST_EMPTY
+
+    # Broad transport fallbacks come after the semantic markers above. Otherwise a
+    # ConnectionError/ClientConnectionError carrying "401 unauthorized" becomes
+    # ADDHON-430 and MQTT treats a credential rejection as a retryable outage.
+    if isinstance(err, ConnectionError):
+        return CONNECTION_REFUSED
+    if any(
+        family in class_names
+        for family in (
+            "clientconnectionerror",
+            "clientconnectorerror",
+            "clientoserror",
+            "serverconnectionerror",
+            "serverdisconnectederror",
+        )
+    ):
+        return CONNECTION_REFUSED
 
     # Coarse fallback via the existing routing predicates (single source of truth).
     from .hon_client import _is_auth_error, _is_retryable_server_error

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.8.2"
+  "version": "5.8.3"
 }

--- a/docs/superpowers/plans/2026-07-14-ac-selfclean-mode-compressor.md
+++ b/docs/superpowers/plans/2026-07-14-ac-selfclean-mode-compressor.md
@@ -1,0 +1,261 @@
+# AC self-clean vs mode compressor-off fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the AC integration from emitting a `settings` command that starts or resumes an operating mode while a self-clean flag is still `1`, which leaves the unit running the fan with the compressor off.
+
+**Architecture:** Add a capability-gated helper in `ac_command.py` that augments a settings params dict with `selfCleaningStatus="0"` / `selfCleaning56Status="0"` for the flags the device exposes. Wrap the two mode-establishing sends in `climate.py` (active-mode `async_set_hvac_mode`, settings-based `async_turn_on`) with it. This mirrors the Haier app's `startProgram` payload, which always carries self-clean = 0 when starting a normal mode.
+
+**Tech Stack:** Python, Home Assistant custom integration, unittest + pytest test harness.
+
+## Global Constraints
+
+- Scope is the settings-based AC write path only. Program-based ACs already route through `startProgram` and are untouched.
+- The helper must be capability-gated: it injects a flag ONLY if `settings_param(appliance, name)` is not None. A device without the flag gets no injected key (an unknown param would make `async_send_command` raise "Parameter(s) not found").
+- Do NOT clear self-clean on OFF, `set_temperature`, `set_fan_mode`, or `set_swing_mode`. Only starting/resuming an active mode clears it.
+- Assertions read `RecordingCommand.sent` (the payload frozen at `send()`), which snapshots ALL params on the settings command, not only the ones passed in.
+- Code and comments in English. No em/en dashes in code or comments. Conventional-commit messages. No `Co-Authored-By: Claude` trailer. Commit locally, do not push (push on explicit request only).
+- Run tests one at a time, no parallel/xdist, and read the real exit code.
+
+---
+
+### Task 1: `with_self_clean_off` helper
+
+**Files:**
+- Modify: `custom_components/addhon/ac_command.py` (add helper + constant near `settings_param`)
+- Test: `tests/test_ac_write_path.py` (add helper unit tests)
+
+**Interfaces:**
+- Consumes: `settings_param(appliance, name)` (already in `ac_command.py`).
+- Produces: `AC_SELF_CLEAN_PARAMS: tuple[str, ...]` and `with_self_clean_off(appliance, params: dict) -> dict` (returns a NEW dict; never mutates the input).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_ac_write_path.py` (new test class; `types` and `ac_command`, `Param`, `RecordingCommand` are already imported at module top):
+
+```python
+class WithSelfCleanOffTest(unittest.TestCase):
+    def _ac_settings(self, params: dict):
+        return types.SimpleNamespace(commands={"settings": RecordingCommand(params)})
+
+    def test_injects_zero_for_exposed_flags(self) -> None:
+        appliance = self._ac_settings(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("0"),
+                "selfCleaningStatus": Param("1"),
+                "selfCleaning56Status": Param("1"),
+            }
+        )
+        out = ac_command.with_self_clean_off(
+            appliance, {"onOffStatus": "1", "machMode": "1"}
+        )
+        self.assertEqual(
+            {
+                "onOffStatus": "1",
+                "machMode": "1",
+                "selfCleaningStatus": "0",
+                "selfCleaning56Status": "0",
+            },
+            out,
+        )
+
+    def test_skips_flags_the_device_does_not_expose(self) -> None:
+        appliance = self._ac_settings(
+            {"onOffStatus": Param("0"), "machMode": Param("0")}
+        )
+        out = ac_command.with_self_clean_off(
+            appliance, {"onOffStatus": "1", "machMode": "1"}
+        )
+        self.assertEqual({"onOffStatus": "1", "machMode": "1"}, out)
+
+    def test_does_not_override_caller_supplied_value(self) -> None:
+        appliance = self._ac_settings({"selfCleaningStatus": Param("0")})
+        out = ac_command.with_self_clean_off(appliance, {"selfCleaningStatus": "1"})
+        self.assertEqual("1", out["selfCleaningStatus"])
+
+    def test_does_not_mutate_input(self) -> None:
+        appliance = self._ac_settings({"selfCleaningStatus": Param("1")})
+        params = {"onOffStatus": "1"}
+        ac_command.with_self_clean_off(appliance, params)
+        self.assertEqual({"onOffStatus": "1"}, params)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_ac_write_path.py -k WithSelfCleanOff -p no:randomly`
+Expected: FAIL with `AttributeError: module 'custom_components.addhon.ac_command' has no attribute 'with_self_clean_off'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `custom_components/addhon/ac_command.py`, after the `settings_param` function, add:
+
+```python
+# Self-clean flags. On the settings write path these must be 0 whenever HA starts or
+# resumes an operating mode: the Haier app's startProgram payload always carries
+# selfCleaningStatus=0 for a normal mode, and on single-split (1to1) installs the
+# fixed-0 programRule is inert, so a mode command could otherwise ship machMode together
+# with a cached selfCleaningStatus=1 and the unit runs the fan with the compressor off.
+AC_SELF_CLEAN_PARAMS = ("selfCleaningStatus", "selfCleaning56Status")
+
+
+def with_self_clean_off(appliance, params: dict) -> dict:
+    """Return a copy of `params` with the self-clean flags forced to '0', for the flags
+    the device exposes on its settings command. Capability-gated (an absent flag is not
+    injected). setdefault so a caller that set the flag itself is never overridden."""
+    out = dict(params)
+    for name in AC_SELF_CLEAN_PARAMS:
+        if settings_param(appliance, name) is not None:
+            out.setdefault(name, "0")
+    return out
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_ac_write_path.py -k WithSelfCleanOff -p no:randomly`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/addhon/ac_command.py tests/test_ac_write_path.py
+git commit -m "fix(ac): add with_self_clean_off settings helper"
+```
+
+---
+
+### Task 2: Clear self-clean when starting or resuming a mode
+
+**Files:**
+- Modify: `custom_components/addhon/climate.py` (import + two call sites)
+- Test: `tests/test_ac_write_path.py` (behavioral + regression tests)
+
+**Interfaces:**
+- Consumes: `with_self_clean_off(appliance, params)` from Task 1; existing `_send_command_in_executor`, `_climate`, `RecordingCommand`, `Param`, `FakeClient`, `FakeHass`, `FakeCoordinator`, `_ac`, `switch`.
+- Produces: no new public symbol.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the AC write-path test class in `tests/test_ac_write_path.py` (same class as `test_set_hvac_mode_maps_each_mode`):
+
+```python
+    async def test_set_hvac_mode_active_clears_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("0"),
+                "selfCleaningStatus": Param("1"),
+                "selfCleaning56Status": Param("1"),
+            }
+        )
+        await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual("1", settings.sent["machMode"])
+        self.assertEqual("0", settings.sent["selfCleaningStatus"])
+        self.assertEqual("0", settings.sent["selfCleaning56Status"])
+
+    async def test_turn_on_clears_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("4"),
+                "selfCleaningStatus": Param("1"),
+            }
+        )
+        await entity.async_turn_on()
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual("0", settings.sent["selfCleaningStatus"])
+
+    async def test_set_temperature_does_not_clear_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {"tempSel": Param("16"), "selfCleaningStatus": Param("1")}
+        )
+        await entity.async_set_temperature(temperature=22)
+        self.assertEqual("1", settings.sent["selfCleaningStatus"])
+
+    async def test_self_clean_switch_turn_on_still_sets_one(self) -> None:
+        settings = RecordingCommand({"selfCleaningStatus": Param("0")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        desc = switch.HonAcSwitchDescription(
+            key="self_clean", param="selfCleaningStatus"
+        )
+        sw = switch.HonAcSwitch(coordinator, "ac-1", desc, FakeClient())
+        sw.hass = FakeHass()
+        await sw.async_turn_on()
+        self.assertEqual("1", settings.sent["selfCleaningStatus"])
+```
+
+- [ ] **Step 2: Run the tests to verify the new mode/turn_on ones fail**
+
+Run: `python -m pytest tests/test_ac_write_path.py -k "active_clears_self_clean or turn_on_clears_self_clean" -p no:randomly`
+Expected: FAIL. `sent["selfCleaningStatus"]` is `"1"` (the mode command carries the stale flag) instead of `"0"`.
+
+Note: `test_set_temperature_does_not_clear_self_clean` and `test_self_clean_switch_turn_on_still_sets_one` should already PASS before the change (they assert unchanged behavior). Run them too to confirm the change does not regress them in Step 5.
+
+- [ ] **Step 3: Wire the helper into `climate.py`**
+
+3a. Add `with_self_clean_off` to the `ac_command` import block (currently `async_send_settings, fixed_vertical_value, param_allowed_values, settings_param`):
+
+```python
+from .ac_command import (
+    async_send_settings,
+    fixed_vertical_value,
+    param_allowed_values,
+    settings_param,
+    with_self_clean_off,
+)
+```
+
+3b. Active-mode branch of `async_set_hvac_mode` (the `else` that sends `{"onOffStatus": "1", "machMode": str(mode_key)}`):
+
+```python
+                await self._send_command_in_executor(
+                    client,
+                    appliance,
+                    with_self_clean_off(
+                        appliance, {"onOffStatus": "1", "machMode": str(mode_key)}
+                    ),
+                )
+```
+
+3c. Settings-based branch of `async_turn_on` (the `else` that sends `{"onOffStatus": "1"}`):
+
+```python
+                await self._send_command_in_executor(
+                    client, appliance, with_self_clean_off(appliance, {"onOffStatus": "1"})
+                )
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `python -m pytest tests/test_ac_write_path.py -k "active_clears_self_clean or turn_on_clears_self_clean or set_temperature_does_not_clear or self_clean_switch_turn_on_still" -p no:randomly`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Run the full AC write-path file to verify no regression**
+
+Run: `python -m pytest tests/test_ac_write_path.py -p no:randomly`
+Expected: PASS. In particular `test_set_hvac_mode_maps_each_mode` and `test_turn_on_*` still pass unchanged, because their fixtures expose no self-clean param so the helper injects nothing.
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `python -m pytest tests/ -p no:randomly`
+Expected: PASS (no new failures).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/addhon/climate.py tests/test_ac_write_path.py
+git commit -m "fix(ac): clear self-clean flags when starting or resuming a mode"
+```
+
+---
+
+## Post-implementation (not a code task)
+
+Live-validate on Roberto's HA with debug ON: trigger self-clean, then set cool from HA, confirm `compressorStatus`/`compressorFrequency` show the compressor engaging (no fan-only). Push only on explicit request.
+
+## Self-Review
+
+- Spec coverage: helper (spec section "New helper") = Task 1. Two call sites + exclusions (spec "Call sites") = Task 2 steps 3b/3c + the temperature regression test. Testing section = Task 1 + Task 2 tests. Rollout = Post-implementation note. No gaps.
+- Placeholder scan: none.
+- Type consistency: `with_self_clean_off(appliance, params)` signature identical in Task 1 (definition) and Task 2 (call sites + import). `AC_SELF_CLEAN_PARAMS` used only where defined.

--- a/docs/superpowers/specs/2026-07-14-ac-selfclean-mode-compressor-design.md
+++ b/docs/superpowers/specs/2026-07-14-ac-selfclean-mode-compressor-design.md
@@ -1,0 +1,121 @@
+# AC self-clean vs mode: compressor-off fix
+
+Date: 2026-07-14
+Status: approved design, not yet implemented
+Scope: `custom_components/addhon/ac_command.py`, `custom_components/addhon/climate.py`, tests
+
+## Problem
+
+Roberto's AC (`climate.clima_camera`, settings-based model) ran the self-clean
+cycle triggered from Home Assistant, then when it entered cool the compressor did
+not engage: the indoor unit ran as a fan. A physical power cycle cleared it.
+
+Ground truth from the appliance schema dump (`apk/dump/ac_roberto/`) and the real
+`commandHistory`:
+
+- Self-clean is a program in the Haier app: `startProgram` with
+  `program = iot_self_clean` / `iot_self_clean_56`.
+- The app drives this AC via `startProgram`, whose payload always carries
+  `selfCleaningStatus = "0"` when starting a normal operating mode (e.g. cool with
+  `machMode = "1"`).
+- In the `settings` command, `settings.programRules` pins `selfCleaningStatus`
+  (and `selfCleaning56Status`) to `"0"`, but only for `installationType` `1to2` /
+  `1toN`. A single-split unit is `1to1`, for which the rule does not fire
+  (`rules.py` `_apply_config_rules`, only `1to2`/`1toN` branches exist).
+
+addhon side:
+
+- `_is_program_based()` returns False for this AC because `settings` exposes
+  `onOffStatus`, so the integration drives mode via the `settings` command.
+- The `settings` command sends all of its parameters on every send
+  (`ac_command.py` header note). A mode change writes `{onOffStatus, machMode}`
+  merged into the full snapshot.
+- Nothing clears `selfCleaningStatus` on a mode write, and for `1to1` the config
+  rule is inert. So a cool command can ship `machMode = cool` alongside a cached
+  `selfCleaningStatus = "1"`. Contradictory payload, unit runs the fan with the
+  compressor off. This matches the reported symptom.
+
+This is a latent incoherence in the settings write path, independent of whether
+the specific incident was triggered by a HA command or an appliance-side
+auto-transition after the clean (the latter is being confirmed separately via the
+debug capture now enabled on Roberto's HA).
+
+## Invariant
+
+Home Assistant must never emit a `settings` command that commands active operation
+while `selfCleaningStatus` / `selfCleaning56Status` is `1`. Any command that starts
+or resumes a normal operating mode carries self-clean = `0`, mirroring the app's
+`startProgram` payload.
+
+## Design (surgical)
+
+### 1. New helper in `ac_command.py`
+
+```python
+AC_SELF_CLEAN_PARAMS = ("selfCleaningStatus", "selfCleaning56Status")
+
+def with_self_clean_off(appliance, params: dict) -> dict:
+    """Return `params` plus the self-clean flags forced to '0', for the flags the
+    device actually exposes on its settings command.
+
+    The Haier app's startProgram payload always carries selfCleaningStatus=0 when
+    starting a normal operating mode. On the settings write path (1to1 installs,
+    where the fixed-0 programRule is inert) HA must assert the same, otherwise a
+    mode command can ship machMode together with a cached selfCleaningStatus=1 and
+    the unit runs the fan with the compressor off."""
+    out = dict(params)
+    for p in AC_SELF_CLEAN_PARAMS:
+        if settings_param(appliance, p) is not None:
+            out.setdefault(p, "0")
+    return out
+```
+
+`setdefault` so a caller that intentionally set the flag (the self-clean switch)
+is never overridden. Capability-gated by `settings_param`, so a device without the
+flag gets no injected key.
+
+### 2. Call sites in `climate.py`
+
+Wrap the params dict at the two mode-establishing sends only:
+
+- Active-mode branch of `async_set_hvac_mode` (currently
+  `{"onOffStatus": "1", "machMode": str(mode_key)}`).
+- `async_turn_on` settings-based resume (currently `{"onOffStatus": "1"}`).
+
+Import `with_self_clean_off` from `.ac_command`.
+
+Deliberately excluded (self-clean must NOT be cleared by these): OFF
+(`onOffStatus=0`), `set_temperature`, `set_fan_mode`, `set_swing_mode`. A
+temperature or fan nudge during a self-clean cycle must not abort it; only starting
+or resuming a mode does.
+
+Program-based ACs are unaffected: they already go through `startProgram`, whose
+schema carries a coherent self-clean value.
+
+## Testing
+
+Follow the existing climate/switch test patterns.
+
+- `set_hvac_mode(COOL)` on a device exposing both flags: the sent settings params
+  include `selfCleaningStatus="0"` and `selfCleaning56Status="0"` alongside
+  `onOffStatus="1"` and `machMode`.
+- `set_hvac_mode` on a device WITHOUT the flags: no `KeyError`, no self-clean key
+  injected.
+- `async_turn_on` (settings-based): self-clean cleared.
+- Regression: the `self_clean` switch turn-on still sends
+  `selfCleaningStatus="1"` (helper not on that path, not clobbered).
+- `set_temperature`: self-clean NOT injected (an in-progress clean is not aborted).
+
+## Rollout
+
+Implement on `dev`, deploy sources to pve, build there, live-validate on Roberto's
+HA with debug ON: trigger self-clean, then set cool from HA, confirm the compressor
+engages. Push only on explicit request.
+
+## Caveat
+
+`unitConfiguration` is not in the diagnostics dump (it is a device record field),
+so "Roberto = 1to1" is inference from the single indoor unit, not proven. If the
+debug capture shows the cool transition came from the appliance itself with no HA
+command, this fix was not the trigger of that specific episode, but it still closes
+the latent incoherence (mode + selfClean=1 in one settings command).

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -846,6 +846,53 @@ class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("inner_sw", getattr(ctx.exception, "translation_key", None))
 
 
+class WithSelfCleanOffTest(unittest.TestCase):
+    def _ac_settings(self, params: dict):
+        return types.SimpleNamespace(commands={"settings": RecordingCommand(params)})
+
+    def test_injects_zero_for_exposed_flags(self) -> None:
+        appliance = self._ac_settings(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("0"),
+                "selfCleaningStatus": Param("1"),
+                "selfCleaning56Status": Param("1"),
+            }
+        )
+        out = ac_command.with_self_clean_off(
+            appliance, {"onOffStatus": "1", "machMode": "1"}
+        )
+        self.assertEqual(
+            {
+                "onOffStatus": "1",
+                "machMode": "1",
+                "selfCleaningStatus": "0",
+                "selfCleaning56Status": "0",
+            },
+            out,
+        )
+
+    def test_skips_flags_the_device_does_not_expose(self) -> None:
+        appliance = self._ac_settings(
+            {"onOffStatus": Param("0"), "machMode": Param("0")}
+        )
+        out = ac_command.with_self_clean_off(
+            appliance, {"onOffStatus": "1", "machMode": "1"}
+        )
+        self.assertEqual({"onOffStatus": "1", "machMode": "1"}, out)
+
+    def test_does_not_override_caller_supplied_value(self) -> None:
+        appliance = self._ac_settings({"selfCleaningStatus": Param("0")})
+        out = ac_command.with_self_clean_off(appliance, {"selfCleaningStatus": "1"})
+        self.assertEqual("1", out["selfCleaningStatus"])
+
+    def test_does_not_mutate_input(self) -> None:
+        appliance = self._ac_settings({"selfCleaningStatus": Param("1")})
+        params = {"onOffStatus": "1"}
+        ac_command.with_self_clean_off(appliance, params)
+        self.assertEqual({"onOffStatus": "1"}, params)
+
+
 class AcCommandUnitTest(unittest.IsolatedAsyncioTestCase):
     """Pure helpers of ac_command + the requested-value-wins integration."""
 

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -553,6 +553,51 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(0, settings.send_calls)
 
+    async def test_set_hvac_mode_active_clears_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("0"),
+                "selfCleaningStatus": Param("1"),
+                "selfCleaning56Status": Param("1"),
+            }
+        )
+        await entity.async_set_hvac_mode(HVACMode.COOL)
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual("1", settings.sent["machMode"])
+        self.assertEqual("0", settings.sent["selfCleaningStatus"])
+        self.assertEqual("0", settings.sent["selfCleaning56Status"])
+
+    async def test_turn_on_clears_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {
+                "onOffStatus": Param("0"),
+                "machMode": Param("4"),
+                "selfCleaningStatus": Param("1"),
+            }
+        )
+        await entity.async_turn_on()
+        self.assertEqual("1", settings.sent["onOffStatus"])
+        self.assertEqual("0", settings.sent["selfCleaningStatus"])
+
+    async def test_set_temperature_does_not_clear_self_clean(self) -> None:
+        entity, settings, _ = _climate(
+            {"tempSel": Param("16"), "selfCleaningStatus": Param("1")}
+        )
+        await entity.async_set_temperature(temperature=22)
+        self.assertEqual("1", settings.sent["selfCleaningStatus"])
+
+    async def test_self_clean_switch_turn_on_still_sets_one(self) -> None:
+        settings = RecordingCommand({"selfCleaningStatus": Param("0")})
+        coordinator = FakeCoordinator(_ac({"settings": settings}))
+        desc = switch.HonAcSwitchDescription(
+            key="self_clean", param="selfCleaningStatus"
+        )
+        sw = switch.HonAcSwitch(coordinator, "ac-1", desc, FakeClient())
+        sw.hass = FakeHass()
+        await sw.async_turn_on()
+        self.assertEqual("1", settings.sent["selfCleaningStatus"])
+
 
 class AcClimateProgramWritePathTest(unittest.IsolatedAsyncioTestCase):
     """Program-based AC (AD71S2SM3FA(H)): power/mode via startProgram/stopProgram.

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -121,6 +121,87 @@ class ClassifyTest(unittest.TestCase):
         self.assertIs(ec.classify(RuntimeError("getaddrinfo failed")), ec.DNS_FAILURE)
         self.assertIs(ec.classify(RuntimeError("Connection refused")), ec.CONNECTION_REFUSED)
 
+    def test_real_decode_and_disconnect_types_are_not_unknown(self) -> None:
+        self.assertIs(
+            ec.classify(json.JSONDecodeError("Expecting value", "", 0)),
+            ec.DECODE_ERROR,
+        )
+        self.assertIs(
+            ec.classify(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")),
+            ec.DECODE_ERROR,
+        )
+        self.assertIs(
+            ec.classify(ConnectionError("connection aborted")),
+            ec.CONNECTION_REFUSED,
+        )
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        class ClientPayloadError(Exception):
+            pass
+
+        self.assertIs(
+            ec.classify(ServerDisconnectedError("Server disconnected")),
+            ec.CONNECTION_REFUSED,
+        )
+        self.assertIs(
+            ec.classify(ClientPayloadError("Response payload is not completed")),
+            ec.DECODE_ERROR,
+        )
+
+    def test_auth_rejections_beat_broad_connection_types(self) -> None:
+        class AuthConnectionError(ConnectionError):
+            pass
+
+        class ClientConnectionError(Exception):
+            pass
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        cases = (
+            (AuthConnectionError("api_auth: status 401"), ec.AUTH_API_AUTH),
+            (ClientConnectionError("HTTP 401 unauthorized"), ec.INVALID_CREDENTIALS),
+            (ServerDisconnectedError("token rejected"), ec.INVALID_CREDENTIALS),
+        )
+        for err, expected in cases:
+            with self.subTest(error=type(err).__name__):
+                self.assertIs(ec.classify(err), expected)
+                self.assertTrue(hc._requires_reauth(err))
+
+    def test_connection_class_names_without_auth_are_refused(self) -> None:
+        # aiohttp-style connection classes with a plain outage message (no auth
+        # marker, no refused/reset/DNS/TLS keyword) must reach the class-name
+        # family fallback and classify as CONNECTION_REFUSED. Guards the family
+        # list in classify() so dropping a name there is caught by a test.
+        class ClientConnectionError(Exception):
+            pass
+
+        class ClientConnectorError(Exception):
+            pass
+
+        class ClientOSError(Exception):
+            pass
+
+        class ServerConnectionError(Exception):
+            pass
+
+        cases = (
+            ClientConnectionError("connection lost"),
+            ClientConnectorError("host unreachable"),
+            ClientOSError("socket failure"),
+            ServerConnectionError("peer gone"),
+        )
+        for err in cases:
+            with self.subTest(error=type(err).__name__):
+                self.assertIs(ec.classify(err), ec.CONNECTION_REFUSED)
+
+    def test_server_status_beats_builtin_connection_type(self) -> None:
+        err = ConnectionError("503 server error")
+        self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+        self.assertFalse(hc._requires_reauth(err))
+
     def test_aiohttp_connect_failure_is_not_tls(self) -> None:
         # aiohttp's ClientConnectorError __str__ ALWAYS carries "ssl:default" for any
         # HTTPS connect failure; that is a plain outage, NOT a TLS problem (refuter F1).

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -197,6 +197,40 @@ class ClassifyTest(unittest.TestCase):
             with self.subTest(error=type(err).__name__):
                 self.assertIs(ec.classify(err), ec.CONNECTION_REFUSED)
 
+    def test_classify_and_requires_reauth_agree_on_auth_phrasings(self) -> None:
+        # Coherence guard against drift: classify()'s auth-rejection gate and
+        # hon_client._requires_reauth's keyword predicate are two independent
+        # lists. For an EXPLICIT rejection phrasing both must route to reauth; for
+        # a plain outage neither must. Bare endpoint names ("api_auth" alone) are
+        # out of scope here: the two predicates intentionally differ on those. If
+        # a new rejection phrase is added to one side only, this test goes red.
+        reauth_phrasings = (
+            "unauthorized",
+            "HTTP 401",
+            "HTTP 403",
+            "status 401",
+            "token rejected",
+            "invalid token",
+            "expired token",
+            "invalid credential",
+            "api_auth: status 401",
+        )
+        non_reauth_phrasings = (
+            "503 service unavailable",
+            "429 too many requests",
+            "connection reset by peer",
+        )
+        for phrase in reauth_phrasings:
+            err = RuntimeError(phrase)
+            with self.subTest(reauth=phrase):
+                self.assertTrue(ec.classify(err).requires_reauth)
+                self.assertTrue(hc._requires_reauth(err))
+        for phrase in non_reauth_phrasings:
+            err = RuntimeError(phrase)
+            with self.subTest(non_reauth=phrase):
+                self.assertFalse(ec.classify(err).requires_reauth)
+                self.assertFalse(hc._requires_reauth(err))
+
     def test_server_status_beats_builtin_connection_type(self) -> None:
         err = ConnectionError("503 server error")
         self.assertIs(ec.classify(err), ec.SERVER_ERROR)

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -534,21 +534,19 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.mqtt_calls, [])
         self.assertIsNone(nh._mqtt_client)
 
-    def test_mqtt_start_failure_keeps_http_polling_available(self) -> None:
+    def test_unexpected_mqtt_start_failure_propagates(self) -> None:
         h = _Harness(self, [])
         h.install()
 
         async def mqtt_boom(_hon):
-            raise ConnectionError("AWS token service status 503")
+            raise TypeError("builder contract regression")
 
         self._patch(NativeHon, "_make_mqtt", mqtt_boom)
         nh = self._nh_with_api(h, enable_mqtt=True)
-        with self.assertLogs(session_mod._LOGGER, level="WARNING") as logs:
+        with self.assertRaisesRegex(TypeError, "builder contract regression"):
             _run(nh.setup())
 
         self.assertIsNone(nh._mqtt_client)
-        self.assertEqual(nh._setup_phase, "")
-        self.assertIn("continuing with HTTP polling", "\n".join(logs.output))
 
     def test_mqtt_start_cancellation_still_propagates(self) -> None:
         h = _Harness(self, [])

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -534,6 +534,35 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.mqtt_calls, [])
         self.assertIsNone(nh._mqtt_client)
 
+    def test_mqtt_start_failure_keeps_http_polling_available(self) -> None:
+        h = _Harness(self, [])
+        h.install()
+
+        async def mqtt_boom(_hon):
+            raise ConnectionError("AWS token service status 503")
+
+        self._patch(NativeHon, "_make_mqtt", mqtt_boom)
+        nh = self._nh_with_api(h, enable_mqtt=True)
+        with self.assertLogs(session_mod._LOGGER, level="WARNING") as logs:
+            _run(nh.setup())
+
+        self.assertIsNone(nh._mqtt_client)
+        self.assertEqual(nh._setup_phase, "")
+        self.assertIn("continuing with HTTP polling", "\n".join(logs.output))
+
+    def test_mqtt_start_cancellation_still_propagates(self) -> None:
+        h = _Harness(self, [])
+        h.install()
+
+        async def mqtt_cancelled(_hon):
+            raise asyncio.CancelledError()
+
+        self._patch(NativeHon, "_make_mqtt", mqtt_cancelled)
+        nh = self._nh_with_api(h, enable_mqtt=True)
+        with self.assertRaises(asyncio.CancelledError):
+            _run(nh.setup())
+        self.assertIsNone(nh._mqtt_client)
+
     def test_minimal_skips_per_appliance_loads_and_mqtt(self) -> None:
         # #30: config-flow validation builds + counts the appliances but does NOT run
         # the per-appliance load_commands/attributes/statistics, and never starts MQTT.

--- a/tests/test_session_protocol_live.py
+++ b/tests/test_session_protocol_live.py
@@ -17,7 +17,6 @@ trick pre-registers empty packages to skip the heavy integration __init__).
 """
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import sys
 import textwrap
@@ -27,27 +26,31 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[1]
 
 
-def _deps_available() -> bool:
-    # Importing the real Hon requires aiohttp AND awscrt (hon.py imports mqtt.py
-    # which does `from awscrt import mqtt5`). Both are needed or the subprocess
-    # would fail the import instead of skipping. Robust against modules STUBBED by
-    # other tests (another test module may register a fake `aiohttp` in
-    # sys.modules: find_spec on a module without __spec__ raises ValueError, and a
-    # real module always has spec.origin) -> when in doubt: not available, skip.
-    for name in ("aiohttp", "awscrt", "yarl"):
-        try:
-            spec = importlib.util.find_spec(name)
-        except (ValueError, ImportError):
-            return False
-        if spec is None or spec.origin is None:
-            return False
-    return True
+def _probe_dependencies() -> tuple[bool, str]:
+    # Probe in a clean interpreter. Other test modules deliberately install fake
+    # aiohttp/awscrt packages in this process during collection; inspecting
+    # sys.modules/find_spec here consequently skipped this live test even when all
+    # real dependencies were installed. The protocol assertion already runs in a
+    # subprocess, so its dependency gate must use the same isolation boundary.
+    result = subprocess.run(
+        [sys.executable, "-c", "import aiohttp, awscrt, yarl"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    detail = (result.stderr or result.stdout).strip()
+    return result.returncode == 0, detail
 
 
 class LiveSessionProtocolTest(unittest.TestCase):
     def test_real_hon_satisfies_honsession(self) -> None:
-        if not _deps_available():
-            self.skipTest("aiohttp/awscrt/yarl not available: skipping the real Hon check")
+        available, detail = _probe_dependencies()
+        if not available:
+            suffix = f" ({detail})" if detail else ""
+            self.skipTest(
+                "aiohttp/awscrt/yarl not available: skipping the real Hon check"
+                f"{suffix}"
+            )
         script = textwrap.dedent(
             f"""
             import sys, types, importlib.util

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -214,7 +214,16 @@ class NativeAuthFlowTest(unittest.TestCase):
         responses = _happy_responses()
         responses[-1] = FakeResp(json={"cognitoUser": {}})  # no Token
         auth = self._auth(responses)
-        with self.assertRaises(NativeAuthError):
+        with self.assertRaisesRegex(
+            NativeAuthError, r"api_auth: no cognito token \(status 200\)"
+        ):
+            asyncio.run(auth.authenticate())
+
+    def test_api_auth_server_error_preserves_status_for_retry_routing(self) -> None:
+        responses = _happy_responses()
+        responses[-1] = FakeResp(status=503, json={})
+        auth = self._auth(responses)
+        with self.assertRaisesRegex(NativeAuthError, r"api_auth: status 503"):
             asyncio.run(auth.authenticate())
 
     def test_progressive_login_without_href_raises(self) -> None:

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -152,6 +152,24 @@ class StopTest(unittest.TestCase):
         _run(m.stop())  # no client/watchdog -> no-op, does not raise
         _run(m.stop())
 
+    def test_stop_invalidates_late_success_callback(self) -> None:
+        class FakeClient:
+            def stop(self) -> None:
+                return None
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 7
+        m._connection = True
+        m._subscribed_topics_set = {_RECOVERY_TOPIC}
+        m._client = FakeClient()
+        _run(m.stop())
+
+        self.assertEqual(m._generation, 8)
+        self.assertFalse(m._connection)
+        self.assertEqual(m._subscribed_topics_set, set())
+        m._on_link_up(None, generation=7)  # queued callback from the stopped client
+        self.assertFalse(m._connection)
+
 
 class CreatePathTest(unittest.TestCase):
     """Drives the REAL path create()->_start->_subscribe->watchdog with richer awscrt
@@ -234,6 +252,228 @@ class CreatePathTest(unittest.TestCase):
         self.assertTrue(had_watchdog)
         self.assertTrue(fake_client.stopped)
         self.assertIsNone(m._watchdog_task)
+
+    def test_retryable_initial_failure_retains_client_and_recovers(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        async def body():
+            m = NativeMqttClient(FakeHon([FakeAppliance(_RECOVERY_TOPIC)]), "MID")
+            starts = 0
+            subscribed = asyncio.Event()
+
+            async def flaky_start():
+                nonlocal starts
+                starts += 1
+                if starts == 1:
+                    raise RuntimeError("hOn server error (status 503)")
+                m._connection = True
+
+            async def subscribe_missing():
+                m._subscribed_topics_set = {_RECOVERY_TOPIC}
+                subscribed.set()
+
+            m._start = flaky_start  # type: ignore[assignment]
+            m._subscribe_missing = subscribe_missing  # type: ignore[assignment]
+            old_ticks = mod._RECONNECT_AFTER_FAILED_TICKS
+            old_interval = mod._WATCHDOG_INTERVAL
+            mod._RECONNECT_AFTER_FAILED_TICKS = 1
+            mod._WATCHDOG_INTERVAL = 0
+            try:
+                with self.assertLogs(mod._LOGGER, level="WARNING") as logs:
+                    result = await m.create()
+                    watchdog = m._watchdog_task
+                    await asyncio.wait_for(subscribed.wait(), 1)
+                self.assertIn("ADDHON-450", "\n".join(logs.output))
+                recovered_topics = set(m._subscribed_topics_set)
+                await m.stop()
+                return result, m, watchdog, starts, recovered_topics
+            finally:
+                mod._RECONNECT_AFTER_FAILED_TICKS = old_ticks
+                mod._WATCHDOG_INTERVAL = old_interval
+
+        result, m, watchdog, starts, recovered_topics = _run(body())
+        self.assertIs(result, m)
+        self.assertEqual(starts, 2)
+        self.assertIsNotNone(watchdog)
+        self.assertTrue(watchdog.done())
+        self.assertIsNone(m._watchdog_task)
+        self.assertEqual(recovered_topics, {_RECOVERY_TOPIC})
+        self.assertEqual(m._subscribed_topics_set, set())
+
+    def test_stop_cancels_deferred_startup_retry(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        async def body():
+            m = NativeMqttClient(FakeHon([]), "MID")
+            starts = 0
+
+            async def unavailable():
+                nonlocal starts
+                starts += 1
+                raise RuntimeError("hOn server error (status 503)")
+
+            m._start = unavailable  # type: ignore[assignment]
+            with self.assertLogs(mod._LOGGER, level="WARNING"):
+                result = await m.create()
+            watchdog = m._watchdog_task
+            await asyncio.sleep(0)  # let the watchdog enter its first backoff sleep
+            await m.stop()
+            await asyncio.sleep(0)
+            return result, m, watchdog, starts
+
+        result, m, watchdog, starts = _run(body())
+        self.assertIs(result, m)
+        self.assertEqual(starts, 1)
+        self.assertIsNotNone(watchdog)
+        self.assertTrue(watchdog.done())
+        self.assertIsNone(m._watchdog_task)
+
+    def test_unexpected_initial_failure_is_not_hidden_or_retried(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+
+        async def broken_builder_contract():
+            raise TypeError("builder returned 503 invalid arguments")
+
+        m._start = broken_builder_contract  # type: ignore[assignment]
+        with self.assertRaisesRegex(TypeError, "503 invalid arguments"):
+            _run(m.create())
+        self.assertIsNone(m._watchdog_task)
+        self.assertIsNone(m._client)
+
+    def test_aws_token_failures_are_typed_without_hiding_unknown_errors(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.error_codes import AWS_TOKEN_FAILED, SERVER_ERROR
+
+        class Api:
+            def __init__(self, result=None, error=None) -> None:
+                self.result = result
+                self.error = error
+
+            async def load_aws_token(self):
+                if self.error is not None:
+                    raise self.error
+                return self.result
+
+        async def load(api):
+            hon = FakeHon([])
+            hon.api = api
+            return await NativeMqttClient(hon, "MID")._load_aws_signature()
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as empty:
+            _run(load(Api(result="")))
+        self.assertIs(empty.exception.error_code, AWS_TOKEN_FAILED)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as outage:
+            _run(load(Api(error=RuntimeError("hOn server error (status 503)"))))
+        self.assertIs(outage.exception.error_code, SERVER_ERROR)
+        self.assertIsInstance(outage.exception.__cause__, RuntimeError)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as malformed:
+            _run(load(Api(error=json.JSONDecodeError("Expecting value", "", 0))))
+        from custom_components.addhon.error_codes import DECODE_ERROR
+
+        self.assertIs(malformed.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as bad_charset:
+            _run(
+                load(
+                    Api(
+                        error=UnicodeDecodeError(
+                            "utf-8", b"\xff", 0, 1, "invalid start byte"
+                        )
+                    )
+                )
+            )
+        self.assertIs(bad_charset.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as disconnected:
+            _run(load(Api(error=ConnectionError("connection aborted"))))
+        from custom_components.addhon.error_codes import CONNECTION_REFUSED
+
+        self.assertIs(disconnected.exception.error_code, CONNECTION_REFUSED)
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        class ClientPayloadError(Exception):
+            pass
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as server_disconnect:
+            _run(load(Api(error=ServerDisconnectedError("Server disconnected"))))
+        self.assertIs(server_disconnect.exception.error_code, CONNECTION_REFUSED)
+        with self.assertRaises(mod.MqttStartupUnavailable) as bad_payload:
+            _run(load(Api(error=ClientPayloadError("payload incomplete"))))
+        self.assertIs(bad_payload.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaisesRegex(TypeError, "503 schema regression"):
+            _run(load(Api(error=TypeError("503 schema regression"))))
+
+    def test_cancellation_during_aws_token_load_cleans_up_and_propagates(self) -> None:
+        class Api:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+
+            async def load_aws_token(self):
+                self.started.set()
+                await asyncio.Event().wait()
+
+        async def body():
+            api = Api()
+            hon = FakeHon([])
+            hon.api = api
+            m = NativeMqttClient(hon, "MID")
+            task = asyncio.create_task(m.create())
+            await api.started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            return m
+
+        m = _run(body())
+        self.assertIsNone(m._client)
+        self.assertIsNone(m._watchdog_task)
+
+    def test_awscrt_operational_error_retries_but_invalid_argument_fails_fast(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.error_codes import MQTT_CONNECT_TIMEOUT
+
+        AwsCrtError = type("AwsCrtError", (Exception,), {})
+        outage = AwsCrtError("socket closed")
+        outage.name = "AWS_IO_SOCKET_CLOSED"
+        invalid = AwsCrtError("invalid")
+        invalid.name = "AWS_ERROR_INVALID_ARGUMENT"
+
+        self.assertIs(mod._retryable_startup_code(outage), MQTT_CONNECT_TIMEOUT)
+        self.assertIsNone(mod._retryable_startup_code(invalid))
+
+    def test_auth_marked_transport_errors_propagate_instead_of_retrying(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        class ClientConnectionError(Exception):
+            pass
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        errors = (
+            ConnectionError("api_auth: status 401"),
+            ClientConnectionError("HTTP 401 unauthorized"),
+            ServerDisconnectedError("token rejected"),
+        )
+        for err in errors:
+            with self.subTest(error=type(err).__name__):
+                self.assertIsNone(mod._retryable_startup_code(err))
+
+                mqtt_client = NativeMqttClient(FakeHon([]), "MID")
+
+                async def rejected(error=err):
+                    raise error
+
+                mqtt_client._start = rejected  # type: ignore[assignment]
+                with self.assertRaises(type(err)):
+                    _run(mqtt_client.create())
+                self.assertIsNone(mqtt_client._watchdog_task)
+                self.assertIsNone(mqtt_client._client)
 
     def test_create_stops_client_when_subscribe_fails(self) -> None:
         # #21: _start() already started the awscrt client; if a later step raises,
@@ -721,7 +961,6 @@ class StartReconnectTest(unittest.TestCase):
     previous awscrt client before building a new one, instead of leaking it."""
 
     def test_start_stops_previous_client_before_rebuild(self) -> None:
-        import awscrt
         import awsiot
 
         built: list = []
@@ -955,6 +1194,52 @@ class StartGenerationWiringTest(unittest.TestCase):
         gen2["on_lifecycle_disconnection"](None)
         self.assertFalse(m._connection)
 
+    def test_rebuild_invalidates_success_emitted_during_old_client_stop(self) -> None:
+        import awsiot
+
+        builds: list = []
+
+        class FakeClient:
+            def __init__(self, callbacks) -> None:
+                self.callbacks = callbacks
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                # Adversarial interleaving: native shutdown emits a queued success
+                # synchronously. It must already be stale when stop() is entered.
+                self.callbacks["on_lifecycle_connection_success"](None)
+
+        def fake_builder(**kwargs):
+            builds.append(kwargs)
+            return FakeClient(kwargs)
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = fake_builder
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        m = NativeMqttClient(hon, "MID")
+
+        async def body():
+            await m._start()
+            builds[0]["on_lifecycle_connection_success"](None)
+            self.assertTrue(m._connection)
+            await m._start()
+
+        _run(body())
+        self.assertEqual(len(builds), 2)
+        self.assertFalse(m._connection)
+
 
 class WatchdogResilienceTest(unittest.TestCase):
     """#3: the watchdog must survive a transient rebuild error (instead of dying and
@@ -1002,7 +1287,7 @@ class WatchdogResilienceTest(unittest.TestCase):
 
         async def boom():
             starts.append(True)
-            raise RuntimeError("load_aws_token 5xx")
+            raise RuntimeError("hOn server error (status 503)")
 
         self._drive([False] * 7, boom)  # two rebuild windows
         # Pre-fix the first raise would end the task -> starts == 1. Surviving -> >= 2.
@@ -1035,7 +1320,7 @@ class WatchdogResilienceTest(unittest.TestCase):
         from custom_components.addhon.client.transport.mqtt import _WATCHDOG_INTERVAL
 
         async def boom():
-            raise RuntimeError("x")
+            raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 9 + [True], boom)
         base = _WATCHDOG_INTERVAL
@@ -1053,7 +1338,7 @@ class WatchdogResilienceTest(unittest.TestCase):
         async def flaky_start():
             calls["n"] += 1
             if calls["n"] <= 2:
-                raise RuntimeError("transient")
+                raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 14, flaky_start)  # connection never comes up
         base = _WATCHDOG_INTERVAL
@@ -1067,10 +1352,30 @@ class WatchdogResilienceTest(unittest.TestCase):
         )
 
         async def boom():
-            raise RuntimeError("x")
+            raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 60, boom)
         self.assertLessEqual(max(intervals), _WATCHDOG_INTERVAL + _RECONNECT_BACKOFF_CAP)
+
+    def test_watchdog_keeps_retrying_unknown_runtime_error(self) -> None:
+        starts = []
+
+        async def unknown_runtime_failure():
+            starts.append(True)
+            raise RuntimeError("opaque native runtime failure")
+
+        self._drive([False] * 7, unknown_runtime_failure)
+        self.assertGreaterEqual(len(starts), 2)
+
+    def test_watchdog_stops_on_structural_error(self) -> None:
+        starts = []
+
+        async def structural_failure():
+            starts.append(True)
+            raise TypeError("builder returned 503 invalid arguments")
+
+        self._drive([False] * 7, structural_failure)
+        self.assertEqual(len(starts), 1)
 
 
 class SubscribeNonBlockingTest(unittest.TestCase):
@@ -1545,7 +1850,6 @@ class SubscribedFlagLifecycleTest(unittest.TestCase):
         self.assertEqual(m._subscribed_topics_set, {"t"})
 
     def test_start_resets_subscribed(self) -> None:
-        import awscrt
         import awsiot
 
         class FakeClient:


### PR DESCRIPTION
Automated release PR for `v5.8.3`.

<!-- release-tag: v5.8.3 -->

## Summary by Sourcery

Handle MQTT startup failures and HTTP authentication errors more robustly while updating tests and CI dependencies for the v5.8.3 release.

Bug Fixes:
- Ensure HTTP authentication errors preserve response status codes so retry routing can distinguish server failures from credential issues.
- Allow MQTT startup failures to fall back to HTTP polling instead of making the integration unavailable.

Enhancements:
- Improve live session dependency probing to avoid interference from stubbed modules in other tests.
- Log detailed information when MQTT startup fails while keeping the config entry usable.

Build:
- Install aiohttp and all manifest-specified runtime requirements in CI before running tests.

Tests:
- Add tests covering MQTT startup failure and cancellation behavior in native sessions.
- Extend authentication tests to verify preserved HTTP status codes and updated error messages.

Chores:
- Bump integration version metadata to 5.8.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MQTT startup failures are now classified and handled so HTTP polling can continue, with temporary unavailability retrying appropriately.
  - Authentication/login errors now preserve HTTP status for more accurate retry/routing decisions.
  - AC self-clean flags are cleared for active-mode and settings-based turn-on flows, without affecting temperature or self-clean toggle behavior.
- **Tests**
  - Expanded coverage for MQTT failure/cancellation handling, auth status propagation, dependency-gated live protocol checks, and AC self-clean parameter injection.
- **Chores**
  - CI now installs additional test/runtime dependencies and integration requirements; manifest version bumped to 5.8.3.
- **Documentation**
  - Added AC self-clean mode-compressor design and implementation plan docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the addhOn integration for v5.8.3. The main changes are:

- MQTT startup failures can fall back to HTTP polling while retrying in the background.
- HTTP auth errors keep response status codes for retry and reauth routing.
- AC self-clean flags are cleared when starting or resuming normal modes.
- CI installs runtime requirements before running tests.
- Tests cover the updated MQTT, auth, error-code, and AC write paths.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/session.py | Setup now leaves retryable MQTT recovery to the retained MQTT client. |
| custom_components/addhon/client/transport/mqtt.py | MQTT startup now classifies retryable failures and starts watchdog recovery. |
| custom_components/addhon/client/transport/auth.py | Auth failures now preserve HTTP status details in raised errors. |
| custom_components/addhon/error_codes.py | Error classification now handles decode, connection, and explicit auth rejection cases. |
| custom_components/addhon/ac_command.py | Adds a helper for capability-gated AC self-clean flag clearing. |
| custom_components/addhon/climate.py | Mode-start and turn-on commands now clear exposed AC self-clean flags. |

<sub>Reviews (4): Last reviewed commit: ["test(error-codes): pin classify/\_require..."](https://github.com/tis24dev/addhon/commit/592d37687a223b81d4b302f1e8908a11a84644ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43797158)</sub>

<!-- /greptile_comment -->