### PR TITLE
Fix MQTT startup retry after transient AWS failures

### DIFF
--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -244,19 +244,11 @@ class NativeHon:
                     await self._create_appliance(appliance.copy(), zone=zone + 1)
             await self._create_appliance(appliance)
         if self._enable_mqtt and not self._mqtt_client:
-            try:
-                self._mqtt_client = await self._make_mqtt()
-            except Exception as error:  # noqa: BLE001 - realtime is optional
-                # MQTT is an acceleration channel; the HTTP poller remains the source
-                # of truth. An AWS token/transport outage must therefore not make the
-                # whole config entry unavailable. Cancellation still propagates because
-                # asyncio.CancelledError inherits BaseException on supported Python.
-                self._mqtt_client = None
-                _LOGGER.warning(
-                    "MQTT startup failed; continuing with HTTP polling: %s",
-                    error,
-                    exc_info=True,
-                )
+            # NativeMqttClient owns MQTT recovery. On a retryable AWS token/transport
+            # outage create() returns a retained, temporarily-disconnected client whose
+            # watchdog retries in the background; unexpected programming/configuration
+            # errors still propagate instead of being silently converted to polling-only.
+            self._mqtt_client = await self._make_mqtt()
         # Setup done: clear the phase so a later (non-setup) loop timeout is not
         # mis-attributed to a setup step.
         self._setup_phase = ""

--- a/custom_components/addhon/client/transport/mqtt.py
+++ b/custom_components/addhon/client/transport/mqtt.py
@@ -38,7 +38,21 @@ from awsiot import mqtt5_client_builder  # type: ignore[import-untyped]
 from .device import MOBILE_ID
 from .values import AWS_AUTHORIZER, AWS_ENDPOINT
 from ...debug_utils import redact_id, redact_identity, redact_topic
