### PR TITLE
Release v5.9.1

### DIFF
--- a/custom_components/addhon/client/engine/appliance.py
+++ b/custom_components/addhon/client/engine/appliance.py
@@ -366,6 +366,10 @@ class HonAppliance:
                 new := self.attributes.get("parameters", {}).get(key)
             ) is None or new.value == "":
                 continue
+            setting = command.settings.get(key)
+            if setting is None:
+                continue
+            raw = str(new.value)
             try:
                 # Always assign as a STRING (range params included): the range
                 # setter runs str_to_float, which tries int() first, so a float
@@ -374,7 +378,20 @@ class HonAppliance:
                 # rules.py._apply_fixed). A string preserves the decimals, so a
                 # half-degree setpoint is not silently rounded when synced into
                 # the command and later re-sent to the cloud.
-                command.settings[key].value = str(new.value)
+                setting.value = raw
             except ValueError as error:
-                _LOGGER.info("Can't set %s - %s", key, error)
+                # The device shadow can report an OFF-GRID value for a range setpoint
+                # (a measured 17.2 for a step-1 target). Skipping would leave the command
+                # at its load-time default (min), which a later FULL-command send writes
+                # back to the device -- clobbering the real setpoint (both wine-cooler
+                # zones snapped to 5C when the light switch fired, discussion #62). Snap
+                # the shadow value onto the grid so the command carries the true setpoint.
+                snap = getattr(setting, "snap_to_grid", None)
+                if callable(snap):
+                    try:
+                        setting.value = snap(raw)
+                        continue
+                    except ValueError:
+                        pass
+                _LOGGER.info("Can't sync %s from shadow %r - %s", key, raw, error)
                 continue

--- a/custom_components/addhon/client/engine/parameter/range.py
+++ b/custom_components/addhon/client/engine/parameter/range.py
@@ -130,23 +130,29 @@ class HonParameterRange(HonParameter):
         return abs(self.min + index * step - value) <= self._grid_eps(step)
 
     def snap_to_grid(self, value: str | float) -> float:
-        """Nearest in-range value that lands on the min/step grid.
+        """Nearest grid value for an IN-RANGE off-grid input.
 
