### PR TITLE
Fix complete 5xx retry routing and redact coordinator names

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -464,7 +464,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             summary = [
                 {
                     "id": redact_mac(appliance_id),
-                    "name": appliance_data.get("name"),
+                    "name": redact_id(appliance_data.get("name")),
                     "type": appliance_data.get("type"),
                     "mac": redact_mac(appliance_data.get("mac")),
                     "attributes": len(appliance_data.get("attributes", {}))

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -42,13 +42,13 @@ def _http_statuses(text: str) -> set[int]:
     return {int(match.group(1)) for match in _HTTP_STATUS_RE.finditer(text)}
 
 
-def _is_rate_limited_text(text: str) -> bool:
+def is_rate_limited_text(text: str) -> bool:
     """Whether an error message represents HTTP rate limiting."""
     text = text.lower()
     return 429 in _http_statuses(text) or "too many requests" in text
 
 
-def _is_server_failure_text(text: str) -> bool:
+def is_server_failure_text(text: str) -> bool:
     """Whether an error message represents a retryable server-side failure."""
     text = text.lower()
     return any(500 <= status <= 599 for status in _http_statuses(text)) or any(
@@ -234,9 +234,9 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
     text = str(err).lower()
     hay = f"{text} {name}"
 
-    if _is_rate_limited_text(hay):
+    if is_rate_limited_text(hay):
         return RATE_LIMITED
-    if _is_server_failure_text(hay):
+    if is_server_failure_text(hay):
         return SERVER_ERROR
     if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
         return phase_timeout_code(phase)

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -26,9 +26,39 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import json
+import re
 from dataclasses import dataclass
 
 CODE_PREFIX = "ADDHON"
+
+# HTTP status tokens must be standalone numbers. Besides avoiding false positives
+# such as a model/identifier ending in ``5000``, this covers the complete 5xx range
+# instead of the previous hand-picked 500/502/503/504 subset.
+_HTTP_STATUS_RE = re.compile(r"(?<![A-Za-z0-9])([1-5]\d{2})(?!\d)")
+
+
+def _http_statuses(text: str) -> set[int]:
+    """Return standalone HTTP-like status numbers found in *text*."""
+    return {int(match.group(1)) for match in _HTTP_STATUS_RE.finditer(text)}
+
+
+def _is_rate_limited_text(text: str) -> bool:
+    """Whether an error message represents HTTP rate limiting."""
+    return 429 in _http_statuses(text) or "too many requests" in text
+
+
+def _is_server_failure_text(text: str) -> bool:
+    """Whether an error message represents a retryable server-side failure."""
+    return any(500 <= status <= 599 for status in _http_statuses(text)) or any(
+        marker in text
+        for marker in (
+            "internal server error",
+            "server error",
+            "bad gateway",
+            "gateway timeout",
+            "temporarily unavailable",
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -202,22 +232,9 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
     text = str(err).lower()
     hay = f"{text} {name}"
 
-    if "429" in hay or "too many requests" in hay:
+    if _is_rate_limited_text(hay):
         return RATE_LIMITED
-    if any(
-        token in hay
-        for token in (
-            "500",
-            "502",
-            "503",
-            "504",
-            "internal server error",
-            "server error",
-            "bad gateway",
-            "gateway timeout",
-            "temporarily unavailable",
-        )
-    ):
+    if _is_server_failure_text(hay):
         return SERVER_ERROR
     if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
         return phase_timeout_code(phase)

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -31,24 +31,26 @@ from dataclasses import dataclass
 
 CODE_PREFIX = "ADDHON"
 
-# HTTP status tokens must be standalone numbers. Besides avoiding false positives
-# such as a model/identifier ending in ``5000``, this covers the complete 5xx range
-# instead of the previous hand-picked 500/502/503/504 subset.
-_HTTP_STATUS_RE = re.compile(r"(?<![A-Za-z0-9])([1-5]\d{2})(?!\d)")
+# Retry-relevant HTTP status tokens must be standalone numbers. Besides avoiding
+# false positives such as model/identifier H500 or 5000, this covers rate limiting
+# (429) and the complete 5xx range instead of the previous hand-picked subset.
+_HTTP_STATUS_RE = re.compile(r"(?<![A-Za-z0-9])(429|5\d{2})(?!\d)")
 
 
 def _http_statuses(text: str) -> set[int]:
-    """Return standalone HTTP-like status numbers found in *text*."""
+    """Return standalone retry-relevant HTTP status numbers found in *text*."""
     return {int(match.group(1)) for match in _HTTP_STATUS_RE.finditer(text)}
 
 
 def _is_rate_limited_text(text: str) -> bool:
     """Whether an error message represents HTTP rate limiting."""
+    text = text.lower()
     return 429 in _http_statuses(text) or "too many requests" in text
 
 
 def _is_server_failure_text(text: str) -> bool:
     """Whether an error message represents a retryable server-side failure."""
+    text = text.lower()
     return any(500 <= status <= 599 for status in _http_statuses(text)) or any(
         marker in text
         for marker in (

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -17,9 +17,9 @@ from .error_codes import (
     UNKNOWN,
     HonCodedError,
     HonErrorCode,
-    _is_rate_limited_text,
-    _is_server_failure_text,
     classify,
+    is_rate_limited_text,
+    is_server_failure_text,
     phase_timeout_code,
 )
 
@@ -223,8 +223,8 @@ def _is_retryable_server_error(err: BaseException) -> bool:
         return True
     err_str = _error_text(err)
     return (
-        _is_rate_limited_text(err_str)
-        or _is_server_failure_text(err_str)
+        is_rate_limited_text(err_str)
+        or is_server_failure_text(err_str)
         or "timeout" in err_str
         or "timed out" in err_str
     )

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -17,6 +17,8 @@ from .error_codes import (
     UNKNOWN,
     HonCodedError,
     HonErrorCode,
+    _is_rate_limited_text,
+    _is_server_failure_text,
     classify,
     phase_timeout_code,
 )
@@ -220,19 +222,12 @@ def _is_retryable_server_error(err: BaseException) -> bool:
     if isinstance(err, (asyncio.TimeoutError, concurrent.futures.TimeoutError, TimeoutError)):
         return True
     err_str = _error_text(err)
-    return any(k in err_str for k in (
-        "internal server error",
-        "server error",
-        "500",
-        "502",
-        "503",
-        "504",
-        "timeout",
-        "timed out",
-        "temporarily unavailable",
-        "too many requests",
-        "429",
-    ))
+    return (
+        _is_rate_limited_text(err_str)
+        or _is_server_failure_text(err_str)
+        or "timeout" in err_str
+        or "timed out" in err_str
+    )
 
 
 def _is_missing_session_error(err: BaseException) -> bool:

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -79,10 +79,12 @@ class AuthErrorClassificationTest(unittest.TestCase):
         self.assertFalse(hc._requires_reauth(err))
 
     def test_auth_class_but_5xx_does_not_reauth(self) -> None:
-        # Class name = auth, but message 500 -> retryable -> NOT reauth.
-        err = NativeAuthError("boom status 500")
-        self.assertTrue(hc._is_auth_error(err))      # via class name
-        self.assertFalse(hc._requires_reauth(err))   # but retryable wins
+        # Class name = auth, but every 5xx status is retryable -> NOT reauth.
+        for status in (500, 501, 505, 507, 511, 599):
+            err = NativeAuthError(f"boom status {status}")
+            with self.subTest(status=status):
+                self.assertTrue(hc._is_auth_error(err))      # via class name
+                self.assertFalse(hc._requires_reauth(err))   # but retryable wins
 
     def test_message_based_classification_still_works(self) -> None:
         self.assertTrue(hc._is_auth_error(RuntimeError("HTTP 401 unauthorized")))

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -121,8 +121,9 @@ class CoordinatorErrorClassificationTest(unittest.TestCase):
         # Auth-named class but a 5xx message -> retryable wins -> NotReady (retry),
         # NOT a reauth prompt.
         _AF, NotReady, _UF, setup, _upd = self._imports()
-        with self.assertRaises(NotReady):
-            setup(NativeAuthError("boom status 500"))
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status), self.assertRaises(NotReady):
+                setup(NativeAuthError(f"boom status {status}"))
 
     def test_update_auth_error_is_config_entry_auth_failed(self) -> None:
         AuthFailed, _NotReady, _UF, _setup, upd = self._imports()
@@ -136,8 +137,9 @@ class CoordinatorErrorClassificationTest(unittest.TestCase):
 
     def test_update_retryable_5xx_is_update_failed_not_auth(self) -> None:
         _AF, _NotReady, UpdateFailed, _setup, upd = self._imports()
-        with self.assertRaises(UpdateFailed):
-            upd(NativeAuthError("boom status 500"))
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status), self.assertRaises(UpdateFailed):
+                upd(NativeAuthError(f"boom status {status}"))
 
     def test_setup_mfa_challenge_is_config_entry_auth_failed(self) -> None:
         # A 2FA challenge during a BACKGROUND setup cannot prompt -> must route to the

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -140,6 +140,14 @@ class CoordinatorConfigEntryTest(unittest.TestCase):
                     _is_redact_mac(kv[field]),
                     f"summary '{field}' must be a redact_mac(...) call",
                 )
+            name_value = kv["name"]
+            self.assertIsInstance(name_value, ast.Call)
+            name_func = name_value.func
+            self.assertTrue(
+                (isinstance(name_func, ast.Name) and name_func.id == "redact_id")
+                or (isinstance(name_func, ast.Attribute) and name_func.attr == "redact_id"),
+                "summary 'name' must be a redact_id(...) call",
+            )
 
     def test_manifest_has_no_invalid_homeassistant_key(self) -> None:
         manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -148,6 +148,16 @@ class CoordinatorConfigEntryTest(unittest.TestCase):
                 or (isinstance(name_func, ast.Attribute) and name_func.attr == "redact_id"),
                 "summary 'name' must be a redact_id(...) call",
             )
+            self.assertEqual(len(name_value.args), 1)
+            raw_name = name_value.args[0]
+            self.assertIsInstance(raw_name, ast.Call)
+            self.assertIsInstance(raw_name.func, ast.Attribute)
+            self.assertEqual(raw_name.func.attr, "get")
+            self.assertIsInstance(raw_name.func.value, ast.Name)
+            self.assertEqual(raw_name.func.value.id, "appliance_data")
+            self.assertEqual(len(raw_name.args), 1)
+            self.assertIsInstance(raw_name.args[0], ast.Constant)
+            self.assertEqual(raw_name.args[0].value, "name")
 
     def test_manifest_has_no_invalid_homeassistant_key(self) -> None:
         manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))

--- a/tests/test_engine_appliances.py
+++ b/tests/test_engine_appliances.py
@@ -15,7 +15,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _golden import REPO, frozen, install_stubs, normalize  # noqa: E402
+from _golden import frozen, install_stubs, normalize  # noqa: E402
 
 install_stubs()
 

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -113,18 +113,33 @@ class ClassifyTest(unittest.TestCase):
 
     def test_server_and_rate_limit_win_over_auth_name(self) -> None:
         # Retryable 5xx / 429 must beat the auth-named class (existing routing rule).
-        for status in (500, 501, 502, 503, 504, 505, 507, 511, 599):
+        for status in range(500, 600):
             err = NativeAuthError(f"api_auth: status {status}")
             with self.subTest(status=status):
                 self.assertIs(ec.classify(err), ec.SERVER_ERROR)
                 self.assertFalse(hc._requires_reauth(err))
         self.assertIs(ec.classify(NativeAuthError("429 too many requests")), ec.RATE_LIMITED)
 
+    def test_server_status_format_variants(self) -> None:
+        for message in (
+            "api_auth: status=501",
+            "api_auth: HTTP 505",
+            "api_auth: response (507)",
+            "api_auth: upstream [511]",
+            "599 server response",
+        ):
+            with self.subTest(message=message):
+                err = NativeAuthError(message)
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
+
     def test_status_matching_does_not_accept_longer_identifiers(self) -> None:
-        # A model/id-like token containing 500 must not masquerade as an HTTP 5xx.
-        err = NativeAuthError("api_auth: model H5000 unavailable")
-        self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
-        self.assertTrue(hc._requires_reauth(err))
+        # Model/id-like and out-of-range tokens must not masquerade as an HTTP 5xx.
+        for token in ("H500", "X599Y", "5000", "1500", "499", "600"):
+            with self.subTest(token=token):
+                err = NativeAuthError(f"api_auth: model {token} unavailable")
+                self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
+                self.assertTrue(hc._requires_reauth(err))
 
     def test_network_classes(self) -> None:
         self.assertIs(ec.classify(RuntimeError("certificate verify failed")), ec.TLS_FAILURE)

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -133,6 +133,23 @@ class ClassifyTest(unittest.TestCase):
                 self.assertIs(ec.classify(err), ec.SERVER_ERROR)
                 self.assertFalse(hc._requires_reauth(err))
 
+    def test_textual_server_errors_are_case_insensitive(self) -> None:
+        for message in (
+            "hOn server error",
+            "Internal Server Error",
+            "Bad Gateway",
+            "Gateway Timeout",
+            "Temporarily Unavailable",
+        ):
+            with self.subTest(message=message):
+                err = NativeAuthError(message)
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
+
+        rate_limit = NativeAuthError("Too Many Requests")
+        self.assertIs(ec.classify(rate_limit), ec.RATE_LIMITED)
+        self.assertFalse(hc._requires_reauth(rate_limit))
+
     def test_status_matching_does_not_accept_longer_identifiers(self) -> None:
         # Model/id-like and out-of-range tokens must not masquerade as an HTTP 5xx.
         for token in ("H500", "X599Y", "5000", "1500", "499", "600"):

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -113,8 +113,18 @@ class ClassifyTest(unittest.TestCase):
 
     def test_server_and_rate_limit_win_over_auth_name(self) -> None:
         # Retryable 5xx / 429 must beat the auth-named class (existing routing rule).
-        self.assertIs(ec.classify(NativeAuthError("boom status 500")), ec.SERVER_ERROR)
+        for status in (500, 501, 502, 503, 504, 505, 507, 511, 599):
+            err = NativeAuthError(f"api_auth: status {status}")
+            with self.subTest(status=status):
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
         self.assertIs(ec.classify(NativeAuthError("429 too many requests")), ec.RATE_LIMITED)
+
+    def test_status_matching_does_not_accept_longer_identifiers(self) -> None:
+        # A model/id-like token containing 500 must not masquerade as an HTTP 5xx.
+        err = NativeAuthError("api_auth: model H5000 unavailable")
+        self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
+        self.assertTrue(hc._requires_reauth(err))
 
     def test_network_classes(self) -> None:
         self.assertIs(ec.classify(RuntimeError("certificate verify failed")), ec.TLS_FAILURE)

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -12,7 +12,6 @@ test_coordinator_config_entry.py).
 from __future__ import annotations
 
 import asyncio