-from ...error_codes import HonCodedError, MQTT_SUBSCRIBE_TIMEOUT
+from ...error_codes import (
+    AWS_TOKEN_FAILED,
+    CONNECTION_REFUSED,
+    DECODE_ERROR,
+    DNS_FAILURE,
+    MQTT_CONNECT_TIMEOUT,
+    MQTT_SUBSCRIBE_TIMEOUT,
+    NETWORK_TIMEOUT,
+    RATE_LIMITED,
+    SERVER_ERROR,
+    TLS_FAILURE,
+    UNKNOWN,
+    HonCodedError,
+    classify,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +77,71 @@ _RECONNECT_BACKOFF_CAP = 60
 # to a full rebuild PROMPTLY -- skipping the _RECONNECT_AFTER_FAILED_TICKS grace wait,
 # since this connection is already known dead. Reset to 0 on ANY successful subscribe.
 _MAX_RESUBSCRIBE_FAILURES = 3
+
+# Only operational failures are allowed to make the initial MQTT connection
+# polling-only while the watchdog retries. UNKNOWN is deliberately absent: an
+# ImportError, TypeError, AttributeError or invalid builder contract is a code/config
+# regression and must fail setup visibly instead of being hidden forever.
+_RETRYABLE_STARTUP_CODES = frozenset(
+    {
+        AWS_TOKEN_FAILED,
+        MQTT_CONNECT_TIMEOUT,
+        NETWORK_TIMEOUT,
+        DNS_FAILURE,
+        TLS_FAILURE,
+        CONNECTION_REFUSED,
+        RATE_LIMITED,
+        SERVER_ERROR,
+        DECODE_ERROR,
+    }
+)
+
+
+class MqttStartupUnavailable(HonCodedError):
+    """Retryable failure before the MQTT client's watchdog could be started."""
+
+
+_STRUCTURAL_ERRORS = (
+    AssertionError,
+    AttributeError,
+    ImportError,
+    IndexError,
+    KeyError,
+    NameError,
+    TypeError,
+)
+
+
+def _is_structural_error(error: BaseException) -> bool:
+    """True for deterministic code/schema errors which retry cannot repair."""
+    if isinstance(error, _STRUCTURAL_ERRORS):
+        return True
+    # JSONDecodeError and UnicodeDecodeError are ValueErrors but represent unreadable
+    # cloud responses, not deterministic builder/schema faults.
+    return isinstance(error, ValueError) and not isinstance(
+        error, (json.JSONDecodeError, UnicodeDecodeError)
+    )
+
+
+def _retryable_startup_code(error: BaseException):
+    """Return a stable retry code, or None for a fail-fast setup error."""
+    if _is_structural_error(error):
+        return None
+    code = classify(error, phase="aws_token")
+    if code in _RETRYABLE_STARTUP_CODES:
+        return code
+    # awscrt surfaces native connection/runtime failures through one generic class.
+    # Invalid argument/state errors are deterministic builder-contract faults; other
+    # CRT failures are operational and should use the existing MQTT connect code.
+    if type(error).__name__ == "AwsCrtError":
+        crt_name = str(getattr(error, "name", "")).upper()
+        if any(
+            marker in crt_name
+            for marker in ("INVALID_ARGUMENT", "INVALID_STATE", "ALREADY_STARTED")
+        ):
+            return None
+        return MQTT_CONNECT_TIMEOUT
+    return None
 
 
 def _subscribed_topics(appliance) -> list:
@@ -135,7 +214,26 @@ class NativeMqttClient:
     async def create(self) -> "NativeMqttClient":
         try:
             self._set_setup_phase("mqtt_connect")
-            await self._start()
+            try:
+                await self._start()
+            except Exception as err:
+                code = _retryable_startup_code(err)
+                if code is None:
+                    raise
+                # MQTT is an acceleration channel; HTTP polling remains the source of
+                # truth. Retain THIS NativeMqttClient and start its existing watchdog so
+                # a temporary AWS-token outage heals without a config-entry reload. Stop
+                # a partially-created native client first: it owns sockets/worker threads
+                # and cannot be left beside the later watchdog-created generation.
+                await self.stop()
+                await self._start_watchdog()
+                _LOGGER.warning(
+                    "[%s] MQTT startup deferred; continuing with HTTP polling and "
+                    "retrying in the background",
+                    code.label,
+                    exc_info=True,
+                )
+                return self
             gen = self._generation
             self._set_setup_phase("mqtt_subscribe")
             await self._subscribe_missing()
@@ -161,6 +259,23 @@ class NativeMqttClient:
             raise
         return self
 
+    def _stop_client(self) -> None:
+        """Stop and clear only the native client, leaving watchdog ownership alone."""
+        client, self._client = self._client, None
+        self._connection = False
+        self._subscribed_topics_set = set()
+        if client is None:
+            return
+        # Invalidate callbacks BEFORE stop(): awscrt shutdown is asynchronous and can
+        # emit a queued success/failure after stop. Without the bump that late event is
+        # still "current" and can resurrect a false connected state on a client we no
+        # longer own, causing the watchdog to skip recovery (especially with zero topics).
+        self._generation += 1
+        try:
+            client.stop()
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("addhOn: MQTT client stop failed: %s", err)
+
     async def stop(self) -> None:
         """Stop watchdog (cancel+await) and then the awscrt client. Idempotent."""
         if self._watchdog_task is not None:
@@ -172,12 +287,7 @@ class NativeMqttClient:
             except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.debug("addhOn: awaiting MQTT watchdog cancel failed: %s", err)
             self._watchdog_task = None
-        if self._client is not None:
-            try:
-                self._client.stop()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("addhOn: MQTT client stop failed: %s", err)
-            self._client = None
+        self._stop_client()
 
     # -- lifecycle callbacks ---------------------------------------------------
     # The callbacks that write self._connection are registered (in _start) bound to the
@@ -388,12 +498,10 @@ class NativeMqttClient:
         # without stopping the previous one leaks its native AWS IoT connection
         # (socket + worker threads are NOT released by GC, only by .stop()), so a
         # sustained disconnection would spawn a new orphan client every cycle.
-        if self._client is not None:
-            try:
-                self._client.stop()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("addhOn: stopping previous MQTT client failed: %s", err)
-            self._client = None
+        # _stop_client invalidates the old generation BEFORE stop(), so even a success
+        # callback synchronously/late emitted by native shutdown cannot resurrect a
+        # false connected state during the rebuild.
+        self._stop_client()
         # A fresh client carries over no subscriptions: clear the set here (the caller
         # -- create() or the watchdog rebuild path -- re-populates it only after the
         # subscribe succeeds). Rebind (atomic) rather than .clear().
@@ -406,19 +514,19 @@ class NativeMqttClient:
         # healthy), but a rebuild whose subscribe then fails would leave a
         # stale connected-but-unsubscribed state on a client that is not actually up yet,
         # sending the next tick down the in-place re-subscribe path against a dead client
-        # instead of rebuilding. The only late callback the stopped client can still emit
-        # is a disconnection (-> False), never a spurious success, and the generation bump
-        # below rejects every other stale event; so this reset cannot be flipped True.
+        # instead of rebuilding. _stop_client already invalidated every old callback;
+        # this reset establishes the initial state for the new generation.
         self._connection = False
         # Tag this client's state-mutating callbacks with a fresh generation so a late
         # event from the client just stopped cannot flip self._connection (see
         # _is_stale_generation).
         self._generation += 1
         generation = self._generation
+        signature = await self._load_aws_signature()
         self._client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=AWS_ENDPOINT,
             auth_authorizer_name=AWS_AUTHORIZER,
-            auth_authorizer_signature=await self._api.load_aws_token(),
+            auth_authorizer_signature=signature,
             auth_token_key_name="token",
             auth_token_value=self._api.auth.id_token,
             # AWS-IoT requires a UNIQUE MQTT clientId (awsiot docs). Keep the EXACT
@@ -440,6 +548,31 @@ class NativeMqttClient:
             on_publish_received=self._on_message,
         )
         self.client.start()
+
+    async def _load_aws_signature(self) -> str:
+        """Load the custom-authorizer signature and type retryable startup errors.
+
+        This is the only synchronous network step before the awscrt client exists.
+        Once ``client.start()`` succeeds, awscrt owns broker reconnects and our
+        watchdog owns token refresh/rebuilds. Keeping the boundary here prevents a
+        broad ``except Exception`` from hiding builder/programming regressions.
+        """
+        try:
+            signature = await self._api.load_aws_token()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            code = _retryable_startup_code(err)
+            if code is not None:
+                raise MqttStartupUnavailable(
+                    code, "MQTT startup is temporarily unavailable"
+                ) from err
+            raise
+        if not signature:
+            raise MqttStartupUnavailable(
+                AWS_TOKEN_FAILED, "AWS IoT token response was empty"
+            )
+        return signature
 
     def _all_topics(self) -> set[str]:
         """Union of the subscribe topics of every appliance (the target set)."""