-        Used to sync a device shadow value that is off-grid (e.g. a measured ``17.2`` for a
-        step-1 setpoint) INTO the command without tripping the setter's off-grid ValueError.
-        The setter itself must keep raising -- the climate/number entities rely on it for
-        rollback -- so snapping stays here and is applied explicitly by
-        ``sync_params_to_command``, never implicitly in the setter.
+        Used to sync a device shadow value that is off-grid but within range (e.g. a measured
+        ``17.2`` for a step-1 setpoint in 5..20) INTO the command without tripping the setter's
+        off-grid ValueError. Snapping stays here, never in the setter -- the climate/number
+        entities rely on the setter's ValueError for rollback.
+
+        Raises ``ValueError`` if the value is OUT of ``[min, max]``: a value outside the range
+        signals stale/mismatched local metadata, and clamping it to a boundary and re-sending
+        would overwrite whatever (possibly user-set) value the command currently holds. The
+        caller (``sync_params_to_command``) instead skips it and keeps the command's value.
         """
         v = str_to_float(str(value))
-        v = min(self.max, max(self.min, v))
+        if not self.min <= v <= self.max:
+            raise ValueError(f"Out of range: {v} not in [{self.min}, {self.max}]")
         step = self.step
         if step <= 0:
             return v
         # FLOOR the top index (not round): the last grid point must never exceed max, or
         # the setter's min<=value<=max check would reject the snapped value and the caller
         # would fall back to the default. The shared grid epsilon keeps an on-grid max from
-        # being dropped by float drift. The final min(max, ...) is a defensive clamp.
+        # being dropped by float drift. The final min(max, ...) is a defensive clamp for the
+        # <= eps overshoot on an on-grid max; v is already guaranteed in range above.
         max_index = max(0, int((self.max - self.min + self._grid_eps(step)) / step))
         index = min(max_index, max(0, round((v - self.min) / step)))
         return min(self.max, self.min + index * step)

--- a/custom_components/addhon/client/engine/parameter/range.py
+++ b/custom_components/addhon/client/engine/parameter/range.py
@@ -129,6 +129,28 @@ class HonParameterRange(HonParameter):
         index = round((value - self.min) / step)
         return abs(self.min + index * step - value) <= self._grid_eps(step)
 
+    def snap_to_grid(self, value: str | float) -> float:
+        """Nearest in-range value that lands on the min/step grid.
+
+        Used to sync a device shadow value that is off-grid (e.g. a measured ``17.2`` for a
+        step-1 setpoint) INTO the command without tripping the setter's off-grid ValueError.
+        The setter itself must keep raising -- the climate/number entities rely on it for
+        rollback -- so snapping stays here and is applied explicitly by
+        ``sync_params_to_command``, never implicitly in the setter.
+        """
+        v = str_to_float(str(value))
+        v = min(self.max, max(self.min, v))
+        step = self.step
+        if step <= 0:
+            return v
+        # FLOOR the top index (not round): the last grid point must never exceed max, or
+        # the setter's min<=value<=max check would reject the snapped value and the caller
+        # would fall back to the default. The shared grid epsilon keeps an on-grid max from
+        # being dropped by float drift. The final min(max, ...) is a defensive clamp.
+        max_index = max(0, int((self.max - self.min + self._grid_eps(step)) / step))
+        index = min(max_index, max(0, round((v - self.min) / step)))
+        return min(self.max, self.min + index * step)
+
     def _grid_eps(self, step: float) -> float:
         """Snap/enumeration tolerance for the min/step grid, capped to a fraction of step.
 

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.9.0"
+  "version": "5.9.1"
 }

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -544,6 +544,28 @@ class ClusterBehaviorTest(unittest.TestCase):
         app.sync_params_to_command("settings")
         self.assertEqual(command.settings["temp"].value, 22.5)
 
+    def test_sync_params_to_command_snaps_off_grid_shadow(self) -> None:
+        # REGRESSION (discussion #62): a wine cooler reports its setpoint OFF-GRID in the
+        # shadow (a measured 17.2 for a step-1 tempSel). The old code let the range setter
+        # raise on 17.2 and then SKIPPED the key, leaving the command at its load-time
+        # default (min=5). A later full-command send (fired by the light switch) then wrote
+        # 5C back to the device, clobbering the real setpoint. The fix snaps the off-grid
+        # shadow value onto the grid so the command carries the true setpoint (17), not 5.
+        from custom_components.addhon.client.engine.attributes import HonAttribute
+
+        command = NaCommand(
+            "settings",
+            {"parameters": {"tempSel": _range(default="5", lo="5", hi="20", inc="1")}},
+            FakeAppliance(),
+        )
+        app = NaAppliance(FakeApi(), dict(_INFO), zone=0)
+        app._commands = {"settings": command}
+        # sanity: without a sync the command sits at the min default, not the real setpoint
+        self.assertEqual(command.settings["tempSel"].value, 5)
+        app._attributes = {"parameters": {"tempSel": HonAttribute({"parNewVal": "17.2"})}}
+        app.sync_params_to_command("settings")
+        self.assertEqual(command.settings["tempSel"].value, 17)
+
     def test_ac_eco_nested_rule_fires(self) -> None:
         # REAL AC structure (apk/dump/ac_live): ecoMode=1 with machMode fixed=1
         # must constrain tempSel to 26 and the wind-direction (nested extra-condition).

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -566,6 +566,24 @@ class ClusterBehaviorTest(unittest.TestCase):
         app.sync_params_to_command("settings")
         self.assertEqual(command.settings["tempSel"].value, 17)
 
