### PR TITLE
Release v5.9.0

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -464,7 +464,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             summary = [
                 {
                     "id": redact_mac(appliance_id),
-                    "name": appliance_data.get("name"),
+                    "name": redact_id(appliance_data.get("name")),
                     "type": appliance_data.get("type"),
                     "mac": redact_mac(appliance_data.get("mac")),
                     "attributes": len(appliance_data.get("attributes", {}))

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -273,7 +273,7 @@ def _mapped_sets(app_type) -> tuple[set[str], set[str]]:
         from .binary_sensor import BINARY_SENSORS, _CONNECTIVITY, _UNIVERSAL_GATED
         from .number import NUMBERS
         from .sensor import SENSORS
-        from .switch import _AC_SWITCHES
+        from .switch import _SETTINGS_SWITCHES
     except Exception:  # pragma: no cover - diagnostics must never crash
         _LOGGER.debug(
             "Diagnostics debug: coverage registries unavailable", exc_info=True
@@ -291,9 +291,10 @@ def _mapped_sets(app_type) -> tuple[set[str], set[str]]:
 
     for desc in NUMBERS.get(app_type, ()):
         mapped_params.add(desc.param)
+    # Settings-command switches (AC toggles + wine-cooler light) map their write param.
+    for desc in _SETTINGS_SWITCHES.get(app_type, ()):
+        mapped_params.add(desc.param)
     if app_type == APPLIANCE_AC:
-        for desc in _AC_SWITCHES:
-            mapped_params.add(desc.param)
         mapped_params |= _AC_CLIMATE_PARAMS
     if app_type in APPLIANCE_WASH_GROUP:
         mapped_params.update(PROGRAM_PARAM_NAMES)

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -26,9 +26,41 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import json
+import re
 from dataclasses import dataclass
 
 CODE_PREFIX = "ADDHON"
+
+# Retry-relevant HTTP status tokens must be standalone numbers. Besides avoiding
+# false positives such as model/identifier H500 or 5000, this covers rate limiting
+# (429) and the complete 5xx range instead of the previous hand-picked subset.
+_HTTP_STATUS_RE = re.compile(r"(?<![A-Za-z0-9])(429|5\d{2})(?!\d)")
+
+
+def _http_statuses(text: str) -> set[int]:
+    """Return standalone retry-relevant HTTP status numbers found in *text*."""
+    return {int(match.group(1)) for match in _HTTP_STATUS_RE.finditer(text)}
+
+
+def is_rate_limited_text(text: str) -> bool:
+    """Whether an error message represents HTTP rate limiting."""
+    text = text.lower()
+    return 429 in _http_statuses(text) or "too many requests" in text
+
+
+def is_server_failure_text(text: str) -> bool:
+    """Whether an error message represents a retryable server-side failure."""
+    text = text.lower()
+    return any(500 <= status <= 599 for status in _http_statuses(text)) or any(
+        marker in text
+        for marker in (
+            "internal server error",
+            "server error",
+            "bad gateway",
+            "gateway timeout",
+            "temporarily unavailable",
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -202,22 +234,9 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
     text = str(err).lower()
     hay = f"{text} {name}"
 
-    if "429" in hay or "too many requests" in hay:
+    if is_rate_limited_text(hay):
         return RATE_LIMITED
-    if any(
-        token in hay
-        for token in (
-            "500",
-            "502",
-            "503",
-            "504",
-            "internal server error",
-            "server error",
-            "bad gateway",
-            "gateway timeout",
-            "temporarily unavailable",
-        )
-    ):
+    if is_server_failure_text(hay):
         return SERVER_ERROR
     if _is_timeout(err) or "timed out" in hay or "timeout" in hay:
         return phase_timeout_code(phase)

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -18,6 +18,8 @@ from .error_codes import (
     HonCodedError,
     HonErrorCode,
     classify,
+    is_rate_limited_text,
+    is_server_failure_text,
     phase_timeout_code,
 )
 
@@ -220,19 +222,12 @@ def _is_retryable_server_error(err: BaseException) -> bool:
     if isinstance(err, (asyncio.TimeoutError, concurrent.futures.TimeoutError, TimeoutError)):
         return True
     err_str = _error_text(err)
-    return any(k in err_str for k in (
-        "internal server error",
-        "server error",
-        "500",
-        "502",
-        "503",
-        "504",
-        "timeout",
-        "timed out",
-        "temporarily unavailable",
-        "too many requests",
-        "429",
-    ))
+    return (
+        is_rate_limited_text(err_str)
+        or is_server_failure_text(err_str)
+        or "timeout" in err_str
+        or "timed out" in err_str
+    )
 
 
 def _is_missing_session_error(err: BaseException) -> bool:

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.8.3"
+  "version": "5.9.0"
 }

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -355,6 +355,11 @@ class HonSettingsSwitch(HonBaseEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
+        # Read the mirrored shadow value only. A settings-command param that the device
+        # does not mirror into the shadow is refreshed only at load time / by our own
+        # writes (sync_params_to_command skips shadow-absent keys), so falling back to the
+        # command value would manufacture a confidently-stale state; honest unknown (None)
+        # is correct. The real WC/AC mirror lightStatus, so this returns a value in practice.
         raw = self._get_attr(self._desc.param)
         if raw is None:
             return None

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 tis24dev
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Haier hOn switches: washer/dryer pause + air conditioner toggles."""
+"""Haier hOn switches: washer/dryer pause + air conditioner toggles + wine-cooler light."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -20,6 +20,7 @@ from .const import (
     APPLIANCE_AC,
     APPLIANCE_TD,
     APPLIANCE_WASH_GROUP,
+    APPLIANCE_WC,
     APPLIANCE_WD,
     APPLIANCE_WM,
     CONF_ENABLE_DEBUG,
@@ -39,11 +40,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class HonAcSwitchDescription:
-    """Boolean AC switch acting on a 0/1 parameter of the settings command.
+class HonSettingsSwitchDescription:
+    """Boolean switch acting on a 0/1 (or range[0,1]) parameter of the `settings` command.
 
     `param` is both the parameter name in the `settings` command (write) and
-    the direct 0/1 attribute read via _get_attr (read).
+    the direct 0/1 attribute read via _get_attr (read). Used by the air conditioner
+    toggles and the wine-cooler interior light (same settings-command convention).
     """
 
     key: str            # unique_id suffix
@@ -53,24 +55,40 @@ class HonAcSwitchDescription:
 
 # AC switches: 0/1 parameters confirmed in the settings command of Roberto's AC.
 # Capability-gated: each is created only if the device actually exposes the parameter.
-_AC_SWITCHES: tuple[HonAcSwitchDescription, ...] = (
-    HonAcSwitchDescription(key="sleep", param="silentSleepStatus", icon="mdi:power-sleep"),
-    HonAcSwitchDescription(key="mute", param="muteStatus", icon="mdi:volume-off"),
-    HonAcSwitchDescription(key="eco", param="echoStatus", icon="mdi:leaf"),
-    HonAcSwitchDescription(key="rapid", param="rapidMode", icon="mdi:fan-plus"),
-    HonAcSwitchDescription(key="health", param="healthMode", icon="mdi:heart-pulse"),
-    HonAcSwitchDescription(key="self_clean", param="selfCleaningStatus", icon="mdi:spray-bottle"),
-    HonAcSwitchDescription(key="self_clean_56", param="selfCleaning56Status", icon="mdi:spray"),
-    HonAcSwitchDescription(key="display", param="screenDisplayStatus", icon="mdi:monitor"),
-    HonAcSwitchDescription(key="light", param="lightStatus", icon="mdi:lightbulb"),
-    HonAcSwitchDescription(key="ten_degree_heating", param="10degreeHeatingStatus", icon="mdi:snowflake-melt"),
-    HonAcSwitchDescription(key="child_lock", param="lockStatus", icon="mdi:lock"),
-    HonAcSwitchDescription(key="human_sensing", param="humanSensingStatus", icon="mdi:motion-sensor"),
-    HonAcSwitchDescription(key="electric_heating", param="electricHeatingStatus", icon="mdi:radiator"),
-    HonAcSwitchDescription(key="fresh_air", param="freshAirStatus", icon="mdi:air-filter"),
-    HonAcSwitchDescription(key="half_degree", param="halfDegreeSettingStatus", icon="mdi:thermometer-lines"),
-    HonAcSwitchDescription(key="energy_saving", param="energySavingStatus", icon="mdi:meter-electric"),
+_AC_SWITCHES: tuple[HonSettingsSwitchDescription, ...] = (
+    HonSettingsSwitchDescription(key="sleep", param="silentSleepStatus", icon="mdi:power-sleep"),
+    HonSettingsSwitchDescription(key="mute", param="muteStatus", icon="mdi:volume-off"),
+    HonSettingsSwitchDescription(key="eco", param="echoStatus", icon="mdi:leaf"),
+    HonSettingsSwitchDescription(key="rapid", param="rapidMode", icon="mdi:fan-plus"),
+    HonSettingsSwitchDescription(key="health", param="healthMode", icon="mdi:heart-pulse"),
+    HonSettingsSwitchDescription(key="self_clean", param="selfCleaningStatus", icon="mdi:spray-bottle"),
+    HonSettingsSwitchDescription(key="self_clean_56", param="selfCleaning56Status", icon="mdi:spray"),
+    HonSettingsSwitchDescription(key="display", param="screenDisplayStatus", icon="mdi:monitor"),
+    HonSettingsSwitchDescription(key="light", param="lightStatus", icon="mdi:lightbulb"),
+    HonSettingsSwitchDescription(key="ten_degree_heating", param="10degreeHeatingStatus", icon="mdi:snowflake-melt"),
+    HonSettingsSwitchDescription(key="child_lock", param="lockStatus", icon="mdi:lock"),
+    HonSettingsSwitchDescription(key="human_sensing", param="humanSensingStatus", icon="mdi:motion-sensor"),
+    HonSettingsSwitchDescription(key="electric_heating", param="electricHeatingStatus", icon="mdi:radiator"),
+    HonSettingsSwitchDescription(key="fresh_air", param="freshAirStatus", icon="mdi:air-filter"),
+    HonSettingsSwitchDescription(key="half_degree", param="halfDegreeSettingStatus", icon="mdi:thermometer-lines"),
+    HonSettingsSwitchDescription(key="energy_saving", param="energySavingStatus", icon="mdi:meter-electric"),
 )
+
+
+# Wine cooler (WC) switches: interior light. Ground-truthed on a real HWS77GDAU1 (discussion
+# #62): the settings command carries lightStatus as range[0,1] (writable). Capability-gated
+# like the AC switches, so a WC without a writable lightStatus creates no entity.
+_WC_SWITCHES: tuple[HonSettingsSwitchDescription, ...] = (
+    HonSettingsSwitchDescription(key="light", param="lightStatus", icon="mdi:lightbulb"),
+)
+
+
+# Per-type settings-command switch tables. Every appliance here shares HonSettingsSwitch:
+# each switch reads/writes a 0/1 parameter of the device's `settings` command, capability-gated.
+_SETTINGS_SWITCHES: dict[str, tuple[HonSettingsSwitchDescription, ...]] = {
+    APPLIANCE_AC: _AC_SWITCHES,
+    APPLIANCE_WC: _WC_SWITCHES,
+}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -179,17 +197,17 @@ async def async_setup_entry(
                 app_type,
                 created_opts,
             )
-        elif app_type == APPLIANCE_AC:
+        elif app_type in _SETTINGS_SWITCHES:
             created: list[str] = []
-            for desc in _AC_SWITCHES:
+            for desc in _SETTINGS_SWITCHES[app_type]:
                 # capability-gate: only if the parameter exists in the settings command
                 if settings_param(appliance, desc.param) is None:
                     continue
-                entities.append(HonAcSwitch(coordinator, appliance_id, desc, client))
+                entities.append(HonSettingsSwitch(coordinator, appliance_id, desc, client))
                 created.append(desc.key)
             _LOGGER.debug(
-                "Switch debug: AC '%s' id=%s -> %d switches %s",
-                data.get("name"), redact_id(appliance_id), len(created), created,
+                "Switch debug: settings switches '%s' id=%s type=%s -> %d %s",
+                data.get("name"), redact_id(appliance_id), app_type, len(created), created,
             )
         else:
             _LOGGER.debug("Switch debug: appliance id=%s ignored, type=%s", redact_id(appliance_id), app_type)
@@ -316,10 +334,14 @@ class HonWashingMachinePauseSwitch(HonBaseEntity, SwitchEntity):
         await self._send_pause_command("resumeProgram", "0")
 
 
-class HonAcSwitch(HonBaseEntity, SwitchEntity):
-    """Boolean air conditioner switch on a parameter of the settings command."""
+class HonSettingsSwitch(HonBaseEntity, SwitchEntity):
+    """Boolean switch on a parameter of the `settings` command.
 
-    def __init__(self, coordinator, appliance_id: str, description: HonAcSwitchDescription, client=None) -> None:
+    Serves the air conditioner toggles and the wine-cooler interior light: both write
+    a 0/1 parameter of the same `settings` command and read it back via _get_attr.
+    """
+
+    def __init__(self, coordinator, appliance_id: str, description: HonSettingsSwitchDescription, client=None) -> None:
         super().__init__(coordinator, appliance_id, client)
         self._desc = description
         self._attr_translation_key = description.key
@@ -327,7 +349,7 @@ class HonAcSwitch(HonBaseEntity, SwitchEntity):
         if description.icon:
             self._attr_icon = description.icon
         _LOGGER.debug(
-            "Switch debug: initialized AC switch '%s' id=%s param=%s",
+            "Switch debug: initialized settings switch '%s' id=%s param=%s",
             redact_id(self._attr_unique_id, appliance_id), redact_id(appliance_id), description.param,
         )
 

--- a/tests/fixtures/wc_hws77/settings_command_params.json
+++ b/tests/fixtures/wc_hws77/settings_command_params.json
@@ -1,0 +1,15 @@
+{
+    "_comment": "Real settings-command parameter NAMES of a live Haier wine cooler (model HWS77GDAU1) captured from the redacted config-entry diagnostics dump on 2026-07-21 (discussion #62). Param NAMES only (no values, no identity). Validates that switch.py _WC_SWITCHES param names exist on a real device, so a wrong name (a capability-gated switch that would then never be created) is caught by a test.",
+    "model": "HWS77GDAU1",
+    "type": "WC",
+    "source": "config_entry diagnostics (.data.appliances[].commands.settings), redacted",
+    "captured": "2026-07-21",
+    "settings_command_params": [
+        "category",
+        "lightStatus",
+        "sabbathStatus",
+        "tempSel",
+        "tempSelZ2",
+        "tempUnit"
+    ]
+}

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -590,10 +590,10 @@ class AcClimateWritePathTest(unittest.IsolatedAsyncioTestCase):
     async def test_self_clean_switch_turn_on_still_sets_one(self) -> None:
         settings = RecordingCommand({"selfCleaningStatus": Param("0")})
         coordinator = FakeCoordinator(_ac({"settings": settings}))
-        desc = switch.HonAcSwitchDescription(
+        desc = switch.HonSettingsSwitchDescription(
             key="self_clean", param="selfCleaningStatus"
         )
-        sw = switch.HonAcSwitch(coordinator, "ac-1", desc, FakeClient())
+        sw = switch.HonSettingsSwitch(coordinator, "ac-1", desc, FakeClient())
         sw.hass = FakeHass()
         await sw.async_turn_on()
         self.assertEqual("1", settings.sent["selfCleaningStatus"])
@@ -830,14 +830,14 @@ class AcClimateReadPathTest(unittest.IsolatedAsyncioTestCase):
 
 
 class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
-    """switch.HonAcSwitch send semantics."""
+    """switch.HonSettingsSwitch send semantics."""
 
-    _DESC = switch.HonAcSwitchDescription(key="eco", param="echoStatus", icon="mdi:leaf")
+    _DESC = switch.HonSettingsSwitchDescription(key="eco", param="echoStatus", icon="mdi:leaf")
 
     def _switch(self, params: dict, attributes: dict | None = None, *, failing=False):
         cmd = (FailingCommand if failing else RecordingCommand)(params)
         coordinator = FakeCoordinator(_ac({"settings": cmd}, attributes))
-        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, FakeClient())
+        entity = switch.HonSettingsSwitch(coordinator, "ac-1", self._DESC, FakeClient())
         entity.hass = FakeHass()
         return entity, cmd, coordinator
 
@@ -871,7 +871,7 @@ class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
     async def test_set_param_client_none_raises(self) -> None:
         cmd = RecordingCommand({"echoStatus": Param("0")})
         coordinator = FakeCoordinator(_ac({"settings": cmd}))
-        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, None)
+        entity = switch.HonSettingsSwitch(coordinator, "ac-1", self._DESC, None)
         entity.hass = FakeHass()
         with self.assertRaises(HomeAssistantError) as ctx:
             await entity.async_turn_on()
@@ -884,7 +884,7 @@ class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
     async def test_reraises_domain_error_unchanged(self) -> None:
         cmd = DomainErrorCommand({"echoStatus": Param("0")}, key="inner_sw")
         coordinator = FakeCoordinator(_ac({"settings": cmd}))
-        entity = switch.HonAcSwitch(coordinator, "ac-1", self._DESC, FakeClient())
+        entity = switch.HonSettingsSwitch(coordinator, "ac-1", self._DESC, FakeClient())
         entity.hass = FakeHass()
         with self.assertRaises(HomeAssistantError) as ctx:
             await entity.async_turn_on()

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -856,6 +856,8 @@ class AcSwitchWritePathTest(unittest.IsolatedAsyncioTestCase):
     async def test_is_on_reads_param(self) -> None:
         on, _, _ = self._switch({"echoStatus": Param("1")}, {"echoStatus": "1"})
         off, _, _ = self._switch({"echoStatus": Param("0")}, {"echoStatus": "0"})
+        # not mirrored into the shadow -> honest unknown (we do NOT fall back to the
+        # command value, which the device never refreshes per poll and would be stale)
         absent, _, _ = self._switch({"echoStatus": Param("0")}, {})
         self.assertIs(True, on.is_on)
         self.assertIs(False, off.is_on)

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -79,10 +79,12 @@ class AuthErrorClassificationTest(unittest.TestCase):
         self.assertFalse(hc._requires_reauth(err))
 
     def test_auth_class_but_5xx_does_not_reauth(self) -> None:
-        # Class name = auth, but message 500 -> retryable -> NOT reauth.
-        err = NativeAuthError("boom status 500")
-        self.assertTrue(hc._is_auth_error(err))      # via class name
-        self.assertFalse(hc._requires_reauth(err))   # but retryable wins
+        # Class name = auth, but every 5xx status is retryable -> NOT reauth.
+        for status in (500, 501, 505, 507, 511, 599):
+            err = NativeAuthError(f"boom status {status}")
+            with self.subTest(status=status):
+                self.assertTrue(hc._is_auth_error(err))      # via class name
+                self.assertFalse(hc._requires_reauth(err))   # but retryable wins
 
     def test_message_based_classification_still_works(self) -> None:
         self.assertTrue(hc._is_auth_error(RuntimeError("HTTP 401 unauthorized")))
@@ -119,8 +121,9 @@ class CoordinatorErrorClassificationTest(unittest.TestCase):
         # Auth-named class but a 5xx message -> retryable wins -> NotReady (retry),
         # NOT a reauth prompt.
         _AF, NotReady, _UF, setup, _upd = self._imports()
-        with self.assertRaises(NotReady):
-            setup(NativeAuthError("boom status 500"))
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status), self.assertRaises(NotReady):
+                setup(NativeAuthError(f"boom status {status}"))
 
     def test_update_auth_error_is_config_entry_auth_failed(self) -> None:
         AuthFailed, _NotReady, _UF, _setup, upd = self._imports()
@@ -134,8 +137,9 @@ class CoordinatorErrorClassificationTest(unittest.TestCase):
 
     def test_update_retryable_5xx_is_update_failed_not_auth(self) -> None:
         _AF, _NotReady, UpdateFailed, _setup, upd = self._imports()
-        with self.assertRaises(UpdateFailed):
-            upd(NativeAuthError("boom status 500"))
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status), self.assertRaises(UpdateFailed):
+                upd(NativeAuthError(f"boom status {status}"))
 
     def test_setup_mfa_challenge_is_config_entry_auth_failed(self) -> None:
         # A 2FA challenge during a BACKGROUND setup cannot prompt -> must route to the

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -140,6 +140,24 @@ class CoordinatorConfigEntryTest(unittest.TestCase):
                     _is_redact_mac(kv[field]),
                     f"summary '{field}' must be a redact_mac(...) call",
                 )
+            name_value = kv["name"]
+            self.assertIsInstance(name_value, ast.Call)
+            name_func = name_value.func
+            self.assertTrue(
+                (isinstance(name_func, ast.Name) and name_func.id == "redact_id")
+                or (isinstance(name_func, ast.Attribute) and name_func.attr == "redact_id"),
+                "summary 'name' must be a redact_id(...) call",
+            )
+            self.assertEqual(len(name_value.args), 1)
+            raw_name = name_value.args[0]
+            self.assertIsInstance(raw_name, ast.Call)
+            self.assertIsInstance(raw_name.func, ast.Attribute)
+            self.assertEqual(raw_name.func.attr, "get")
+            self.assertIsInstance(raw_name.func.value, ast.Name)
+            self.assertEqual(raw_name.func.value.id, "appliance_data")
+            self.assertEqual(len(raw_name.args), 1)
+            self.assertIsInstance(raw_name.args[0], ast.Constant)
+            self.assertEqual(raw_name.args[0].value, "name")
 
     def test_manifest_has_no_invalid_homeassistant_key(self) -> None:
         manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -653,6 +653,30 @@ class DiagnosticsCoverageMetaTest(unittest.TestCase):
         self.assertEqual(len(cov["command_params_unmapped"]), cov["command_params_total"])
 
 
+class WcSettingsSwitchCoverageTest(unittest.TestCase):
+    """The wine-cooler light switch writes settings.lightStatus, so lightStatus must be
+    counted as mapped (not falsely reported as an unmapped writable in the gold signal).
+    Regression guard for _mapped_sets/_coverage being AC-only before the WC switch shipped
+    (discussion #62)."""
+
+    def _wc_appliance(self):
+        # Mirrors the real HWS77GDAU1 settings command (tests/fixtures/wc_hws77).
+        return FakeAppliance(commands={"settings": FakeCommand({
+            "lightStatus": FakeParam(value="0", typology="range", rng=(0, 1, 1)),  # WC switch -> mapped
+            "sabbathStatus": FakeParam(value="0", typology="enum", values=["0", "1"]),  # no entity -> signal
+            "tempUnit": FakeParam(value="0", typology="enum", values=["0", "1"]),
+        })})
+
+    def test_lightstatus_in_mapped_params(self):
+        _, mapped_params = diagnostics._mapped_sets("WC")
+        self.assertIn("lightStatus", mapped_params)
+
+    def test_lightstatus_not_reported_unmapped(self):
+        cov = diagnostics._coverage("WC", {}, {}, self._wc_appliance())
+        self.assertNotIn("lightStatus", cov["command_params_unmapped"])
+        self.assertNotIn("lightStatus", cov["command_params_unmapped_meta"])
+
+
 class IdentityKeysDriftGuardTest(unittest.TestCase):
     """The shared log redactor (debug_utils._IDENTITY_KEYS) must redact at least
     everything the Download-Diagnostics path (diagnostics._TO_REDACT) does, so a

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -675,6 +675,9 @@ class WcSettingsSwitchCoverageTest(unittest.TestCase):
         cov = diagnostics._coverage("WC", {}, {}, self._wc_appliance())
         self.assertNotIn("lightStatus", cov["command_params_unmapped"])
         self.assertNotIn("lightStatus", cov["command_params_unmapped_meta"])
+        # positive control: an un-mapped writable IS still reported, proving the coverage
+        # machinery ran and the lists are populated (guards against a vacuous pass).
+        self.assertIn("sabbathStatus", cov["command_params_unmapped"])
 
 
 class IdentityKeysDriftGuardTest(unittest.TestCase):

--- a/tests/test_engine_appliances.py
+++ b/tests/test_engine_appliances.py
@@ -15,7 +15,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _golden import REPO, frozen, install_stubs, normalize  # noqa: E402
+from _golden import frozen, install_stubs, normalize  # noqa: E402
 
 install_stubs()
 

--- a/tests/test_entity_translation_keys.py
+++ b/tests/test_entity_translation_keys.py
@@ -210,10 +210,11 @@ def _collect_code_keys() -> dict[str, set[str]]:
     used["number"] = {
         _tk(d) for descs in number.NUMBERS.values() for d in descs
     } | {d.translation_key for d in number._PROGRAM_OPTION_NUMBERS}
-    # HonAcSwitch names from description.key; the pause + debug switches use fixed keys;
-    # the program-option switches (#35) come from their description key.
+    # HonSettingsSwitch names from description.key (AC toggles + wine-cooler light); the
+    # pause + debug switches use fixed keys; the program-option switches (#35) come from
+    # their description key.
     used["switch"] = (
-        {d.key for d in switch._AC_SWITCHES}
+        {d.key for descs in switch._SETTINGS_SWITCHES.values() for d in descs}
         | {d.key for d in switch._PROGRAM_OPTION_SWITCHES}
         | {"pause", "debug_logging", "mqtt_realtime_debug"}
     )

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -158,6 +158,16 @@ class ClassifyTest(unittest.TestCase):
                 self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
                 self.assertTrue(hc._requires_reauth(err))
 
+    def test_rate_limit_status_does_not_accept_longer_identifiers(self) -> None:
+        # 429 must match only as a standalone HTTP status, not embedded in longer tokens
+        # (mirror of the 5xx guard; _HTTP_STATUS_RE also feeds is_rate_limited_text).
+        for token in ("H429", "X429Y", "4290", "1429", "428", "430"):
+            with self.subTest(token=token):
+                err = NativeAuthError(f"api_auth: model {token} unavailable")
+                self.assertFalse(ec.is_rate_limited_text(str(err)))
+                self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
+                self.assertTrue(hc._requires_reauth(err))
+
     def test_network_classes(self) -> None:
         self.assertIs(ec.classify(RuntimeError("certificate verify failed")), ec.TLS_FAILURE)
         self.assertIs(ec.classify(RuntimeError("getaddrinfo failed")), ec.DNS_FAILURE)

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -113,8 +113,50 @@ class ClassifyTest(unittest.TestCase):
 
     def test_server_and_rate_limit_win_over_auth_name(self) -> None:
         # Retryable 5xx / 429 must beat the auth-named class (existing routing rule).
-        self.assertIs(ec.classify(NativeAuthError("boom status 500")), ec.SERVER_ERROR)
+        for status in range(500, 600):
+            err = NativeAuthError(f"api_auth: status {status}")
+            with self.subTest(status=status):
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
         self.assertIs(ec.classify(NativeAuthError("429 too many requests")), ec.RATE_LIMITED)
+
+    def test_server_status_format_variants(self) -> None:
+        for message in (
+            "api_auth: status=501",
+            "api_auth: HTTP 505",
+            "api_auth: response (507)",
+            "api_auth: upstream [511]",
+            "599 server response",
+        ):
+            with self.subTest(message=message):
+                err = NativeAuthError(message)
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
+
+    def test_textual_server_errors_are_case_insensitive(self) -> None:
+        for message in (
+            "hOn server error",
+            "Internal Server Error",
+            "Bad Gateway",
+            "Gateway Timeout",
+            "Temporarily Unavailable",
+        ):
+            with self.subTest(message=message):
+                err = NativeAuthError(message)
+                self.assertIs(ec.classify(err), ec.SERVER_ERROR)
+                self.assertFalse(hc._requires_reauth(err))
+
+        rate_limit = NativeAuthError("Too Many Requests")
+        self.assertIs(ec.classify(rate_limit), ec.RATE_LIMITED)
+        self.assertFalse(hc._requires_reauth(rate_limit))
+
+    def test_status_matching_does_not_accept_longer_identifiers(self) -> None:
+        # Model/id-like and out-of-range tokens must not masquerade as an HTTP 5xx.
+        for token in ("H500", "X599Y", "5000", "1500", "499", "600"):
+            with self.subTest(token=token):
+                err = NativeAuthError(f"api_auth: model {token} unavailable")
+                self.assertIs(ec.classify(err), ec.AUTH_API_AUTH)
+                self.assertTrue(hc._requires_reauth(err))
 
     def test_network_classes(self) -> None:
         self.assertIs(ec.classify(RuntimeError("certificate verify failed")), ec.TLS_FAILURE)

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -12,7 +12,6 @@ test_coordinator_config_entry.py).
 from __future__ import annotations
 
 import asyncio
-import logging
 import sys
 import types
 import unittest

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -281,8 +281,6 @@ class MfaResumeTest(unittest.TestCase):
     def test_remoting_debug_line_is_redacted(self) -> None:
         # With DEBUG on, the remoting breadcrumb runs and emits the method + redacted
         # summary, never the response body/secret.
-        import logging
-
         auth = self._auth([FakeResp(text='[{"result":false,"message":"SECRET-MSG"}]')])
         with self.assertLogs(
             "custom_components.addhon.client.transport.auth", level="DEBUG"

--- a/tests/test_switch_params.py
+++ b/tests/test_switch_params.py
@@ -15,7 +15,6 @@ stack); no real Home Assistant install required.
 """
 from __future__ import annotations
 
-import dataclasses
 import json
 import sys
 import types

--- a/tests/test_switch_params.py
+++ b/tests/test_switch_params.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2026 tis24dev
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Validate that switch.py `_AC_SWITCHES` `param` names exist on a real Haier AC.
+"""Validate that switch.py settings-command `param` names exist on real Haier devices
+(AC via `_AC_SWITCHES`, wine cooler via `_WC_SWITCHES`).
 
 The per-type entity tests validate the entity `key` (the slug) but NOT the `param`
 (the Haier command-parameter name the switch reads/writes). A wrong `param` makes a
@@ -26,6 +27,7 @@ if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
 _AC_FIXTURE = REPO / "tests" / "fixtures" / "ac_as35" / "settings_command_params.json"
+_WC_FIXTURE = REPO / "tests" / "fixtures" / "wc_hws77" / "settings_command_params.json"
 
 
 def _mod(name: str) -> types.ModuleType:
@@ -111,6 +113,11 @@ def _real_ac_settings_params() -> set[str]:
     return set(data["settings_command_params"])
 
 
+def _real_wc_settings_params() -> set[str]:
+    data = json.loads(_WC_FIXTURE.read_text(encoding="utf-8"))
+    return set(data["settings_command_params"])
+
+
 class AcSwitchParamRealityTest(unittest.TestCase):
     """The `param` of every AC switch must exist in a real AC's settings schema."""
 
@@ -166,6 +173,52 @@ class AcSwitchPinTest(unittest.TestCase):
 
     def test_ac_switches_pinned(self):
         actual = {desc.key: desc.param for desc in switch._AC_SWITCHES}
+        self.assertEqual(actual, self._PINNED)
+
+
+class WcSwitchParamRealityTest(unittest.TestCase):
+    """The `param` of every wine-cooler switch must exist in a real WC settings schema.
+
+    Fixture tests/fixtures/wc_hws77/, captured live on 2026-07-21 from an HWS77GDAU1
+    (discussion #62), guards against a wrong param name that would make a capability-gated
+    switch silently never created on any wine cooler.
+    """
+
+    def test_every_wc_switch_param_exists_on_real_device(self):
+        real = _real_wc_settings_params()
+        missing = {desc.param for desc in switch._WC_SWITCHES} - real
+        self.assertEqual(
+            missing,
+            set(),
+            "These _WC_SWITCHES params are absent from the real HWS77GDAU1 settings schema "
+            "(a capability-gated switch would then NEVER be created on any wine cooler): "
+            f"{sorted(missing)}. Verify against a real device before changing.",
+        )
+
+    def test_fixture_is_sane(self):
+        # Guard against an empty/garbled fixture silently passing the check above.
+        real = _real_wc_settings_params()
+        self.assertGreater(len(real), 3)
+        self.assertIn("lightStatus", real)  # the writable interior-light param (range[0,1])
+
+    def test_wc_switch_keys_and_params_unique(self):
+        keys = [desc.key for desc in switch._WC_SWITCHES]
+        params = [desc.param for desc in switch._WC_SWITCHES]
+        self.assertEqual(len(keys), len(set(keys)), "duplicate WC switch key")
+        self.assertEqual(len(params), len(set(params)), "duplicate WC switch param")
+
+
+class WcSwitchPinTest(unittest.TestCase):
+    """Drift guard: the wine-cooler (key -> param) mapping is pinned to the value verified
+    against a real HWS77GDAU1 diagnostics dump on 2026-07-21 (discussion #62). Any change
+    here must be re-verified against a real device (see the reality test above)."""
+
+    _PINNED = {
+        "light": "lightStatus",
+    }
+
+    def test_wc_switches_pinned(self):
+        actual = {desc.key: desc.param for desc in switch._WC_SWITCHES}
         self.assertEqual(actual, self._PINNED)
 
 

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
-import re
 import sys
 import types
 import unittest

--- a/tests/test_transport_mqtt.py
+++ b/tests/test_transport_mqtt.py
@@ -363,10 +363,17 @@ class CreatePathTest(unittest.TestCase):
             _run(load(Api(result="")))
         self.assertIs(empty.exception.error_code, AWS_TOKEN_FAILED)
 
-        with self.assertRaises(mod.MqttStartupUnavailable) as outage:
-            _run(load(Api(error=RuntimeError("hOn server error (status 503)"))))
-        self.assertIs(outage.exception.error_code, SERVER_ERROR)
-        self.assertIsInstance(outage.exception.__cause__, RuntimeError)
+        for status in (500, 501, 505, 507, 511, 599):
+            with self.subTest(status=status):
+                with self.assertRaises(mod.MqttStartupUnavailable) as outage:
+                    _run(load(Api(error=RuntimeError(f"api_auth: status {status}"))))
+                self.assertIs(outage.exception.error_code, SERVER_ERROR)
+                self.assertIsInstance(outage.exception.__cause__, RuntimeError)
+
+        with self.assertRaises(mod.MqttStartupUnavailable) as textual_outage:
+            _run(load(Api(error=RuntimeError("hOn Internal Server Error"))))
+        self.assertIs(textual_outage.exception.error_code, SERVER_ERROR)
+        self.assertIsInstance(textual_outage.exception.__cause__, RuntimeError)
 
         with self.assertRaises(mod.MqttStartupUnavailable) as malformed:
             _run(load(Api(error=json.JSONDecodeError("Expecting value", "", 0))))


### PR DESCRIPTION
Automated release PR for `v5.9.0`.

<!-- release-tag: v5.9.0 -->

## Summary by Sourcery

Add wine-cooler support and harden error handling, diagnostics, and identity redaction for the v5.9.0 release.

New Features:
- Expose a wine-cooler interior light switch using the shared settings-command switch abstraction.
- Extend diagnostics coverage and reporting to include wine-cooler settings parameters so mapped/unmapped commands are correctly tracked.

Enhancements:
- Generalize the air-conditioner settings switch abstraction into a reusable HonSettingsSwitch for all 0/1 settings-command toggles.
- Improve HTTP error classification and retry logic by centralizing rate-limit and server-failure detection with robust status parsing and case-insensitive textual matching.
- Strengthen coordinator diagnostics summaries by redacting appliance names through the shared identity redactor.
- Tidy test modules and helper imports for the engine, MFA, realtime client, and transport API tests.

Build:
- Bump the integration manifest version to 5.9.0 for the new release.

Documentation:
- Clarify module and class docstrings to describe the generalized settings-command switches for AC and wine coolers and document the new error-handling behavior.

Tests:
- Add fixtures and reality/drift-guard tests for wine-cooler settings-command parameters and the light switch mapping.
- Expand tests around HTTP 5xx/429 error classification, retry behavior, and MQTT startup error routing.
- Update AC switch write-path, translation-key, diagnostics coverage, auth error classification, and MQTT transport tests to reflect the new settings-switch abstraction and error helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wine-cooler interior light controls.
  * Expanded settings-based switch support across compatible appliances.

* **Bug Fixes**
  * Improved handling of rate-limit and server errors, including retry and authentication behavior.
  * Redacted appliance names in device summaries and diagnostics.

* **Maintenance**
  * Updated the component version to 5.9.0.
  * Expanded validation and regression coverage for switches, diagnostics, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the add-on for v5.9.0 with wine-cooler controls and broader error handling.

- Adds a wine-cooler interior-light switch through the shared settings-switch abstraction.
- Extends diagnostics mapping and appliance-name redaction.
- Improves HTTP rate-limit and server-error classification.
- Updates tests, fixtures, and the integration version.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The wine-cooler switch state remains available through the existing settings-to-attributes merge.
- The diagnostics registry uses the expected per-appliance data shape.
- No blocking issue remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/switch.py | Generalizes settings-command switches and adds the capability-gated wine-cooler light control. |
| custom_components/addhon/diagnostics.py | Extends mapped settings-switch parameters to wine coolers. |
| custom_components/addhon/error_codes.py | Centralizes retryable HTTP status and message classification. |
| custom_components/addhon/hon_client.py | Uses the shared HTTP error helpers for retry decisions. |
| custom_components/addhon/__init__.py | Redacts appliance names in coordinator diagnostic summaries. |

<sub>Reviews (2): Last reviewed commit: ["fix(review): address PR #65 review comme..."](https://github.com/tis24dev/addhon/commit/9c34277aa161fd97ae0c527ddccd445015a393dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45949676)</sub>

<!-- /greptile_comment -->