@@ -638,16 +771,31 @@ class NativeMqttClient:
                 backoff = 0  # rebuild succeeded
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception as err:
                 # Only the REBUILD path (load_aws_token / _start / the rebuild's
                 # _subscribe_missing) can land here now: the in-place re-subscribe uses
                 # _subscribe_missing(), which swallows a per-topic HonCodedError (the
                 # blackout escalation is driven inline by resubscribe_failures, not by a
                 # raise). Back off (capped, reset on recovery) so a persistent 5xx from
                 # the AWS authorizer is not hammered every tick.
+                code = _retryable_startup_code(err)
+                if code is None and _is_structural_error(err):
+                    # A deterministic code/schema error cannot heal. Stop the partial
+                    # transport and surface it loudly; do not spin forever. Non-
+                    # structural UNKNOWN runtime failures retain the old watchdog
+                    # resilience below, because terminating the supervisor would make
+                    # realtime permanently dead for this session.
+                    self._stop_client()
+                    _LOGGER.error(
+                        "MQTT watchdog stopped after a structural recovery error",
+                        exc_info=True,
+                    )
+                    return
+                code = code or UNKNOWN
                 backoff = min(backoff + _WATCHDOG_INTERVAL, _RECONNECT_BACKOFF_CAP)
                 _LOGGER.warning(
-                    "MQTT watchdog: reconnect failed, retrying in %ss",
+                    "[%s] MQTT watchdog: reconnect failed, retrying in %ss",
+                    code.label,
                     _WATCHDOG_INTERVAL + backoff,
                     exc_info=True,
                 )

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 from dataclasses import dataclass
 
 CODE_PREFIX = "ADDHON"
@@ -190,7 +191,18 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
     if isinstance(code, HonErrorCode):
         return code
 
+    # Type-first decoding/transport cases. Their ordinary messages do not reliably
+    # contain "decode error", "refused" or a status, so substring-only classification
+    # turns real transient AWS introspection failures into UNKNOWN. Keep this module
+    # dependency-free: aiohttp errors are recognized by their stable public class names
+    # (the same name-based seam already used below for auth/TLS exception families).
+    if isinstance(err, (json.JSONDecodeError, UnicodeDecodeError)):
+        return DECODE_ERROR
+    if isinstance(err, ConnectionError):
+        return CONNECTION_REFUSED
+
     name = type(err).__name__.lower()
+    class_names = " ".join(cls.__name__.lower() for cls in type(err).__mro__)
     text = str(err).lower()
     hay = f"{text} {name}"
 
@@ -237,6 +249,19 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         or "reset by peer" in hay
         or "cannot connect to host" in hay
         or "network is unreachable" in text
+    ):
+        return CONNECTION_REFUSED
+    if "clientpayloaderror" in class_names:
+        return DECODE_ERROR
+    if any(
+        family in class_names
+        for family in (
+            "clientconnectionerror",
+            "clientconnectorerror",
+            "clientoserror",
+            "serverconnectionerror",
+            "serverdisconnectederror",
+        )
     ):
         return CONNECTION_REFUSED
     if "decode error" in hay:

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -183,23 +183,19 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
 
     Order is most-specific-first. A carried code wins; then rate-limit/5xx (which
     must beat the auth-named-class rule, like the existing classifier); then