+    def test_sync_params_out_of_range_shadow_keeps_command_value(self) -> None:
+        # GUARD (PR #66 review): an OUT-OF-RANGE shadow value (stale local metadata) must NOT
+        # be snapped/clamped into the command, or a later send would overwrite the command's
+        # current (here user-set) value with a boundary guess. Sync leaves the command as-is.
+        from custom_components.addhon.client.engine.attributes import HonAttribute
+
+        command = NaCommand(
+            "settings",
+            {"parameters": {"tempSel": _range(default="5", lo="5", hi="20", inc="1")}},
+            FakeAppliance(),
+        )
+        app = NaAppliance(FakeApi(), dict(_INFO), zone=0)
+        app._commands = {"settings": command}
+        command.settings["tempSel"].value = "18"   # a good, user-set value on the command
+        app._attributes = {"parameters": {"tempSel": HonAttribute({"parNewVal": "25"})}}
+        app.sync_params_to_command("settings")
+        self.assertEqual(command.settings["tempSel"].value, 18)  # preserved, not clamped to 20
+
     def test_ac_eco_nested_rule_fires(self) -> None:
         # REAL AC structure (apk/dump/ac_live): ecoMode=1 with machMode fixed=1
         # must constrain tempSel to 26 and the wind-direction (nested extra-condition).

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -303,10 +303,20 @@ class RangeSnapToGridTest(unittest.TestCase):
         self.assertEqual(p.snap_to_grid("12.2"), 12)
         self.assertEqual(p.snap_to_grid(17.6), 18)     # rounds to nearest
 
-    def test_snaps_within_bounds(self) -> None:
+    def test_out_of_range_raises_not_clamped(self) -> None:
+        # An out-of-range shadow value (stale metadata) must NOT be clamped to a boundary:
+        # clamping + a later send would overwrite the command's current (possibly user-set)
+        # value. snap raises so sync_params_to_command skips it and keeps the command value.
         p = self._range("5", "20", "1")
-        self.assertEqual(p.snap_to_grid("2"), 5)       # below min -> clamp to min
-        self.assertEqual(p.snap_to_grid("99"), 20)     # above max -> clamp to max
+        with self.assertRaises(ValueError):
+            p.snap_to_grid("2")    # below min
+        with self.assertRaises(ValueError):
+            p.snap_to_grid("99")   # above max
+
+    def test_non_numeric_raises(self) -> None:
+        p = self._range("5", "20", "1")
+        with self.assertRaises(ValueError):
+            p.snap_to_grid("bad")
 
     def test_on_grid_value_unchanged(self) -> None:
         p = self._range("16", "30", "0.5")

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -286,6 +286,54 @@ class RangeGridSetterTest(unittest.TestCase):
         self.assertLessEqual(len(p.values), _MAX_RANGE_VALUES)
 
 