-import logging
 import sys
 import types
 import unittest

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -281,8 +281,6 @@ class MfaResumeTest(unittest.TestCase):
     def test_remoting_debug_line_is_redacted(self) -> None:
         # With DEBUG on, the remoting breadcrumb runs and emits the method + redacted
         # summary, never the response body/secret.
-        import logging
-
         auth = self._auth([FakeResp(text='[{"result":false,"message":"SECRET-MSG"}]')])
         with self.assertLogs(
             "custom_components.addhon.client.transport.auth", level="DEBUG"

--- a/tests/test_switch_params.py
+++ b/tests/test_switch_params.py
@@ -15,7 +15,6 @@ stack); no real Home Assistant install required.
 """
 from __future__ import annotations
 
-import dataclasses
 import json
 import sys
 import types

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
-import re
 import sys
 import types
 import unittest

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -363,10 +363,12 @@ class CreatePathTest(unittest.TestCase):
             _run(load(Api(result="")))
         self.assertIs(empty.exception.error_code, AWS_TOKEN_FAILED)
 
-        with self.assertRaises(mod.MqttStartupUnavailable) as outage:
-            _run(load(Api(error=RuntimeError("hOn server error (status 503)"))))
-        self.assertIs(outage.exception.error_code, SERVER_ERROR)
-        self.assertIsInstance(outage.exception.__cause__, RuntimeError)
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status):
+                with self.assertRaises(mod.MqttStartupUnavailable) as outage:
+                    _run(load(Api(error=RuntimeError(f"api_auth: status {status}"))))
+                self.assertIs(outage.exception.error_code, SERVER_ERROR)
+                self.assertIsInstance(outage.exception.__cause__, RuntimeError)
 
         with self.assertRaises(mod.MqttStartupUnavailable) as malformed:
             _run(load(Api(error=json.JSONDecodeError("Expecting value", "", 0))))

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -370,6 +370,11 @@ class CreatePathTest(unittest.TestCase):
                 self.assertIs(outage.exception.error_code, SERVER_ERROR)
                 self.assertIsInstance(outage.exception.__cause__, RuntimeError)
 
+        with self.assertRaises(mod.MqttStartupUnavailable) as textual_outage:
+            _run(load(Api(error=RuntimeError("hOn Internal Server Error"))))
+        self.assertIs(textual_outage.exception.error_code, SERVER_ERROR)
+        self.assertIsInstance(textual_outage.exception.__cause__, RuntimeError)
+
         with self.assertRaises(mod.MqttStartupUnavailable) as malformed:
             _run(load(Api(error=json.JSONDecodeError("Expecting value", "", 0))))
         from custom_components.addhon.error_codes import DECODE_ERROR


### PR DESCRIPTION
## Summary

- recognize every standalone HTTP status from 500 through 599 as a retryable server failure
- keep error-code classification and Home Assistant retry/reauth routing on the same predicates
- avoid false positives for model and identifier tokens such as H500, X599Y, 5000, and 1500
- redact appliance names in the coordinator DEBUG summary
- remove five unused imports from the test suite

## Reproduction

Before this patch, NativeAuthError("api_auth: status 501") and other unlisted 5xx responses were classified as ADDHON-140 auth_api_auth with reauth enabled. This could open an unnecessary credentials or OTP flow during an upstream server failure. The same input now maps to ADDHON-450 server_error and remains retryable.

## Validation

- adversarial routing suite: 132 passed, 157 subtests passed
- full suite: 1095 passed, 7 xfailed, 284 subtests passed
- all 100 statuses from 500 through 599 covered
- setup, coordinator-update, and MQTT consumers covered
- Ruff passed for custom_components and tests
- compileall and git diff --check passed

## Summary by Sourcery

Expand server error and rate-limit detection to cover the full HTTP 5xx/429 range consistently across error classification and retry routing, and improve privacy in coordinator debug output.

New Features:
- Support classification of all standalone HTTP 5xx status codes as retryable server-side failures.
- Handle varied HTTP status message formats while avoiding false positives from model or identifier-like tokens.

Bug Fixes:
- Align Home Assistant reauth vs retry routing with server error and rate-limit detection so 5xx responses no longer trigger unnecessary reauth flows.
- Ensure MQTT startup and setup/update flows treat all 5xx errors as retryable server failures instead of authentication failures.

Enhancements:
- Refactor error text parsing into shared helpers reused by both error code classification and client retry logic.
- Redact appliance names in coordinator debug summaries using identifier redaction.

Tests:
- Extend adversarial and routing tests to cover the full 500–599 status range, additional message formats, and false-positive scenarios.
- Tighten coordinator summary tests to enforce name redaction logic and validate the data source.
- Update MQTT, auth, and transport tests to assert the new retryable 5xx behavior and remove unused imports in the test suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands retry routing and removes appliance names from debug output. The main changes are:

- Recognize standalone HTTP statuses from 500 through 599 as retryable server failures.
- Share rate-limit and server-failure predicates across classification and reauthentication routing.
- Avoid matching model and identifier tokens as HTTP statuses.
- Redact appliance names in coordinator debug summaries.
- Remove unused test imports and extend routing coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The retry predicates consistently classify standalone 5xx responses without matching covered identifier-like tokens.
- Coordinator names are masked before they reach the debug summary.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/error_codes.py | Adds shared, boundary-aware detection for HTTP 429 and all 5xx statuses. |
| custom_components/addhon/hon_client.py | Uses the shared predicates to align retry and reauthentication routing. |
| custom_components/addhon/__init__.py | Redacts appliance names in coordinator debug summaries. |
| tests/test_error_codes.py | Covers all 5xx statuses, common formats, textual errors, and false-positive tokens. |
| tests/test_auth_error_classification.py | Checks that representative 5xx authentication errors use retry routing. |
| tests/test_coordinator_config_entry.py | Checks that coordinator summary names pass through identifier redaction. |
| tests/test_transport_mqtt.py | Expands MQTT startup coverage for numeric and textual server failures. |

<sub>Reviews (3): Last reviewed commit: ["refactor: make server-failure and rate-l..."](https://github.com/tis24dev/addhon/commit/698317fcaac90db8dda5bcc04f2992d3886d39df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44898369)</sub>

<!-- /greptile_comment -->