-    timeouts (attributed to ``phase`` when known); then TLS/DNS/refused; then the
-    native auth-step messages; finally the coarse buckets via the existing
-    ``hon_client`` predicates.
+    timeouts (attributed to ``phase`` when known); then explicit auth rejections,
+    TLS/DNS/refused and native auth-step messages; finally broad transport types
+    and the coarse buckets via the existing ``hon_client`` predicates.
     """
     code = getattr(err, "error_code", None)
     if isinstance(code, HonErrorCode):
         return code
 
-    # Type-first decoding/transport cases. Their ordinary messages do not reliably
-    # contain "decode error", "refused" or a status, so substring-only classification
-    # turns real transient AWS introspection failures into UNKNOWN. Keep this module
-    # dependency-free: aiohttp errors are recognized by their stable public class names
-    # (the same name-based seam already used below for auth/TLS exception families).
+    # Decode types are unambiguous even when their ordinary messages do not contain
+    # "decode error". Broad connection types are deliberately handled later: their
+    # messages may still carry a more-specific 5xx or explicit auth rejection.
     if isinstance(err, (json.JSONDecodeError, UnicodeDecodeError)):
         return DECODE_ERROR
-    if isinstance(err, ConnectionError):
-        return CONNECTION_REFUSED
 
     name = type(err).__name__.lower()
     class_names = " ".join(cls.__name__.lower() for cls in type(err).__mro__)
@@ -225,6 +221,45 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return SERVER_ERROR
     if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
         return phase_timeout_code(phase)
+
+    # A transport-shaped exception can wrap a real HTTP/token rejection. Detect only
+    # explicit rejection markers here (not a bare "auth"/"token", which may merely be
+    # an endpoint name) so bad credentials propagate to HA reauth instead of being
+    # converted to MQTT polling-only retries. Retryable 429/5xx/timeouts above retain
+    # priority, including NativeAuthError("api_auth: status 503").
+    auth_rejected = (
+        "unauthorized" in hay
+        or any(
+            marker in hay
+            for marker in (
+                "http 401",
+                "http 403",
+                "status 401",
+                "status 403",
+                "status=401",
+                "status=403",
+                "token rejected",
+                "rejected token",
+                "invalid token",
+                "token invalid",
+                "expired token",
+                "token expired",
+                "invalid credential",
+                "credential rejected",
+            )
+        )
+    )
+    if auth_rejected:
+        if "api_auth" in hay:
+            return AUTH_API_AUTH
+        if "get_token" in hay or "token page" in hay or "progressive" in hay:
+            return AUTH_GET_TOKEN
+        if "login page" in hay or "introduce" in hay or "no fwuid" in hay:
+            return AUTH_INTRODUCE
+        if "login:" in hay or "can't login" in hay or "login failed" in hay:
+            return AUTH_LOGIN
+        return INVALID_CREDENTIALS
+
     # TLS/certificate: key off the exception CLASS NAME or explicit certificate text,
     # NOT a bare "ssl" in the message. aiohttp's ClientConnectorError __str__ ALWAYS
     # contains "ssl:default" for ANY HTTPS connect failure (a plain outage, not a TLS
@@ -253,17 +288,6 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return CONNECTION_REFUSED
     if "clientpayloaderror" in class_names:
         return DECODE_ERROR
-    if any(
-        family in class_names
-        for family in (
-            "clientconnectionerror",
-            "clientconnectorerror",
-            "clientoserror",
-            "serverconnectionerror",
-            "serverdisconnectederror",
-        )
-    ):
-        return CONNECTION_REFUSED
     if "decode error" in hay:
         return DECODE_ERROR
     if "api_auth" in hay:
@@ -276,6 +300,23 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return AUTH_LOGIN
     if "appliance" in hay and "empty" in hay:
         return APPLIANCE_LIST_EMPTY
+
+    # Broad transport fallbacks come after the semantic markers above. Otherwise a
+    # ConnectionError/ClientConnectionError carrying "401 unauthorized" becomes
+    # ADDHON-430 and MQTT treats a credential rejection as a retryable outage.
+    if isinstance(err, ConnectionError):
+        return CONNECTION_REFUSED
+    if any(
+        family in class_names
+        for family in (
+            "clientconnectionerror",
+            "clientconnectorerror",
+            "clientoserror",
+            "serverconnectionerror",
+            "serverdisconnectederror",
+        )
+    ):
+        return CONNECTION_REFUSED
 
     # Coarse fallback via the existing routing predicates (single source of truth).
     from .hon_client import _is_auth_error, _is_retryable_server_error

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -150,6 +150,31 @@ class ClassifyTest(unittest.TestCase):
             ec.DECODE_ERROR,
         )
 
+    def test_auth_rejections_beat_broad_connection_types(self) -> None:
+        class AuthConnectionError(ConnectionError):
+            pass
+
+        class ClientConnectionError(Exception):
+            pass
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        cases = (
+            (AuthConnectionError("api_auth: status 401"), ec.AUTH_API_AUTH),
+            (ClientConnectionError("HTTP 401 unauthorized"), ec.INVALID_CREDENTIALS),
+            (ServerDisconnectedError("token rejected"), ec.INVALID_CREDENTIALS),
+        )
+        for err, expected in cases:
+            with self.subTest(error=type(err).__name__):
+                self.assertIs(ec.classify(err), expected)
+                self.assertTrue(hc._requires_reauth(err))
+
+    def test_server_status_beats_builtin_connection_type(self) -> None:
+        err = ConnectionError("503 server error")
+        self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+        self.assertFalse(hc._requires_reauth(err))
+
     def test_aiohttp_connect_failure_is_not_tls(self) -> None:
         # aiohttp's ClientConnectorError __str__ ALWAYS carries "ssl:default" for any
         # HTTPS connect failure; that is a plain outage, NOT a TLS problem (refuter F1).

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -170,6 +170,33 @@ class ClassifyTest(unittest.TestCase):
                 self.assertIs(ec.classify(err), expected)
                 self.assertTrue(hc._requires_reauth(err))
 
+    def test_connection_class_names_without_auth_are_refused(self) -> None:
+        # aiohttp-style connection classes with a plain outage message (no auth
+        # marker, no refused/reset/DNS/TLS keyword) must reach the class-name
+        # family fallback and classify as CONNECTION_REFUSED. Guards the family
+        # list in classify() so dropping a name there is caught by a test.
+        class ClientConnectionError(Exception):
+            pass
+
+        class ClientConnectorError(Exception):
+            pass
+
+        class ClientOSError(Exception):
+            pass
+
+        class ServerConnectionError(Exception):
+            pass
+
+        cases = (
+            ClientConnectionError("connection lost"),
+            ClientConnectorError("host unreachable"),
+            ClientOSError("socket failure"),
+            ServerConnectionError("peer gone"),
+        )
+        for err in cases:
+            with self.subTest(error=type(err).__name__):
+                self.assertIs(ec.classify(err), ec.CONNECTION_REFUSED)
+
     def test_server_status_beats_builtin_connection_type(self) -> None:
         err = ConnectionError("503 server error")
         self.assertIs(ec.classify(err), ec.SERVER_ERROR)

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -121,6 +121,35 @@ class ClassifyTest(unittest.TestCase):
         self.assertIs(ec.classify(RuntimeError("getaddrinfo failed")), ec.DNS_FAILURE)
         self.assertIs(ec.classify(RuntimeError("Connection refused")), ec.CONNECTION_REFUSED)
 
+    def test_real_decode_and_disconnect_types_are_not_unknown(self) -> None:
+        self.assertIs(
+            ec.classify(json.JSONDecodeError("Expecting value", "", 0)),
+            ec.DECODE_ERROR,
+        )
+        self.assertIs(
+            ec.classify(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")),
+            ec.DECODE_ERROR,
+        )
+        self.assertIs(
+            ec.classify(ConnectionError("connection aborted")),
+            ec.CONNECTION_REFUSED,
+        )
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        class ClientPayloadError(Exception):
+            pass
+
+        self.assertIs(
+            ec.classify(ServerDisconnectedError("Server disconnected")),
+            ec.CONNECTION_REFUSED,
+        )
+        self.assertIs(
+            ec.classify(ClientPayloadError("Response payload is not completed")),
+            ec.DECODE_ERROR,
+        )
+
     def test_aiohttp_connect_failure_is_not_tls(self) -> None:
         # aiohttp's ClientConnectorError __str__ ALWAYS carries "ssl:default" for any
         # HTTPS connect failure; that is a plain outage, NOT a TLS problem (refuter F1).

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -534,21 +534,19 @@ class NativeSessionSetupTest(unittest.TestCase):
         self.assertEqual(h.mqtt_calls, [])
         self.assertIsNone(nh._mqtt_client)
 
-    def test_mqtt_start_failure_keeps_http_polling_available(self) -> None:
+    def test_unexpected_mqtt_start_failure_propagates(self) -> None:
         h = _Harness(self, [])
         h.install()
 
         async def mqtt_boom(_hon):
-            raise ConnectionError("AWS token service status 503")
+            raise TypeError("builder contract regression")
 
         self._patch(NativeHon, "_make_mqtt", mqtt_boom)
         nh = self._nh_with_api(h, enable_mqtt=True)
-        with self.assertLogs(session_mod._LOGGER, level="WARNING") as logs:
+        with self.assertRaisesRegex(TypeError, "builder contract regression"):
             _run(nh.setup())
 
         self.assertIsNone(nh._mqtt_client)
-        self.assertEqual(nh._setup_phase, "")
-        self.assertIn("continuing with HTTP polling", "\n".join(logs.output))
 
     def test_mqtt_start_cancellation_still_propagates(self) -> None:
         h = _Harness(self, [])

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -152,6 +152,24 @@ class StopTest(unittest.TestCase):
         _run(m.stop())  # no client/watchdog -> no-op, does not raise
         _run(m.stop())
 
+    def test_stop_invalidates_late_success_callback(self) -> None:
+        class FakeClient:
+            def stop(self) -> None:
+                return None
+
+        m = NativeMqttClient(FakeHon([]), "MID")
+        m._generation = 7
+        m._connection = True
+        m._subscribed_topics_set = {_RECOVERY_TOPIC}
+        m._client = FakeClient()
+        _run(m.stop())
+
+        self.assertEqual(m._generation, 8)
+        self.assertFalse(m._connection)
+        self.assertEqual(m._subscribed_topics_set, set())
+        m._on_link_up(None, generation=7)  # queued callback from the stopped client
+        self.assertFalse(m._connection)
+
 
 class CreatePathTest(unittest.TestCase):
     """Drives the REAL path create()->_start->_subscribe->watchdog with richer awscrt