+class RangeSnapToGridTest(unittest.TestCase):
+    """snap_to_grid returns the nearest in-range grid value so an off-grid device shadow
+    value (e.g. a measured 17.2 for a step-1 setpoint) can be synced into the command
+    without leaving it at the default (discussion #62). The setter still raises on the raw
+    off-grid value -- snap is applied explicitly, never implicitly in the setter."""
+
+    def _range(self, lo, hi, step):
+        return NaRange("temp", {"category": "command", "typology": "range",
+                                "mandatory": 0, "minimumValue": lo, "maximumValue": hi,
+                                "incrementValue": step, "defaultValue": lo}, "grp")
+
+    def test_snaps_off_grid_to_nearest(self) -> None:
+        p = self._range("5", "20", "1")
+        self.assertEqual(p.snap_to_grid("17.2"), 17)   # the #62 case
+        self.assertEqual(p.snap_to_grid("12.2"), 12)
+        self.assertEqual(p.snap_to_grid(17.6), 18)     # rounds to nearest
+
+    def test_snaps_within_bounds(self) -> None:
+        p = self._range("5", "20", "1")
+        self.assertEqual(p.snap_to_grid("2"), 5)       # below min -> clamp to min
+        self.assertEqual(p.snap_to_grid("99"), 20)     # above max -> clamp to max
+
+    def test_on_grid_value_unchanged(self) -> None:
+        p = self._range("16", "30", "0.5")
+        self.assertEqual(p.snap_to_grid("22.5"), 22.5)  # already on grid, exact
+
+    def test_off_grid_max_never_exceeds_max(self) -> None:
+        # max not on the min/step grid: snapping a near-max value must stay <= max and land
+        # on the grid (last valid point), never round UP past max (which the setter would
+        # then reject, re-creating the #62 default-fallback). Grid tops out below max.
+        p = self._range("5", "22", "3")            # grid: 5,8,11,14,17,20 (23 > 22)
+        self.assertEqual(p.snap_to_grid("22"), 20)
+        p.value = p.snap_to_grid("22")             # must be setter-accepted
+        self.assertEqual(p.value, 20)
+        q = self._range("0", "9.6", "1")           # grid: 0..9 (10 > 9.6)
+        self.assertEqual(q.snap_to_grid("9.6"), 9)
+        q.value = q.snap_to_grid("9.6")
+        self.assertEqual(q.value, 9)
+
+    def test_snapped_value_is_accepted_by_setter(self) -> None:
+        # the whole point: the snapped result must pass the setter that rejected the raw one
+        p = self._range("5", "20", "1")
+        with self.assertRaises(ValueError):
+            p.value = "17.2"
+        p.value = p.snap_to_grid("17.2")
+        self.assertEqual(p.value, 17)
+
+
 class RangeSetterHardeningTest(unittest.TestCase):
     """ITEM A: a fractional float assigned DIRECTLY to the range setter must not be
     truncated. The setter delegated to str_to_float, whose int()-first quirk turned a


### PR DESCRIPTION
Automated release PR for `v5.9.1`.

<!-- release-tag: v5.9.1 -->

## Summary by Sourcery

Align range parameter syncing with device shadows by snapping off-grid shadow values onto the range grid so commands reflect the actual setpoints, and bump the integration version to v5.9.1.

New Features:
- Add a snap_to_grid helper on range parameters to derive the nearest in-range grid value from an off-grid input.

Bug Fixes:
- Ensure sync_params_to_command snaps off-grid shadow values for range parameters instead of falling back to default minimums, preventing unintended setpoint resets.

Tests:
- Add unit tests for snap_to_grid behavior on range parameters, including bounds handling and setter acceptance.
- Add a regression test for syncing off-grid shadow range values into commands to verify correct snapping and prevent default fallback.

Chores:
- Update the addhon integration manifest version from 5.9.0 to 5.9.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of appliance settings when values are missing, unknown, or not aligned with permitted increments.
  * Off-grid numeric values are now adjusted to the nearest valid setting, while values outside allowed limits are clamped safely.
  * Added clearer handling when a setting value cannot be applied.

* **Tests**
  * Added coverage for grid snapping, boundary values, and shadow-setting synchronization.

* **Chores**
  * Updated the integration version to 5.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns range parameter syncing with device shadows and releases version 5.9.1. The main changes are:

- Snap in-range, off-grid shadow values to valid range steps.
- Reject out-of-range shadow values instead of clamping them.
- Add tests for snapping, bounds, parsing, and command syncing.
- Bump the integration version to 5.9.1.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue qualifies for this follow-up review.

- The updated range setter path preserves its stored value when validation fails.
- The snapping helper returns values accepted by the existing range validation.
- No separate production failure remained after applying the follow-up selection scope.

<sub>Reviews (2): Last reviewed commit: ["fix(engine): don&#39;t clamp out-of-range sh..."](https://github.com/tis24dev/addhon/commit/5b74e14b73caf516feb82e4e60093bdee0c309c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46109577)</sub>

<!-- /greptile_comment -->