@@ -234,6 +252,199 @@ class CreatePathTest(unittest.TestCase):
         self.assertTrue(had_watchdog)
         self.assertTrue(fake_client.stopped)
         self.assertIsNone(m._watchdog_task)
+
+    def test_retryable_initial_failure_retains_client_and_recovers(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        async def body():
+            m = NativeMqttClient(FakeHon([FakeAppliance(_RECOVERY_TOPIC)]), "MID")
+            starts = 0
+            subscribed = asyncio.Event()
+
+            async def flaky_start():
+                nonlocal starts
+                starts += 1
+                if starts == 1:
+                    raise RuntimeError("hOn server error (status 503)")
+                m._connection = True
+
+            async def subscribe_missing():
+                m._subscribed_topics_set = {_RECOVERY_TOPIC}
+                subscribed.set()
+
+            m._start = flaky_start  # type: ignore[assignment]
+            m._subscribe_missing = subscribe_missing  # type: ignore[assignment]
+            old_ticks = mod._RECONNECT_AFTER_FAILED_TICKS
+            old_interval = mod._WATCHDOG_INTERVAL
+            mod._RECONNECT_AFTER_FAILED_TICKS = 1
+            mod._WATCHDOG_INTERVAL = 0
+            try:
+                with self.assertLogs(mod._LOGGER, level="WARNING") as logs:
+                    result = await m.create()
+                    watchdog = m._watchdog_task
+                    await asyncio.wait_for(subscribed.wait(), 1)
+                self.assertIn("ADDHON-450", "\n".join(logs.output))
+                recovered_topics = set(m._subscribed_topics_set)
+                await m.stop()
+                return result, m, watchdog, starts, recovered_topics
+            finally:
+                mod._RECONNECT_AFTER_FAILED_TICKS = old_ticks
+                mod._WATCHDOG_INTERVAL = old_interval
+
+        result, m, watchdog, starts, recovered_topics = _run(body())
+        self.assertIs(result, m)
+        self.assertEqual(starts, 2)
+        self.assertIsNotNone(watchdog)
+        self.assertTrue(watchdog.done())
+        self.assertIsNone(m._watchdog_task)
+        self.assertEqual(recovered_topics, {_RECOVERY_TOPIC})
+        self.assertEqual(m._subscribed_topics_set, set())
+
+    def test_stop_cancels_deferred_startup_retry(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        async def body():
+            m = NativeMqttClient(FakeHon([]), "MID")
+            starts = 0
+
+            async def unavailable():
+                nonlocal starts
+                starts += 1
+                raise RuntimeError("hOn server error (status 503)")
+
+            m._start = unavailable  # type: ignore[assignment]
+            with self.assertLogs(mod._LOGGER, level="WARNING"):
+                result = await m.create()
+            watchdog = m._watchdog_task
+            await asyncio.sleep(0)  # let the watchdog enter its first backoff sleep
+            await m.stop()
+            await asyncio.sleep(0)
+            return result, m, watchdog, starts
+
+        result, m, watchdog, starts = _run(body())
+        self.assertIs(result, m)
+        self.assertEqual(starts, 1)
+        self.assertIsNotNone(watchdog)
+        self.assertTrue(watchdog.done())
+        self.assertIsNone(m._watchdog_task)
+
+    def test_unexpected_initial_failure_is_not_hidden_or_retried(self) -> None:
+        m = NativeMqttClient(FakeHon([]), "MID")
+
+        async def broken_builder_contract():
+            raise TypeError("builder returned 503 invalid arguments")
+
+        m._start = broken_builder_contract  # type: ignore[assignment]
+        with self.assertRaisesRegex(TypeError, "503 invalid arguments"):
+            _run(m.create())
+        self.assertIsNone(m._watchdog_task)
+        self.assertIsNone(m._client)
+
+    def test_aws_token_failures_are_typed_without_hiding_unknown_errors(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.error_codes import AWS_TOKEN_FAILED, SERVER_ERROR
+
+        class Api:
+            def __init__(self, result=None, error=None) -> None:
+                self.result = result
+                self.error = error
+
+            async def load_aws_token(self):
+                if self.error is not None:
+                    raise self.error
+                return self.result
+
+        async def load(api):
+            hon = FakeHon([])
+            hon.api = api
+            return await NativeMqttClient(hon, "MID")._load_aws_signature()
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as empty:
+            _run(load(Api(result="")))
+        self.assertIs(empty.exception.error_code, AWS_TOKEN_FAILED)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as outage:
+            _run(load(Api(error=RuntimeError("hOn server error (status 503)"))))
+        self.assertIs(outage.exception.error_code, SERVER_ERROR)
+        self.assertIsInstance(outage.exception.__cause__, RuntimeError)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as malformed:
+            _run(load(Api(error=json.JSONDecodeError("Expecting value", "", 0))))
+        from custom_components.addhon.error_codes import DECODE_ERROR
+
+        self.assertIs(malformed.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as bad_charset:
+            _run(
+                load(
+                    Api(
+                        error=UnicodeDecodeError(
+                            "utf-8", b"\xff", 0, 1, "invalid start byte"
+                        )
+                    )
+                )
+            )
+        self.assertIs(bad_charset.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as disconnected:
+            _run(load(Api(error=ConnectionError("connection aborted"))))
+        from custom_components.addhon.error_codes import CONNECTION_REFUSED
+
+        self.assertIs(disconnected.exception.error_code, CONNECTION_REFUSED)
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        class ClientPayloadError(Exception):
+            pass
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as server_disconnect:
+            _run(load(Api(error=ServerDisconnectedError("Server disconnected"))))
+        self.assertIs(server_disconnect.exception.error_code, CONNECTION_REFUSED)
+        with self.assertRaises(mod.MqttStartupUnavailable) as bad_payload:
+            _run(load(Api(error=ClientPayloadError("payload incomplete"))))
+        self.assertIs(bad_payload.exception.error_code, DECODE_ERROR)
+
+        with self.assertRaisesRegex(TypeError, "503 schema regression"):
+            _run(load(Api(error=TypeError("503 schema regression"))))
+
+    def test_cancellation_during_aws_token_load_cleans_up_and_propagates(self) -> None:
+        class Api:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+
+            async def load_aws_token(self):
+                self.started.set()
+                await asyncio.Event().wait()
+
+        async def body():
+            api = Api()
+            hon = FakeHon([])
+            hon.api = api
+            m = NativeMqttClient(hon, "MID")
+            task = asyncio.create_task(m.create())
+            await api.started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            return m
+
+        m = _run(body())
+        self.assertIsNone(m._client)
+        self.assertIsNone(m._watchdog_task)
+
+    def test_awscrt_operational_error_retries_but_invalid_argument_fails_fast(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+        from custom_components.addhon.error_codes import MQTT_CONNECT_TIMEOUT
+
+        AwsCrtError = type("AwsCrtError", (Exception,), {})
+        outage = AwsCrtError("socket closed")
+        outage.name = "AWS_IO_SOCKET_CLOSED"
+        invalid = AwsCrtError("invalid")
+        invalid.name = "AWS_ERROR_INVALID_ARGUMENT"
+
+        self.assertIs(mod._retryable_startup_code(outage), MQTT_CONNECT_TIMEOUT)
+        self.assertIsNone(mod._retryable_startup_code(invalid))
 
     def test_create_stops_client_when_subscribe_fails(self) -> None:
         # #21: _start() already started the awscrt client; if a later step raises,
@@ -721,7 +932,6 @@ class StartReconnectTest(unittest.TestCase):
     previous awscrt client before building a new one, instead of leaking it."""
 
     def test_start_stops_previous_client_before_rebuild(self) -> None:
-        import awscrt
         import awsiot
 
         built: list = []
@@ -955,6 +1165,52 @@ class StartGenerationWiringTest(unittest.TestCase):
         gen2["on_lifecycle_disconnection"](None)
         self.assertFalse(m._connection)
 
+    def test_rebuild_invalidates_success_emitted_during_old_client_stop(self) -> None:
+        import awsiot
+
+        builds: list = []
+
+        class FakeClient:
+            def __init__(self, callbacks) -> None:
+                self.callbacks = callbacks
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                # Adversarial interleaving: native shutdown emits a queued success
+                # synchronously. It must already be stale when stop() is entered.
+                self.callbacks["on_lifecycle_connection_success"](None)
+
+        def fake_builder(**kwargs):
+            builds.append(kwargs)
+            return FakeClient(kwargs)
+
+        awsiot.mqtt5_client_builder.websockets_with_custom_authorizer = fake_builder
+
+        class FakeAuth:
+            id_token = "IDT"
+
+        class FakeApi:
+            auth = FakeAuth()
+
+            async def load_aws_token(self):
+                return "SIGNED"
+
+        hon = FakeHon([])
+        hon.api = FakeApi()
+        m = NativeMqttClient(hon, "MID")
+
+        async def body():
+            await m._start()
+            builds[0]["on_lifecycle_connection_success"](None)
+            self.assertTrue(m._connection)
+            await m._start()
+
+        _run(body())
+        self.assertEqual(len(builds), 2)
+        self.assertFalse(m._connection)
+
 
 class WatchdogResilienceTest(unittest.TestCase):
     """#3: the watchdog must survive a transient rebuild error (instead of dying and
@@ -1002,7 +1258,7 @@ class WatchdogResilienceTest(unittest.TestCase):
 
         async def boom():
             starts.append(True)
-            raise RuntimeError("load_aws_token 5xx")
+            raise RuntimeError("hOn server error (status 503)")
 
         self._drive([False] * 7, boom)  # two rebuild windows
         # Pre-fix the first raise would end the task -> starts == 1. Surviving -> >= 2.
@@ -1035,7 +1291,7 @@ class WatchdogResilienceTest(unittest.TestCase):
         from custom_components.addhon.client.transport.mqtt import _WATCHDOG_INTERVAL
 
         async def boom():
-            raise RuntimeError("x")
+            raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 9 + [True], boom)
         base = _WATCHDOG_INTERVAL
@@ -1053,7 +1309,7 @@ class WatchdogResilienceTest(unittest.TestCase):
         async def flaky_start():
             calls["n"] += 1
             if calls["n"] <= 2:
-                raise RuntimeError("transient")
+                raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 14, flaky_start)  # connection never comes up
         base = _WATCHDOG_INTERVAL
@@ -1067,10 +1323,30 @@ class WatchdogResilienceTest(unittest.TestCase):
         )
 
         async def boom():
-            raise RuntimeError("x")
+            raise RuntimeError("hOn server error (status 503)")
 
         intervals = self._drive([False] * 60, boom)
         self.assertLessEqual(max(intervals), _WATCHDOG_INTERVAL + _RECONNECT_BACKOFF_CAP)
+
+    def test_watchdog_keeps_retrying_unknown_runtime_error(self) -> None:
+        starts = []
+
+        async def unknown_runtime_failure():
+            starts.append(True)
+            raise RuntimeError("opaque native runtime failure")
+
+        self._drive([False] * 7, unknown_runtime_failure)
+        self.assertGreaterEqual(len(starts), 2)
+
+    def test_watchdog_stops_on_structural_error(self) -> None:
+        starts = []
+
+        async def structural_failure():
+            starts.append(True)
+            raise TypeError("builder returned 503 invalid arguments")
+
+        self._drive([False] * 7, structural_failure)
+        self.assertEqual(len(starts), 1)
 
 
 class SubscribeNonBlockingTest(unittest.TestCase):
@@ -1545,7 +1821,6 @@ class SubscribedFlagLifecycleTest(unittest.TestCase):
         self.assertEqual(m._subscribed_topics_set, {"t"})
 
     def test_start_resets_subscribed(self) -> None:
-        import awscrt
         import awsiot
 
         class FakeClient:

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -446,6 +446,35 @@ class CreatePathTest(unittest.TestCase):
         self.assertIs(mod._retryable_startup_code(outage), MQTT_CONNECT_TIMEOUT)
         self.assertIsNone(mod._retryable_startup_code(invalid))
 
+    def test_auth_marked_transport_errors_propagate_instead_of_retrying(self) -> None:
+        import custom_components.addhon.client.transport.mqtt as mod
+
+        class ClientConnectionError(Exception):
+            pass
+
+        class ServerDisconnectedError(Exception):
+            pass
+
+        errors = (
+            ConnectionError("api_auth: status 401"),
+            ClientConnectionError("HTTP 401 unauthorized"),
+            ServerDisconnectedError("token rejected"),
+        )
+        for err in errors:
+            with self.subTest(error=type(err).__name__):
+                self.assertIsNone(mod._retryable_startup_code(err))
+
+                mqtt_client = NativeMqttClient(FakeHon([]), "MID")
+
+                async def rejected(error=err):
+                    raise error
+
+                mqtt_client._start = rejected  # type: ignore[assignment]
+                with self.assertRaises(type(err)):
+                    _run(mqtt_client.create())
+                self.assertIsNone(mqtt_client._watchdog_task)
+                self.assertIsNone(mqtt_client._client)
+
     def test_create_stops_client_when_subscribe_fails(self) -> None:
         # #21: _start() already started the awscrt client; if a later step raises,
         # create() must stop it before re-raising (otherwise NativeHon never gets a


### PR DESCRIPTION
## Summary

- retain the MQTT transport when initial AWS token or IoT endpoint setup fails transiently
- let the existing watchdog retry realtime startup with bounded backoff while HTTP polling remains available
- preserve fail-fast behavior for structural and programming errors
- harden error classification and invalidate late MQTT callbacks during client replacement
- add regression coverage for startup recovery, cancellation, AWS CRT errors, decode failures, and stop/start races

No new stable error code was required. Empty or failed AWS token acquisition uses the existing ADDHON-300 code, while existing transport-specific codes remain in use.

## Validation

- full suite: 1079 passed, 1 skipped, 7 xfailed
- focused MQTT/session/error-code suite: 142 passed
- Ruff, compileall, JSON validation, and git diff check passed
- adversarial review completed with no remaining blocker
- deployed the three changed runtime files to a live Home Assistant instance: integration diagnostics remained healthy, manual refresh succeeded, and no AddhOn, MQTT, or AWS errors appeared after restart

Fixes the realtime startup retry issue reported in the review of PR #57.

## Summary by Sourcery

Improve MQTT startup resilience by deferring transient AWS/token/connection failures to the MQTT watchdog while keeping HTTP polling active and preserving fail-fast behavior for structural errors.

Bug Fixes:
- Ensure MQTT client and watchdog are correctly cleaned up on AWS token load cancellation and failed startup, avoiding leaked clients and inconsistent connection state.
- Prevent stale or late MQTT lifecycle callbacks from resurrecting a disconnected client after stop or rebuild, eliminating false-connected states and missed recovery.
- Stop the watchdog on structural startup/rebuild errors instead of spinning indefinitely, so deterministic schema/contract faults surface clearly.
- Correct error classification so real decode and disconnect failures map to specific error codes instead of UNKNOWN, improving diagnostics.

Enhancements:
- Introduce typed MQTT startup unavailability handling with retryable error codes and structural error detection to drive bounded background reconnection.
- Refactor MQTT client stopping into a dedicated helper that resets connection/subscription state and generation to safely handle late callbacks and rebuilds.
- Add a dedicated AWS signature loader that maps AWS token and CRT operational errors into existing error codes without introducing new stable codes.
- Simplify session MQTT setup to rely on NativeMqttClient’s internal recovery logic, keeping HTTP polling as the authoritative channel while retries happen in the background.

Tests:
- Expand MQTT transport tests to cover startup retry behavior, stop/start races, AWS token failures, cancellation during token load, CRT error handling, and watchdog behavior on operational vs structural errors.
- Extend error code tests to verify classification of JSON/charset decoding errors and various connection/disconnect scenarios into concrete error codes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes MQTT startup recover from transient AWS failures while keeping HTTP polling available. The main changes are:

- Retryable MQTT startup failures now retain a disconnected client.
- The MQTT watchdog now retries startup in the background.
- Structural MQTT setup errors now fail fast.
- Auth and transport error classification now preserves reauth routing.
- Tests now cover startup recovery, cancellation, CRT errors, late callbacks, and error-code mapping.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/error_codes.py | Updates classification so explicit auth rejections are handled before broad connection fallbacks. |
| custom_components/addhon/client/transport/mqtt.py | Adds retryable MQTT startup handling, watchdog recovery, structural-error fail-fast behavior, and late callback invalidation. |
| custom_components/addhon/client/session.py | Moves MQTT startup recovery ownership from session setup into the MQTT client. |
| tests/test_error_codes.py | Adds tests for auth, decode, and connection error classification. |
| tests/test_transport_mqtt.py | Adds tests for MQTT startup retry, recovery, cancellation, CRT handling, and callback races. |
| tests/test_native_session.py | Updates session tests for propagated unexpected MQTT startup failures. |

<sub>Reviews (3): Last reviewed commit: ["test(error-codes): cover connection clas..."](https://github.com/tis24dev/addhon/commit/1c082b64a45e3bf2993ed776f8dcfa6298b568bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43823520)</sub>

<!-- /greptile_comment -->