### PR TITLE
Release v5.9.3

### DIFF
--- a/custom_components/addhon/client/auth_diagnostics.py
+++ b/custom_components/addhon/client/auth_diagnostics.py
@@ -579,7 +579,13 @@ class _ShapeParser(HTMLParser):
         )
         self.normalized.append(f"{safe_tag}[{','.join(safe_attrs)}]")
         self.tags += 1
-        mapping = {str(name).lower(): str(value or "") for name, value in attrs}
+        # Only these three read the attributes, and the Lightning login page carries
+        # thousands of tags: building the mapping for all of them is pure waste.
+        mapping = (
+            {str(name).lower(): str(value or "") for name, value in attrs}
+            if tag in {"form", "input", "meta"}
+            else {}
+        )
         if tag == "form":
             self.forms += 1
             # FIRST form only: the one the user would have to submit. Keyed off a flag,
@@ -676,7 +682,7 @@ def _parse(source: str) -> tuple[_ShapeParser, bool]:
     try:
         parser.feed(source)
         parser.close()
-    except Exception:
+    except Exception:  # noqa: BLE001 - diagnostics are observational, never fatal
         parse_error = True
     return parser, parse_error
 
@@ -825,7 +831,7 @@ def analyze_page(url: Any, text: Any) -> tuple[HtmlSummary, PageSummary]:
             _html_summary(source, parser, parse_error),
             _page_summary(url, source, parser),
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - diagnostics are observational, never fatal
         empty = _ShapeParser()
         return _html_summary("", empty, True), _page_summary("", "", empty)
 

--- a/custom_components/addhon/client/auth_diagnostics.py
+++ b/custom_components/addhon/client/auth_diagnostics.py
@@ -56,6 +56,13 @@ _ENDPOINTS = frozenset(
         "external",
         "other",
         "none",
+        # Post-login interstitials the flow can be diverted to (issue #67). Named so a
+        # landing page that is NOT the token redirect is identifiable from the trace.
+        "change_password",
+        "set_password",
+        "reset_password",
+        "secur",
+        "apex_page",
     }
 )
 _MEDIA_TYPES = frozenset(
@@ -74,6 +81,7 @@ _CHARSETS = frozenset({"utf-8", "utf8", "us-ascii", "iso-8859-1"})
 _REASONS = frozenset(
     {
         "incomplete_tokens",
+        "account_action",
         "no_href",
         "status",
         "no_login_url",
@@ -157,6 +165,146 @@ _TOKEN_RE = re.compile(
 )
 _CODE_RE = re.compile(r"^ADDHON-\d{3}$")
 
+# -- Page-identity vocabulary (issue #67) -------------------------------------
+# A sign-in that dies on "incomplete tokens" is only actionable if the trace says WHICH
+# page the flow landed on. These allowlists turn a page into named structure: nothing
+# outside them is ever emitted (unknown material is only COUNTED), so the identity of
+# an unexpected interstitial is readable without shipping URL, markup or text.
+
+# Path segments the login flow can legitimately reach (Salesforce Experience Cloud /
+# VisualForce URL space). Anything else is counted as an unknown segment.
+_PATH_SEGMENTS = frozenset(
+    {
+        "apex",
+        "aura",
+        "authorize",
+        "changepassword",
+        "checkpasswordresetstatus",
+        "consent",
+        "expid_login",
+        "finaltok",
+        "forgotpassword",
+        "frontdoor",
+        "identity",
+        "login",
+        "newhonlogin",
+        "oauth2",
+        "privacy",
+        "profile",
+        "progressivelogin",
+        "register",
+        "registration",
+        "reset",
+        "resetpassword",
+        "s",
+        "secur",
+        "selfregister",
+        "services",
+        "setpassword",
+        "sfsites",
+        "terms",
+        "token",
+        "verify",
+        "vforcesite",
+    }
+)
+# Query-parameter NAMES worth naming (values are never read).
+_QUERY_NAMES = frozenset(
+    {
+        "client_id",
+        "code",
+        "display",
+        "ec",
+        "error",
+        "error_description",
+        "expid",
+        "inst",
+        "isdtp",
+        "language",
+        "locale",
+        "nonce",
+        "redirect_uri",
+        "registrationsubchannel",
+        "response_type",
+        "returl",
+        "scope",
+        "sid",
+        "startpage",
+        "starturl",
+        "state",
+        "system",
+        "un",
+    }
+)
+# Presence vocabulary, PREFIX-matched against the page's VISIBLE text only (script and
+# style bodies excluded). Authored words carry no account material, and they are what
+# separates a forced password change from a consent wall or a lock-out.
+_TEXT_MARKERS = (
+    "accept",
+    "agree",
+    "blocked",
+    "captcha",
+    "challeng",
+    "complet",
+    "confirm",
+    "consent",
+    "continu",
+    "disabl",
+    "error",
+    "expir",
+    "inactiv",
+    "invalid",
+    "locked",
+    "maintenance",
+    "mandator",
+    "migrat",
+    "otp",
+    "passphrase",
+    "password",
+    "polic",
+    "privacy",
+    "profil",
+    "registr",
+    "renew",
+    "requir",
+    "reset",
+    "session",
+    "suspend",
+    "terms",
+    "unauthor",
+    "unavailab",
+    "updat",
+    "verif",
+    "welcome",
+)
+_JS_REDIRECT_MARKERS = (
+    "location.replace",
+    "location.assign",
+    "location.href",
+    "window.location",
+)
+_PASSWORD_KINDS = frozenset(
+    {"password", "new_password", "confirm_password", "current_password"}
+)
+_MAX_MARKERS = 25
+_MAX_SKELETON_NODES = 60
+_TEXT_SCAN_CHARS = 40_000
+_TITLE_SCAN_CHARS = 200
+# Why a token page carried no tokens. Controlled vocabulary: the two ACCOUNT_ACTION
+# verdicts are the ones the user can act on, so they escalate to their own error code.
+_TOKEN_PAGE_VERDICTS = frozenset(
+    {
+        "password_change",
+        "consent",
+        "login",
+        "mfa",
+        "token_link_unparsed",
+        "empty",
+        "unknown",
+    }
+)
+ACCOUNT_ACTION_VERDICTS = frozenset({"password_change", "consent"})
+
 
 def _enum(value: Any, allowed: frozenset[str], fallback: str = "other") -> str:
     candidate = str(value or "").lower()
@@ -193,6 +341,14 @@ def classify_endpoint(url: Any) -> str:
         return "authorize"
     if path.endswith("/services/oauth2/token"):
         return "token_refresh"
+    # Post-login interstitials (issue #67): checked BEFORE the generic login/apex rules
+    # so a forced password step is named instead of collapsing into "auth_other".
+    if "changepassword" in path or "change_password" in path:
+        return "change_password"
+    if "setpassword" in path or "set_password" in path:
+        return "set_password"
+    if "forgotpassword" in path or "resetpassword" in path or "passwordreset" in path:
+        return "reset_password"
     if "/s/login/" in path:
         return "login"
     if path.endswith("/s/sfsites/aura"):
@@ -201,6 +357,10 @@ def classify_endpoint(url: Any) -> str:
         return "mfa_remoting"
     if path.endswith("/auth/v1/login"):
         return "api_auth"
+    if "/secur/" in path or path.endswith("/frontdoor.jsp"):
+        return "secur"
+    if "/apex/" in path:
+        return "apex_page"
     if not host and not path:
         return "none"
     if host == "account2.hon-smarthome.com" or host.endswith(".salesforce.com"):
@@ -215,6 +375,10 @@ def classify_endpoint(url: Any) -> str:
 def classify_failure_reason(error: BaseException) -> str:
     """Map an exception to a controlled reason without retaining its message."""
     message = str(error).lower()
+    # Checked before the token reasons: the account-action failure IS a token-page
+    # failure, but the reason must say the account needs a user step (issue #67).
+    if "account action required" in message:
+        return "account_action"
     if "incomplete token" in message:
         return "incomplete_tokens"
     if "no href" in message:
@@ -347,16 +511,35 @@ def summarize_response(
 
 
 def _input_kind(attributes: Mapping[str, str]) -> str:
+    """Controlled kind for one input, read from its NAME/ID/TYPE only (never a value).
+
+    Password fields are split into current/new/confirm because that split is what tells
+    a login form apart from a forced password change (issue #67). Matching is by
+    SUBSTRING for the password/ViewState families: VisualForce prefixes every field
+    (``j_id0:theForm:newPassword``), so name equality saw them all as "other".
+    """
     name = attributes.get("name", "").lower()
+    identifier = attributes.get("id", "").lower()
     input_type = attributes.get("type", "").lower()
+    hay = f"{name} {identifier}"
+    if input_type == "password" or "password" in hay or "passwd" in hay:
+        if any(marker in hay for marker in ("confirm", "verify", "repeat", "again")):
+            return "confirm_password"
+        if "new" in hay:
+            return "new_password"
+        if "current" in hay or "old" in hay:
+            return "current_password"
+        return "password"
     if name in {"username", "email", "emailaddress", "login"} or input_type == "email":
         return "username"
-    if name in {"password", "passwd"} or input_type == "password":
-        return "password"
-    if name in {"otp", "code", "verificationcode", "emailotp"}:
+    if name in {"otp", "code", "verificationcode", "emailotp"} or any(
+        marker in hay for marker in ("verificationcode", "emailotp")
+    ):
         return "otp"
-    if name in {"csrf", "viewstate", "token"}:
+    if name in {"csrf", "viewstate", "token"} or "viewstate" in hay:
         return "security"
+    if any(marker in hay for marker in ("consent", "terms", "privacy", "accept")):
+        return "consent"
     return "other"
 
 
@@ -370,6 +553,18 @@ class _ShapeParser(HTMLParser):
         self.scripts = 0
         self.input_kinds: list[str] = []
         self.normalized: list[str] = []
+        # Page-identity extras (issue #67). The captured text is scanned against
+        # _TEXT_MARKERS and then dropped: only the presence booleans leave this module.
+        self.title_chars: list[str] = []
+        self.text_chars: list[str] = []
+        self.title_len = 0
+        self.text_len = 0
+        self.form_action = ""
+        self.form_method = ""
+        self.buttons = 0
+        self.meta_refresh = False
+        self._in_title = False
+        self._skip_depth = 0
 
     def handle_starttag(
         self, tag: str, attrs: list[tuple[str, str | None]]
@@ -383,17 +578,48 @@ class _ShapeParser(HTMLParser):
         )
         self.normalized.append(f"{safe_tag}[{','.join(safe_attrs)}]")
         self.tags += 1
+        mapping = {str(name).lower(): str(value or "") for name, value in attrs}
         if tag == "form":
             self.forms += 1
+            # FIRST form only: the one the user would have to submit.
+            if not self.form_action and not self.form_method:
+                self.form_action = mapping.get("action", "")
+                self.form_method = mapping.get("method", "")
         elif tag == "input":
             self.inputs += 1
-            self.input_kinds.append(
-                _input_kind({str(name): str(value or "") for name, value in attrs})
-            )
+            self.input_kinds.append(_input_kind(mapping))
         elif tag in {"a", "link"}:
             self.links += 1
         elif tag == "script":
             self.scripts += 1
+        elif tag == "button":
+            self.buttons += 1
+        elif tag == "meta" and mapping.get("http-equiv", "").lower() == "refresh":
+            self.meta_refresh = True
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+        elif tag == "title":
+            self._in_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"}:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        elif tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        # Script/style bodies are NOT text: scanning them would report every vocabulary
+        # word the framework happens to ship (the login page alone is 300+ KB of JS).
+        if self._skip_depth:
+            return
+        if self._in_title:
+            if self.title_len < _TITLE_SCAN_CHARS:
+                self.title_chars.append(data)
+                self.title_len += len(data)
+            return
+        if self.text_len < _TEXT_SCAN_CHARS:
+            self.text_chars.append(data)
+        self.text_len += len(data)
 
 
 @dataclass(frozen=True)
@@ -412,11 +638,35 @@ class HtmlSummary:
     page_kind: str
     dom_fingerprint: str
     parse_error: bool
+    password_inputs: int = 0
+    password_change: bool = False
+    skeleton: tuple[str, ...] = ()
 
 
-def summarize_html(text: Any) -> HtmlSummary:
-    """Summarize recognized HTML structure and boolean protocol markers."""
-    source = str(text or "")
+@dataclass(frozen=True)
+class PageSummary:
+    """Identity of a page, as named structure only (issue #67)."""
+
+    endpoint: str
+    path_depth: int
+    path_markers: tuple[str, ...]
+    unknown_segments: int
+    path_hash: str
+    query_names: tuple[str, ...]
+    unknown_query: int
+    title_markers: tuple[str, ...]
+    text_markers: tuple[str, ...]
+    text_chars: int
+    form_action: str
+    form_method: str
+    buttons: int
+    meta_refresh: bool
+    js_redirect: bool
+    hon_scheme: bool
+    oauth_done_hits: int
+
+
+def _parse(source: str) -> tuple[_ShapeParser, bool]:
     parser = _ShapeParser()
     parse_error = False
     try:
@@ -424,6 +674,34 @@ def summarize_html(text: Any) -> HtmlSummary:
         parser.close()
     except Exception:
         parse_error = True
+    return parser, parse_error
+
+
+def _markers(text: str) -> tuple[str, ...]:
+    lowered = text.lower()
+    return tuple(
+        marker for marker in _TEXT_MARKERS if marker in lowered
+    )[:_MAX_MARKERS]
+
+
+def _path_shape(path: str) -> tuple[tuple[str, ...], int, int]:
+    """(named segments, unknown segment count, depth) for a URL path."""
+    segments = [segment for segment in path.lower().split("/") if segment]
+    markers: list[str] = []
+    unknown = 0
+    for segment in segments:
+        base = segment.split(".", 1)[0]
+        if base in _PATH_SEGMENTS:
+            if base not in markers:
+                markers.append(base)
+        else:
+            unknown += 1
+    return tuple(markers), unknown, len(segments)
+
+
+def _html_summary(
+    source: str, parser: _ShapeParser, parse_error: bool
+) -> HtmlSummary:
     lowered = source.lower()
     normalized = "|".join(parser.normalized).encode("ascii", "strict")
     fingerprint = hashlib.sha256(normalized).hexdigest()[:12]
@@ -438,16 +716,24 @@ def summarize_html(text: Any) -> HtmlSummary:
         marker in lowered for marker in ("privacy", "consent", "terms")
     )
     oauth_done = "oauth/done" in lowered
+    password_inputs = sum(
+        1 for kind in parser.input_kinds if kind in _PASSWORD_KINDS
+    )
+    # Two or more password boxes is never a login form and never a token page: it is a
+    # set/change-password step (new + confirm), so it gets its own kind.
+    password_change = password_inputs >= 2
     if oauth_done:
         page_kind = "oauth_done"
     elif otp:
         page_kind = "mfa"
-    elif privacy:
-        page_kind = "privacy"
+    elif password_change:
+        page_kind = "password_change"
     elif progressive_login:
         page_kind = "progressive_login"
     elif login:
         page_kind = "login"
+    elif privacy:
+        page_kind = "privacy"
     else:
         page_kind = "other"
     return HtmlSummary(
@@ -465,7 +751,111 @@ def summarize_html(text: Any) -> HtmlSummary:
         page_kind=page_kind,
         dom_fingerprint=fingerprint,
         parse_error=parse_error,
+        password_inputs=password_inputs,
+        password_change=password_change,
+        skeleton=tuple(parser.normalized[:_MAX_SKELETON_NODES]),
     )
+
+
+def _page_summary(url: Any, source: str, parser: _ShapeParser) -> PageSummary:
+    try:
+        parts = urlsplit(str(url or ""))
+        path = parts.path or ""
+        query = parts.query or ""
+    except (TypeError, ValueError):
+        path, query = "", ""
+    path_markers, unknown_segments, depth = _path_shape(path)
+    query_names: list[str] = []
+    unknown_query = 0
+    for field in query.split("&"):
+        if not field:
+            continue
+        name = field.partition("=")[0].strip().lower()
+        if name in _QUERY_NAMES:
+            if name not in query_names:
+                query_names.append(name)
+        else:
+            unknown_query += 1
+    lowered = source.lower()
+    return PageSummary(
+        endpoint=classify_endpoint(url),
+        path_depth=depth,
+        path_markers=path_markers,
+        unknown_segments=unknown_segments,
+        # Hash of the PATH only (never the query): two reports of the same landing page
+        # are comparable, and a known-good login can be diffed against a broken one.
+        path_hash=(
+            hashlib.sha256(path.lower().encode("utf-8", "replace")).hexdigest()[:12]
+            if path
+            else "none"
+        ),
+        query_names=tuple(query_names),
+        unknown_query=unknown_query,
+        title_markers=_markers("".join(parser.title_chars)),
+        text_markers=_markers("".join(parser.text_chars)),
+        text_chars=parser.text_len,
+        form_action=(
+            classify_endpoint(parser.form_action) if parser.form_action else "none"
+        ),
+        form_method=_enum(parser.form_method, frozenset({"get", "post"}), "none"),
+        buttons=parser.buttons,
+        meta_refresh=parser.meta_refresh,
+        js_redirect=any(marker in lowered for marker in _JS_REDIRECT_MARKERS),
+        # The token redirect leaves fingerprints even when the tokens are absent: if
+        # these are set the page DID carry the hand-off and our parsing is at fault,
+        # which is the opposite diagnosis from a server-side interstitial.
+        hon_scheme="hon://" in lowered,
+        oauth_done_hits=min(lowered.count("oauth/done"), 99),
+    )
+
+
+def analyze_page(url: Any, text: Any) -> tuple[HtmlSummary, PageSummary]:
+    """Both summaries from a SINGLE parse. Never raises (diagnostics are observational)."""
+    source = str(text or "")
+    try:
+        parser, parse_error = _parse(source)
+        return (
+            _html_summary(source, parser, parse_error),
+            _page_summary(url, source, parser),
+        )
+    except Exception:
+        empty = _ShapeParser()
+        return _html_summary("", empty, True), _page_summary("", "", empty)
+
+
+def summarize_html(text: Any) -> HtmlSummary:
+    """Summarize recognized HTML structure and boolean protocol markers."""
+    return analyze_page("", text)[0]
+
+
+def summarize_page(url: Any, text: Any) -> PageSummary:
+    """Summarize the identity of a page (path/query/text shape), never its content."""
+    return analyze_page(url, text)[1]
+
+
+def classify_token_page(html: HtmlSummary, page: PageSummary) -> str:
+    """Why a token page carried no tokens, as a controlled verdict (issue #67).
+
+    Structural, not textual: a page that carries the OAuth hand-off never holds a
+    password form, so ``password_change``/``consent`` identify a server-side step the
+    USER must complete, while ``token_link_unparsed`` accuses our own parser instead.
+    """
+    if html.oauth_done or page.hon_scheme:
+        return "token_link_unparsed"
+    if html.otp:
+        return "mfa"
+    if html.password_inputs >= 2:
+        return "password_change"
+    if html.tags == 0:
+        return "empty"
+    if html.password_inputs == 1 and "username" in html.input_kinds:
+        return "login"
+    if html.forms and any(
+        marker in page.text_markers
+        for marker in ("consent", "terms", "accept", "agree", "polic")
+    ):
+        return "consent"
+    return "unknown"
 
 
 @dataclass(frozen=True)
@@ -665,6 +1055,57 @@ class AuthDiagnosticTrace:
                 ("page_kind", summary.page_kind),
                 ("dom", summary.dom_fingerprint),
                 ("parse_error", summary.parse_error),
+            ),
+        )
+
+    def page(self, phase: Any, summary: PageSummary) -> None:
+        """Emit the named identity of a page (issue #67)."""
+        self._append(
+            "page",
+            (
+                ("phase", _phase(phase)),
+                ("endpoint", _enum(summary.endpoint, _ENDPOINTS)),
+                ("path_depth", summary.path_depth),
+                ("path_markers", summary.path_markers),
+                ("unknown_segments", summary.unknown_segments),
+                ("path_hash", summary.path_hash),
+                ("query_names", summary.query_names),
+                ("unknown_query", summary.unknown_query),
+                ("title_markers", summary.title_markers),
+                ("text_markers", summary.text_markers),
+                ("text_chars", summary.text_chars),
+                ("form_action", _enum(summary.form_action, _ENDPOINTS)),
+                ("form_method", summary.form_method),
+                ("buttons", summary.buttons),
+                ("meta_refresh", summary.meta_refresh),
+                ("js_redirect", summary.js_redirect),
+                ("hon_scheme", summary.hon_scheme),
+                ("oauth_done_hits", summary.oauth_done_hits),
+            ),
+        )
+
+    def skeleton(self, phase: Any, summary: HtmlSummary) -> None:
+        """Emit the bounded tag/attribute-NAME skeleton of an unexpected page.
+
+        Tags and attribute names are allowlisted upstream (anything else is already
+        "other") and no value is ever included, so the shape identifies the page
+        without shipping its markup."""
+        self._append(
+            "skeleton",
+            (
+                ("phase", _phase(phase)),
+                ("nodes", len(summary.skeleton)),
+                ("shape", "|".join(summary.skeleton) or "none"),
+            ),
+        )
+
+    def verdict(self, phase: Any, verdict: Any) -> None:
+        """Emit why a token page carried no tokens (controlled vocabulary)."""
+        self._append(
+            "verdict",
+            (
+                ("phase", _phase(phase)),
+                ("page", _enum(verdict, _TOKEN_PAGE_VERDICTS, "unknown")),
             ),
         )
 

--- a/custom_components/addhon/client/auth_diagnostics.py
+++ b/custom_components/addhon/client/auth_diagnostics.py
@@ -840,12 +840,16 @@ def classify_token_page(html: HtmlSummary, page: PageSummary) -> str:
     password form, so ``password_change``/``consent`` identify a server-side step the
     USER must complete, while ``token_link_unparsed`` accuses our own parser instead.
     """
-    if html.oauth_done or page.hon_scheme:
-        return "token_link_unparsed"
     if html.otp:
         return "mfa"
+    # The password form is checked FIRST: an interstitial can ECHO the OAuth request it
+    # interrupted (the redirect_uri and the escaped oauth/done link show up in the
+    # markup), and a page holding two password boxes is an account step no matter what
+    # it quotes. Only a page with no such form gets to blame our parser.
     if html.password_inputs >= 2:
         return "password_change"
+    if html.oauth_done or page.hon_scheme:
+        return "token_link_unparsed"
     if html.tags == 0:
         return "empty"
     if html.password_inputs == 1 and "username" in html.input_kinds:

--- a/custom_components/addhon/client/auth_diagnostics.py
+++ b/custom_components/addhon/client/auth_diagnostics.py
@@ -565,6 +565,7 @@ class _ShapeParser(HTMLParser):
         self.meta_refresh = False
         self._in_title = False
         self._skip_depth = 0
+        self._form_seen = False
 
     def handle_starttag(
         self, tag: str, attrs: list[tuple[str, str | None]]
@@ -581,8 +582,11 @@ class _ShapeParser(HTMLParser):
         mapping = {str(name).lower(): str(value or "") for name, value in attrs}
         if tag == "form":
             self.forms += 1
-            # FIRST form only: the one the user would have to submit.
-            if not self.form_action and not self.form_method:
+            # FIRST form only: the one the user would have to submit. Keyed off a flag,
+            # not off the captured values: a bare <form> would otherwise leave them empty
+            # and let a LATER form claim them, naming the wrong form in the trace.
+            if not self._form_seen:
+                self._form_seen = True
                 self.form_action = mapping.get("action", "")
                 self.form_method = mapping.get("method", "")
         elif tag == "input":
@@ -722,12 +726,15 @@ def _html_summary(
     # Two or more password boxes is never a login form and never a token page: it is a
     # set/change-password step (new + confirm), so it gets its own kind.
     password_change = password_inputs >= 2
-    if oauth_done:
-        page_kind = "oauth_done"
-    elif otp:
+    # Same precedence as classify_token_page: an interstitial can ECHO the OAuth request
+    # it interrupted, and page_kind gates the skeleton emission, so ranking oauth_done
+    # first would drop the shape of exactly the page that needs identifying.
+    if otp:
         page_kind = "mfa"
     elif password_change:
         page_kind = "password_change"
+    elif oauth_done:
+        page_kind = "oauth_done"
     elif progressive_login:
         page_kind = "progressive_login"
     elif login:

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -25,6 +25,7 @@ from yarl import URL
 
 from ...debug_utils import redact_remoting_summary
 from ...error_codes import (
+    ACCOUNT_ACTION_REQUIRED,
     MFA_CODE_INVALID,
     MFA_REQUIRED,
     MFA_SEND_FAILED,
@@ -32,8 +33,11 @@ from ...error_codes import (
     MFA_TOKEN_AFTER_VERIFY_FAILED,
 )
 from ..auth_diagnostics import (
+    ACCOUNT_ACTION_VERDICTS,
     AuthDiagnosticTrace,
+    analyze_page,
     classify_endpoint,
+    classify_token_page,
     summarize_html,
     summarize_json,
     summarize_links,
@@ -133,6 +137,17 @@ class MFATokenAfterVerifyFailed(NativeAuthError):
     """OTP accepted but the post-verify authorize did not yield tokens."""
 
     error_code = MFA_TOKEN_AFTER_VERIFY_FAILED
+
+
+class AccountActionRequired(NativeAuthError):
+    """The password was accepted but the account is parked on a step only the USER can
+    clear (a set/change-password form, a consent wall) instead of the token hand-off.
+
+    Structurally detected on the token page (issue #67): retrying cannot fix it, so it
+    gets its own code and a message that says WHERE to go, rather than the mute
+    "token retrieval failed"."""
+
+    error_code = ACCOUNT_ACTION_REQUIRED
 
 
 class _NoAuthNeeded(Exception):
@@ -235,6 +250,41 @@ class HonAuth:
         if self._auth_trace.enabled:
             self._auth_trace.html(phase, summarize_html(text))
 
+    def _diagnostic_page(self, phase: str, url: Any, text: Any) -> None:
+        """Emit the structure AND the named identity of a page (issue #67).
+
+        The skeleton is emitted only for a page the flow did not expect: on the known
+        stops it would be noise, on an unexpected landing page it is what identifies it
+        without a second round-trip to the reporter."""
+        if not self._auth_trace.enabled:
+            return
+        shape, page = analyze_page(url, text)
+        self._auth_trace.html(phase, shape)
+        self._auth_trace.page(phase, page)
+        if shape.page_kind not in ("login", "progressive_login", "oauth_done", "mfa"):
+            self._auth_trace.skeleton(phase, shape)
+
+    def _page_verdict(self, phase: str, url: Any, text: Any) -> str:
+        """Why a page is a dead end, as a controlled verdict. Runs with the diagnostics
+        OFF too: the actionable error must not depend on the opt-in checkbox."""
+        verdict = "unknown"
+        try:
+            shape, page = analyze_page(url, text)
+            verdict = classify_token_page(shape, page)
+        except Exception:  # noqa: BLE001 - a diagnostic must never replace the failure
+            verdict = "unknown"
+        self._auth_trace.verdict(phase, verdict)
+        return verdict
+
+    def _guard_account_action(self, phase: str, url: Any, text: Any) -> None:
+        """Raise AccountActionRequired when a dead-end page is a step only the USER can
+        clear, instead of the mute "no href" the caller would otherwise raise."""
+        verdict = self._page_verdict(phase, url, text)
+        if verdict in ACCOUNT_ACTION_VERDICTS:
+            raise AccountActionRequired(
+                f"{phase}: account action required ({verdict})"
+            )
+
     def _diagnostic_links(
         self, phase: str, hrefs: list[str], selected_index: int = -1
     ) -> None:
@@ -259,7 +309,7 @@ class HonAuth:
         async with self._session.get(url, headers=self._ua()) as resp:
             text = await resp.text()
             self._diagnostic_response("introduce", resp, text, started)
-            self._diagnostic_html("introduce", text)
+            self._diagnostic_page("introduce", url, text)
             self._expires = datetime.now(timezone.utc)
             login_url = extract_login_url(text)
             if login_url is None:
@@ -323,7 +373,7 @@ class HonAuth:
         ) as resp:
             text = await resp.text()
             self._diagnostic_response("login_page", resp, text, started)
-            self._diagnostic_html("login_page", text)
+            self._diagnostic_page("login_page", login_url, text)
             match = _FWUID_RE.findall(text)
             if not match:
                 self._phase("login_page", status=resp.status, fwuid=False)
@@ -369,19 +419,23 @@ class HonAuth:
         started = self._diagnostic_request(
             "post_login", "GET", "post_login"
         )
-        async with self._session.get(absolutize(url), headers=self._ua()) as resp:
+        post_login_url = absolutize(url)
+        async with self._session.get(post_login_url, headers=self._ua()) as resp:
             if resp.status != 200:
                 self._diagnostic_response("post_login", resp, b"", started)
                 self._phase("get_token", status=resp.status)
                 raise NativeAuthError(f"get_token: status {resp.status}")
             text = await resp.text()
             self._diagnostic_response("post_login", resp, text, started)
-            self._diagnostic_html("post_login", text)
+            self._diagnostic_page("post_login", post_login_url, text)
             href = _HREF_RE.findall(text)
             self._diagnostic_links(
                 "post_login", href, selected_index=0 if href else -1
             )
         if not href:
+            # A post-login page with no next hop may BE the account step (a consent form
+            # has no navigation href at all), so name it before failing (issue #67).
+            self._guard_account_action("post_login", post_login_url, text)
             self._phase("get_token", status=resp.status, href=False)
             raise NativeAuthError("get_token: no href")
         if "ProgressiveLogin" in href[0]:
@@ -399,11 +453,11 @@ class HonAuth:
                 self._diagnostic_response(
                     "progressive_page", resp, prog_text, started
                 )
-                self._diagnostic_html("progressive_page", prog_text)
                 # resp.url is the final (post-redirect) URL; fall back to the requested
                 # href (absolutized, so the MfaContext host derivation is correct) if the
                 # response object does not expose it (e.g. test doubles).
                 prog_url = str(getattr(resp, "url", "") or absolutize(href[0]))
+                self._diagnostic_page("progressive_page", prog_url, prog_text)
             # 2FA: when email OTP is enabled this page IS the verification step (no
             # usable redirect href -- the first one is a CSS asset). Detect it and
             # pause the login with the context to resume; otherwise behave exactly as
@@ -422,6 +476,7 @@ class HonAuth:
                 selected_index=0 if href else -1,
             )
             if not href:  # like the guard after the first findall: no IndexError
+                self._guard_account_action("progressive_page", prog_url, prog_text)
                 raise NativeAuthError("progressive: no href")
         token_url = absolutize(href[0])
         self._phase("get_token", status=200, href=True)
@@ -438,11 +493,22 @@ class HonAuth:
             self._diagnostic_response(
                 "token_response", resp, token_text, started
             )
-            self._diagnostic_html("token_response", token_text)
+            self._diagnostic_page("token_response", token_url, token_text)
             self._diagnostic_tokens("token_response", token_text)
             tokens = parse_token_fragment(token_text)
         if not tokens.complete:
-            raise NativeAuthError("token page: incomplete tokens")
+            # The page that should carry the OAuth hand-off did not. Say WHAT it carried
+            # instead: a set/change-password form or a consent wall is an account step
+            # only the user can clear, and retrying it forever (ADDHON-130) told them
+            # nothing (issue #67). Never let the classification break the login: a
+            # diagnostic failure must still raise the original token error.
+            verdict = self._page_verdict("token_response", token_url, token_text)
+            self._phase("get_token", tokens_complete=False, page=verdict)
+            if verdict in ACCOUNT_ACTION_VERDICTS:
+                raise AccountActionRequired(
+                    f"token page: account action required ({verdict})"
+                )
+            raise NativeAuthError(f"token page: incomplete tokens ({verdict})")
         self.access_token = tokens.access_token
         self.refresh_token = tokens.refresh_token
         self.id_token = tokens.id_token
@@ -608,7 +674,7 @@ class HonAuth:
         async with self._session.get(url, headers=self._ua()) as resp:
             text = await resp.text()
             self._diagnostic_response("resume_token", resp, text, started)
-            self._diagnostic_html("resume_token", text)
+            self._diagnostic_page("resume_token", url, text)
         self._expires = datetime.now(timezone.utc)
         # Extract the done-URL FIRST and parse only it (mirrors the live-validated probe).
         # Parsing the whole page first would let a stray `*_token=...&` substring elsewhere

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -38,7 +38,6 @@ from ..auth_diagnostics import (
     analyze_page,
     classify_endpoint,
     classify_token_page,
-    summarize_html,
     summarize_json,
     summarize_links,
     summarize_response,
@@ -245,10 +244,6 @@ class HonAuth:
                 redirects=len(history),
             ),
         )
-
-    def _diagnostic_html(self, phase: str, text: Any) -> None:
-        if self._auth_trace.enabled:
-            self._auth_trace.html(phase, summarize_html(text))
 
     def _diagnostic_page(self, phase: str, url: Any, text: Any) -> None:
         """Emit the structure AND the named identity of a page (issue #67).

--- a/custom_components/addhon/client/transport/auth.py
+++ b/custom_components/addhon/client/transport/auth.py
@@ -245,36 +245,56 @@ class HonAuth:
             ),
         )
 
-    def _diagnostic_page(self, phase: str, url: Any, text: Any) -> None:
+    def _diagnostic_page(
+        self, phase: str, url: Any, text: Any
+    ) -> tuple[Any, Any] | None:
         """Emit the structure AND the named identity of a page (issue #67).
 
         The skeleton is emitted only for a page the flow did not expect: on the known
         stops it would be noise, on an unexpected landing page it is what identifies it
-        without a second round-trip to the reporter."""
+        without a second round-trip to the reporter. Returns the summary pair so a
+        caller that later needs a verdict does not parse the same body twice."""
         if not self._auth_trace.enabled:
-            return
-        shape, page = analyze_page(url, text)
+            return None
+        try:
+            shape, page = analyze_page(url, text)
+        except Exception:  # noqa: BLE001 - diagnostics are observational, never fatal
+            return None
         self._auth_trace.html(phase, shape)
         self._auth_trace.page(phase, page)
         if shape.page_kind not in ("login", "progressive_login", "oauth_done", "mfa"):
             self._auth_trace.skeleton(phase, shape)
+        return shape, page
 
-    def _page_verdict(self, phase: str, url: Any, text: Any) -> str:
+    def _page_verdict(
+        self,
+        phase: str,
+        url: Any,
+        text: Any,
+        summaries: tuple[Any, Any] | None = None,
+    ) -> str:
         """Why a page is a dead end, as a controlled verdict. Runs with the diagnostics
-        OFF too: the actionable error must not depend on the opt-in checkbox."""
+        OFF too: the actionable error must not depend on the opt-in checkbox. Reuses the
+        summaries the trace already built, when there are any."""
         verdict = "unknown"
         try:
-            shape, page = analyze_page(url, text)
+            shape, page = summaries if summaries else analyze_page(url, text)
             verdict = classify_token_page(shape, page)
         except Exception:  # noqa: BLE001 - a diagnostic must never replace the failure
             verdict = "unknown"
         self._auth_trace.verdict(phase, verdict)
         return verdict
 
-    def _guard_account_action(self, phase: str, url: Any, text: Any) -> None:
+    def _guard_account_action(
+        self,
+        phase: str,
+        url: Any,
+        text: Any,
+        summaries: tuple[Any, Any] | None = None,
+    ) -> None:
         """Raise AccountActionRequired when a dead-end page is a step only the USER can
         clear, instead of the mute "no href" the caller would otherwise raise."""
-        verdict = self._page_verdict(phase, url, text)
+        verdict = self._page_verdict(phase, url, text, summaries)
         if verdict in ACCOUNT_ACTION_VERDICTS:
             raise AccountActionRequired(
                 f"{phase}: account action required ({verdict})"
@@ -422,7 +442,9 @@ class HonAuth:
                 raise NativeAuthError(f"get_token: status {resp.status}")
             text = await resp.text()
             self._diagnostic_response("post_login", resp, text, started)
-            self._diagnostic_page("post_login", post_login_url, text)
+            post_login_summaries = self._diagnostic_page(
+                "post_login", post_login_url, text
+            )
             href = _HREF_RE.findall(text)
             self._diagnostic_links(
                 "post_login", href, selected_index=0 if href else -1
@@ -430,7 +452,9 @@ class HonAuth:
         if not href:
             # A post-login page with no next hop may BE the account step (a consent form
             # has no navigation href at all), so name it before failing (issue #67).
-            self._guard_account_action("post_login", post_login_url, text)
+            self._guard_account_action(
+                "post_login", post_login_url, text, post_login_summaries
+            )
             self._phase("get_token", status=resp.status, href=False)
             raise NativeAuthError("get_token: no href")
         if "ProgressiveLogin" in href[0]:
@@ -452,7 +476,9 @@ class HonAuth:
                 # href (absolutized, so the MfaContext host derivation is correct) if the
                 # response object does not expose it (e.g. test doubles).
                 prog_url = str(getattr(resp, "url", "") or absolutize(href[0]))
-                self._diagnostic_page("progressive_page", prog_url, prog_text)
+                prog_summaries = self._diagnostic_page(
+                    "progressive_page", prog_url, prog_text
+                )
             # 2FA: when email OTP is enabled this page IS the verification step (no
             # usable redirect href -- the first one is a CSS asset). Detect it and
             # pause the login with the context to resume; otherwise behave exactly as
@@ -471,7 +497,9 @@ class HonAuth:
                 selected_index=0 if href else -1,
             )
             if not href:  # like the guard after the first findall: no IndexError
-                self._guard_account_action("progressive_page", prog_url, prog_text)
+                self._guard_account_action(
+                    "progressive_page", prog_url, prog_text, prog_summaries
+                )
                 raise NativeAuthError("progressive: no href")
         token_url = absolutize(href[0])
         self._phase("get_token", status=200, href=True)
@@ -488,7 +516,9 @@ class HonAuth:
             self._diagnostic_response(
                 "token_response", resp, token_text, started
             )
-            self._diagnostic_page("token_response", token_url, token_text)
+            token_summaries = self._diagnostic_page(
+                "token_response", token_url, token_text
+            )
             self._diagnostic_tokens("token_response", token_text)
             tokens = parse_token_fragment(token_text)
         if not tokens.complete:
@@ -497,7 +527,9 @@ class HonAuth:
             # only the user can clear, and retrying it forever (ADDHON-130) told them
             # nothing (issue #67). Never let the classification break the login: a
             # diagnostic failure must still raise the original token error.
-            verdict = self._page_verdict("token_response", token_url, token_text)
+            verdict = self._page_verdict(
+                "token_response", token_url, token_text, token_summaries
+            )
             self._phase("get_token", tokens_complete=False, page=verdict)
             if verdict in ACCOUNT_ACTION_VERDICTS:
                 raise AccountActionRequired(

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -49,6 +49,16 @@ def _error_base_and_code(exc: BaseException, fallback_base: str) -> tuple[str, s
     return fallback_base, ""
 
 
+def _discard_diagnostics(client: Any) -> None:
+    """Drop a client's buffered auth trace before closing it.
+
+    Duck-typed: the config-flow tests pass doubles, and a client without the opt-in
+    diagnostics simply has nothing to discard."""
+    discard = getattr(client, "discard_auth_diagnostics", None)
+    if callable(discard):
+        discard()
+
+
 def _redact_email(email: str | None) -> str | None:
     if not email:
         return None
@@ -377,9 +387,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._mfa_reauth_entry = None
         if client is not None:
             try:
-                discard = getattr(client, "discard_auth_diagnostics", None)
-                if callable(discard):
-                    discard()
+                _discard_diagnostics(client)
                 await client.async_close()
             except Exception as err:  # noqa: BLE001 - cleanup must not mask the flow
                 _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
@@ -406,9 +414,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # very warning this method exists to remove.
                 coro.close()
                 _LOGGER.warning("Could not schedule the 2FA client cleanup: %s", err)
-        # No loop to schedule on (very early teardown, or a loop already going away):
-        # tear the client down on THIS thread rather than dropping the reference, which
-        # would leak its loop/thread/session with no owner left to close them.
+            # The blocking teardown waits on the dedicated hOn loop (up to
+            # HonClient._RUN_TIMEOUT) and joins its thread, so it must NOT run on the
+            # event-loop thread: hand it to the executor instead.
+            try:
+                hass.async_add_executor_job(self._close_mfa_client_sync)
+                return
+            except Exception as err:  # noqa: BLE001 - last resort below
+                _LOGGER.warning("Could not offload the 2FA client cleanup: %s", err)
+        # No loop and no executor left (very early teardown, or an HA already going
+        # away): tear the client down on THIS thread rather than dropping the reference,
+        # which would leak its loop/thread/session with no owner left to close them.
         self._close_mfa_client_sync()
 
     def _close_mfa_client_sync(self) -> None:
@@ -421,14 +437,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if client is None:
             return
         try:
-            discard = getattr(client, "discard_auth_diagnostics", None)
-            if callable(discard):
-                discard()
-            # The private teardown is what async_close() itself hands to the executor;
-            # calling it directly is the only way to close without a running loop.
-            closer = getattr(client, "_close_sync", None)
-            if callable(closer):
-                closer()
+            _discard_diagnostics(client)
+            client.close_sync()
         except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
             _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
 

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -384,10 +384,37 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except Exception as err:  # noqa: BLE001 - cleanup must not mask the flow
                 _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
 
-    async def async_remove(self) -> None:
+    def async_remove(self) -> None:
         """Called by HA when the flow is removed/aborted/abandoned: close the held 2FA
-        client so an unfinished verification does not leak its loop/thread/session."""
-        await self._async_close_mfa_client()
+        client so an unfinished verification does not leak its loop/thread/session.
+
+        SYNC on purpose. ``data_entry_flow`` calls ``flow.async_remove()`` WITHOUT
+        awaiting it, so the previous coroutine version was never executed: Home
+        Assistant only logged "coroutine 'ConfigFlow.async_remove' was never awaited"
+        and the 2FA client kept its loop, thread and aiohttp session alive. Scheduling
+        the async teardown on the running loop is what actually closes it."""
+        if self._mfa_client is None:
+            return
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            # No loop to schedule on (very early teardown): tear the client down on this
+            # thread instead of dropping the reference, or the loop/thread/session would
+            # be leaked with no owner left to close them.
+            client, self._mfa_client = self._mfa_client, None
+            self._mfa_context = None
+            self._mfa_data = None
+            self._mfa_reauth_entry = None
+            try:
+                discard = getattr(client, "discard_auth_diagnostics", None)
+                if callable(discard):
+                    discard()
+                closer = getattr(client, "_close_sync", None)
+                if callable(closer):
+                    closer()
+            except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
+                _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+            return
+        hass.async_create_task(self._async_close_mfa_client())
 
     async def async_step_2fa(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -396,25 +396,41 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._mfa_client is None:
             return
         hass = getattr(self, "hass", None)
-        if hass is None:
-            # No loop to schedule on (very early teardown): tear the client down on this
-            # thread instead of dropping the reference, or the loop/thread/session would
-            # be leaked with no owner left to close them.
-            client, self._mfa_client = self._mfa_client, None
-            self._mfa_context = None
-            self._mfa_data = None
-            self._mfa_reauth_entry = None
+        if hass is not None:
+            coro = self._async_close_mfa_client()
             try:
-                discard = getattr(client, "discard_auth_diagnostics", None)
-                if callable(discard):
-                    discard()
-                closer = getattr(client, "_close_sync", None)
-                if callable(closer):
-                    closer()
-            except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
-                _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+                hass.async_create_task(coro)
+                return
+            except Exception as err:  # noqa: BLE001 - fall through to the blocking close
+                # Closing the coroutine matters: an un-awaited one would reproduce the
+                # very warning this method exists to remove.
+                coro.close()
+                _LOGGER.warning("Could not schedule the 2FA client cleanup: %s", err)
+        # No loop to schedule on (very early teardown, or a loop already going away):
+        # tear the client down on THIS thread rather than dropping the reference, which
+        # would leak its loop/thread/session with no owner left to close them.
+        self._close_mfa_client_sync()
+
+    def _close_mfa_client_sync(self) -> None:
+        """Blocking twin of :meth:`_async_close_mfa_client` (same idempotent order)."""
+        client = self._mfa_client
+        self._mfa_client = None
+        self._mfa_context = None
+        self._mfa_data = None
+        self._mfa_reauth_entry = None
+        if client is None:
             return
-        hass.async_create_task(self._async_close_mfa_client())
+        try:
+            discard = getattr(client, "discard_auth_diagnostics", None)
+            if callable(discard):
+                discard()
+            # The private teardown is what async_close() itself hands to the executor;
+            # calling it directly is the only way to close without a running loop.
+            closer = getattr(client, "_close_sync", None)
+            if callable(closer):
+                closer()
+        except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
+            _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
 
     async def async_step_2fa(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 import voluptuous as vol
@@ -374,23 +375,47 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._mfa_data = data
         self._mfa_reauth_entry = reauth_entry
 
-    async def _async_close_mfa_client(self) -> None:
-        """Tear down the held 2FA client. Idempotent (clears the ref first), so it is
-        safe to call from both the success path and the flow-removal hook."""
+    def _detach_mfa_client(self) -> Any:
+        """Take the held 2FA client off the flow and return it, or None.
+
+        Runs on the caller's thread and clears the state FIRST, so a teardown handed to
+        another thread can never be scheduled twice for the same client. The cached form
+        data goes with it: ``_mfa_data`` holds the plaintext password and
+        ``_mfa_reauth_entry`` the reauth target, so stale credentials are not left
+        reachable on the flow object after success, abort, or removal."""
         client = self._mfa_client
         self._mfa_client = None
         self._mfa_context = None
-        # Drop the cached form data too: _mfa_data holds the plaintext password and
-        # _mfa_reauth_entry the reauth target, so stale credentials/state are not left
-        # reachable on the flow object after success, abort, or async_remove.
         self._mfa_data = None
         self._mfa_reauth_entry = None
+        return client
+
+    async def _async_close_client(self, client: Any) -> None:
+        """Close a detached client on the event loop (``async_close`` does the blocking
+        part on the executor, so this never stalls the loop)."""
+        try:
+            _discard_diagnostics(client)
+            await client.async_close()
+        except Exception as err:  # noqa: BLE001 - cleanup must not mask the flow
+            _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+
+    @staticmethod
+    def _close_client_sync(client: Any) -> None:
+        """Blocking twin of :meth:`_async_close_client`. Waits on the client's dedicated
+        loop and joins its thread, so it belongs on an executor or a thread of its own,
+        never on the event-loop thread."""
+        try:
+            _discard_diagnostics(client)
+            client.close_sync()
+        except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
+            _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+
+    async def _async_close_mfa_client(self) -> None:
+        """Tear down the held 2FA client. Idempotent (detaches first), so it is safe to
+        call from both the success path and the flow-removal hook."""
+        client = self._detach_mfa_client()
         if client is not None:
-            try:
-                _discard_diagnostics(client)
-                await client.async_close()
-            except Exception as err:  # noqa: BLE001 - cleanup must not mask the flow
-                _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+            await self._async_close_client(client)
 
     def async_remove(self) -> None:
         """Called by HA when the flow is removed/aborted/abandoned: close the held 2FA
@@ -399,48 +424,71 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         SYNC on purpose. ``data_entry_flow`` calls ``flow.async_remove()`` WITHOUT
         awaiting it, so the previous coroutine version was never executed: Home
         Assistant only logged "coroutine 'ConfigFlow.async_remove' was never awaited"
-        and the 2FA client kept its loop, thread and aiohttp session alive. Scheduling
-        the async teardown on the running loop is what actually closes it."""
-        if self._mfa_client is None:
-            return
-        hass = getattr(self, "hass", None)
-        if hass is not None:
-            coro = self._async_close_mfa_client()
-            try:
-                hass.async_create_task(coro)
-                return
-            except Exception as err:  # noqa: BLE001 - fall through to the blocking close
-                # Closing the coroutine matters: an un-awaited one would reproduce the
-                # very warning this method exists to remove.
-                coro.close()
-                _LOGGER.warning("Could not schedule the 2FA client cleanup: %s", err)
-            # The blocking teardown waits on the dedicated hOn loop (up to
-            # HonClient._RUN_TIMEOUT) and joins its thread, so it must NOT run on the
-            # event-loop thread: hand it to the executor instead.
-            try:
-                hass.async_add_executor_job(self._close_mfa_client_sync)
-                return
-            except Exception as err:  # noqa: BLE001 - last resort below
-                _LOGGER.warning("Could not offload the 2FA client cleanup: %s", err)
-        # No loop and no executor left (very early teardown, or an HA already going
-        # away): tear the client down on THIS thread rather than dropping the reference,
-        # which would leak its loop/thread/session with no owner left to close them.
-        self._close_mfa_client_sync()
+        and the client kept its loop, thread and aiohttp session alive.
 
-    def _close_mfa_client_sync(self) -> None:
-        """Blocking twin of :meth:`_async_close_mfa_client` (same idempotent order)."""
-        client = self._mfa_client
-        self._mfa_client = None
-        self._mfa_context = None
-        self._mfa_data = None
-        self._mfa_reauth_entry = None
+        The teardown itself BLOCKS (it waits on the client's dedicated loop and joins its
+        thread), so it must never run on the event-loop thread. The strategies below are
+        tried in order and the first one that accepts the work wins; the last one brings
+        its own thread, so an HA that refuses both of its schedulers can neither be
+        stalled by the teardown nor leak the client."""
+        client = self._detach_mfa_client()
         if client is None:
             return
+        for schedule in (
+            self._teardown_on_event_loop,
+            self._teardown_in_executor,
+            self._teardown_in_own_thread,
+        ):
+            if schedule(client):
+                return
+        _LOGGER.warning(
+            "Could not schedule the 2FA client teardown; giving up on this client"
+        )
+
+    def _teardown_on_event_loop(self, client: Any) -> bool:
+        """Preferred: the async teardown as a task on Home Assistant's loop."""
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            return False
+        coro = self._async_close_client(client)
         try:
-            _discard_diagnostics(client)
-            client.close_sync()
-        except Exception as err:  # noqa: BLE001 - cleanup must not mask the removal
-            _LOGGER.warning("Error closing HonClient after 2FA: %s", err)
+            hass.async_create_task(coro)
+        except Exception as err:  # noqa: BLE001 - the next strategy takes over
+            # Closing the coroutine matters: an un-awaited one would reproduce the very
+            # warning this method exists to remove.
+            coro.close()
+            _LOGGER.debug("2FA teardown: async_create_task refused it (%s)", err)
+            return False
+        return True
+
+    def _teardown_in_executor(self, client: Any) -> bool:
+        """Fallback: the blocking teardown on Home Assistant's executor."""
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            return False
+        try:
+            hass.async_add_executor_job(self._close_client_sync, client)
+        except Exception as err:  # noqa: BLE001 - the next strategy takes over
+            _LOGGER.debug("2FA teardown: the executor refused it (%s)", err)
+            return False
+        return True
+
+    def _teardown_in_own_thread(self, client: Any) -> bool:
+        """Last resort: our own thread, so no Home Assistant scheduler is needed at all.
+
+        Daemon on purpose: if Home Assistant is going down, a teardown must not hold the
+        process up (the client's own loop thread is a daemon for the same reason)."""
+        try:
+            threading.Thread(
+                target=self._close_client_sync,
+                args=(client,),
+                name="addhon_2fa_teardown",
+                daemon=True,
+            ).start()
+        except Exception as err:  # noqa: BLE001 - nothing left to try
+            _LOGGER.debug("2FA teardown: could not start a thread for it (%s)", err)
+            return False
+        return True
 
     async def async_step_2fa(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/addhon/error_codes.py
+++ b/custom_components/addhon/error_codes.py
@@ -122,13 +122,21 @@ MFA_CODE_INVALID = _reg(161, "mfa_code_invalid", "Verification code was rejected
 # Distinguishable 2FA sub-failures (so the user sees "couldn't send" vs "wrong code" vs
 # "server hiccup"). 162/163 are NOT reauth: the credentials and OTP are fine, it's a
 # transient send/verify problem -> cannot_connect/retry. 164 IS reauth (re-drive login).
-# 165 (account-action-required/privacy) is intentionally RESERVED, not registered: the
-# privacy markers live in every ProgressiveLogin page's remoting registry, so it cannot be
-# detected reliably without a captured privacy-only page. 165-168 stay reserved.
 MFA_SEND_FAILED = _reg(162, "mfa_send_failed", "Could not send the verification code", False)
 MFA_SERVICE_ERROR = _reg(163, "mfa_service_error", "Two-factor verification service error", False)
 MFA_TOKEN_AFTER_VERIFY_FAILED = _reg(
     164, "mfa_token_after_verify_failed", "Sign-in could not finish after verification", True
+)
+# 165 was reserved for "account action required" while the only available marker was
+# textual (privacy words appear in EVERY ProgressiveLogin page, so they proved nothing).
+# It is registered now that the detection is STRUCTURAL: the page that should carry the
+# OAuth hand-off instead carries a set/change-password form or a consent form, which a
+# token page never does (issue #67). 166-168 stay reserved.
+ACCOUNT_ACTION_REQUIRED = _reg(
+    165,
+    "account_action_required",
+    "hOn is asking for an extra step on the account before sign-in can finish",
+    True,
 )
 # 2xx - appliance inventory / per-appliance (runtime, logged only)
 APPLIANCE_LIST_FAILED = _reg(200, "appliance_list_failed", "Could not fetch the appliance list")
@@ -309,6 +317,12 @@ def classify(err: BaseException, *, phase: str | None = None) -> HonErrorCode:
         return DECODE_ERROR
     if "decode error" in hay:
         return DECODE_ERROR
+    # Before the token-page rule: this IS a token-page failure, but the account needs a
+    # user step, so it must not collapse into the mute ADDHON-130 (issue #67). The
+    # carried code already wins above; this keeps the routing right if the marker
+    # reaches the classifier as plain text.
+    if "account action required" in hay:
+        return ACCOUNT_ACTION_REQUIRED
     if "api_auth" in hay:
         return AUTH_API_AUTH
     if "get_token" in hay or "token page" in hay or "progressive" in hay:

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -1042,3 +1042,12 @@ class HonClient:
 
     async def async_close(self) -> None:
         await asyncio.get_running_loop().run_in_executor(None, self._close_sync)
+
+    def close_sync(self) -> None:
+        """Blocking close, for a caller that has no running loop to await on.
+
+        Public counterpart of :meth:`async_close` (which is this exact teardown handed to
+        an executor). Callers outside this module use THIS name: reaching for the private
+        one degrades to a silent no-op the day it is renamed. Blocking: it waits on the
+        dedicated loop and joins its thread, so never call it from an event loop."""
+        self._close_sync()

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.9.2"
+  "version": "5.9.3"
 }

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -47,6 +47,7 @@
       "mfa_send_failed": "Could not send the verification code. Wait a moment and tap Resend. ({error_code})",
       "mfa_service_error": "The verification service had a temporary problem. Try the code again in a moment. ({error_code})",
       "mfa_token_after_verify_failed": "Your code was accepted but sign-in could not finish. Please start the login again. ({error_code})",
+      "account_action_required": "Your password was accepted, but hOn is asking for an extra step on the account (for example a new password to set, or terms to accept). Sign in on the hOn website or app, complete the requested step, then try again here. ({error_code})",
       "appliance_list_failed": "Could not fetch your appliance list. ({error_code})",
       "network_timeout": "Timed out contacting the hOn servers. Check your internet connection. ({error_code})",
       "dns_failure": "Could not resolve the hOn servers (DNS). Check your network and DNS. ({error_code})",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -47,6 +47,7 @@
       "mfa_send_failed": "Impossibile inviare il codice di verifica. Attendi un momento e premi Reinvia. ({error_code})",
       "mfa_service_error": "Il servizio di verifica ha avuto un problema temporaneo. Riprova il codice tra poco. ({error_code})",
       "mfa_token_after_verify_failed": "Codice accettato ma l'accesso non si è completato. Riprova ad accedere da capo. ({error_code})",
+      "account_action_required": "La password è corretta, ma hOn chiede un passaggio aggiuntivo sull'account (per esempio una nuova password da impostare o condizioni da accettare). Accedi dal sito o dall'app hOn, completa il passaggio richiesto, poi riprova qui. ({error_code})",
       "appliance_list_failed": "Impossibile recuperare la lista dei dispositivi. ({error_code})",
       "network_timeout": "Timeout nel contattare i server hOn. Controlla la connessione internet. ({error_code})",
       "dns_failure": "Impossibile risolvere i server hOn (DNS). Controlla rete e DNS. ({error_code})",

--- a/docs/protocol/HAIER-HON-TRANSPORT.md
+++ b/docs/protocol/HAIER-HON-TRANSPORT.md
@@ -117,6 +117,16 @@ with `username`/`password`/`startUrl`), `aura.context`
 `uad=False`), `aura.pageURI`, `aura.token=None`; params `{r:3,
 other.LightningLoginCustom.login:1}`. Key order and encoding are Aura-mandated.
 
+**5.5 Post-login interstitials (CLIENT-CHOSEN handling).** After the login POST is
+accepted, the org can park the session on a page that only the user can clear: a
+set/change-password form, a consent wall. Such a page reaches the flow exactly where the
+token hand-off was expected, so it cannot be told apart by status code. addhOn decides it
+STRUCTURALLY: a page that carries the OAuth hand-off never carries a password form, so
+two or more password fields (or a consent form with no hand-off) mean an account step,
+not a transport failure. That case raises its own code (ADDHON-165) with a message
+pointing the user at the hOn website or app; a page that DOES carry `hon://…oauth/done`
+yet yields no complete fragment is reported as a parser problem on our side instead.
+
 ## sec6 — Token model & lifetimes
 
 **6.1 Inventory.**

--- a/docs/superpowers/specs/2026-07-24-auth-login-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-07-24-auth-login-diagnostics-design.md
@@ -93,6 +93,9 @@ only fields or structural summaries defined for that event, using integers, bool
 - `links(phase, LinksSummary)`
 - `json_shape(phase, JsonSummary)`, which emits `event=json`
 - `token_shape(phase, TokenSummary)`, which emits `event=tokens`
+- `page(phase, PageSummary)`, which emits `event=page`
+- `skeleton(phase, HtmlSummary)`, which emits `event=skeleton`
+- `verdict(phase, verdict)`, which emits `event=verdict`
 - `payload(phase, kind)`
 - `phase(phase, status, outcome)`
 
@@ -127,6 +130,10 @@ reaches the trace:
 - JSON classifier: allowed structural key names and expected container shapes.
 - Token classifier: required token field presence, missing fields, duplicates,
   delimiter style, and completeness.
+- Page-identity classifier: named path segments, named query parameter names, a hash of
+  the path, vocabulary words present in the page title and in the visible text, the kind
+  of the first form action, its method, and the redirect fingerprints of the page.
+- Token-page verdict: why a page that should carry the OAuth hand-off did not.
 
 Unknown values map to `other` or counters. They are not copied verbatim into events.
 
@@ -277,3 +284,41 @@ The work is complete when:
    tested hostile responses.
 5. The checkbox and trace are temporary and never alter persisted configuration.
 6. Authentication behavior and existing error codes remain unchanged.
+
+## Round 2: page identity and an actionable failure (issue #67)
+
+The first release proved where a sign-in dies but not what it died on. A report showed
+`page_kind=other endpoint=auth_other` for the page that should have carried the tokens,
+which is not enough to answer the user, and asking for another log costs a day per
+round trip. Two additions close that gap.
+
+**Page identity.** Every HTML stop in the flow now also emits `event=page`, built from
+allowlists only:
+
+- `path_markers` and `unknown_segments`: which named path segments the landing URL has,
+  and how many it has that we do not name;
+- `path_hash`: a short hash of the path, so two reports of the same page are comparable
+  and a working sign-in can be diffed against a broken one;
+- `query_names` and `unknown_query`: named query parameter names, never their values;
+- `title_markers` and `text_markers`: which words of a fixed vocabulary appear in the
+  title and in the visible text. Script and style bodies are excluded, otherwise every
+  word in the framework payload would look present;
+- `form_action`, `form_method`, `buttons`: what the page would ask the user to submit;
+- `meta_refresh`, `js_redirect`, `hon_scheme`, `oauth_done_hits`: whether the page is a
+  bounce, and whether it carried the token hand-off after all.
+
+A page the flow did not expect also emits `event=skeleton`: the bounded sequence of its
+tags with their attribute names, values excluded. That is what identifies an unknown
+interstitial without shipping its markup.
+
+**Actionable failure.** `classify_token_page` turns "no tokens" into a verdict:
+`password_change`, `consent`, `login`, `mfa`, `token_link_unparsed`, `empty`, or
+`unknown`. The verdict is emitted as `event=verdict` and, for the two verdicts a user
+can act on, the flow raises `AccountActionRequired` (ADDHON-165) with a message that
+says where to go, instead of repeating the mute ADDHON-130 forever. The detection is
+structural, not textual: a page carrying the OAuth hand-off never holds a password form.
+`token_link_unparsed` is the mirror case and accuses our own parser rather than the
+account.
+
+The verdict runs with diagnostics off as well. A user who never ticks the checkbox still
+has to be told what to do, so only the trace lines are opt-in, not the diagnosis.

--- a/tests/test_auth_page_identity.py
+++ b/tests/test_auth_page_identity.py
@@ -1,0 +1,456 @@
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Page identity of the login flow, and the actionable failure it enables (issue #67).
+
+The v5.9.2 diagnostic release localized a report to "the token page carried no tokens",
+but could not say WHAT that page was: the trace only knew ``page_kind=other`` and
+``endpoint=auth_other``. These tests pin the two things that close that gap:
+
+- ``analyze_page`` names a page (path/query/title/text/form shape) using allowlists
+  only, so an unexpected interstitial is identifiable from ONE user log;
+- ``classify_token_page`` turns "no tokens" into a verdict, and a verdict the user can
+  act on (a set/change-password form, a consent wall) raises ADDHON-165 instead of the
+  mute ADDHON-130.
+
+The reproduction replays the exact shape of the reported trace: login accepted (session
+cookie minted), post-login ProgressiveLogin hop, then a VisualForce form with two
+password boxes where the OAuth hand-off should have been.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_stubs() -> None:
+    ce = _mod("homeassistant.config_entries")
+    ce.ConfigEntry = getattr(ce, "ConfigEntry", type("ConfigEntry", (), {}))
+    core = _mod("homeassistant.core")
+    core.HomeAssistant = getattr(core, "HomeAssistant", type("HomeAssistant", (), {}))
+    exc = _mod("homeassistant.exceptions")
+    base = getattr(exc, "HomeAssistantError", type("HomeAssistantError", (Exception,), {}))
+    exc.HomeAssistantError = base
+    exc.ConfigEntryNotReady = getattr(
+        exc, "ConfigEntryNotReady", type("ConfigEntryNotReady", (base,), {})
+    )
+    exc.ConfigEntryAuthFailed = getattr(
+        exc, "ConfigEntryAuthFailed", type("ConfigEntryAuthFailed", (base,), {})
+    )
+    uc = _mod("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = getattr(
+        uc, "DataUpdateCoordinator", type("DataUpdateCoordinator", (), {})
+    )
+    uc.UpdateFailed = getattr(uc, "UpdateFailed", type("UpdateFailed", (Exception,), {}))
+    ha = _mod("homeassistant")
+    ha.config_entries, ha.core, ha.exceptions = ce, core, exc
+    ha.helpers = _mod("homeassistant.helpers")
+    ha.helpers.update_coordinator = uc
+    yarl = _mod("yarl")
+    if not hasattr(yarl, "URL"):
+
+        class URL:
+            def __init__(self, s, encoded=False):
+                self._s = s
+
+            def __str__(self):
+                return self._s
+
+        yarl.URL = URL
+
+
+_install_stubs()
+
+from custom_components.addhon import error_codes as ec  # noqa: E402
+from custom_components.addhon.client.auth_diagnostics import (  # noqa: E402
+    ACCOUNT_ACTION_VERDICTS,
+    AuthDiagnosticTrace,
+    analyze_page,
+    classify_endpoint,
+    classify_failure_reason,
+    classify_token_page,
+    summarize_html,
+    summarize_page,
+)
+from custom_components.addhon.client.transport.auth import (  # noqa: E402
+    AccountActionRequired,
+    HonAuth,
+    NativeAuthError,
+)
+from custom_components.addhon.client.transport.device import HonDevice  # noqa: E402
+
+AUTH = "https://account2.hon-smarthome.com"
+CANARY = "CANARY-secret@example.com-token"
+
+# A Salesforce/VisualForce forced password step: hidden ViewState fields, two password
+# boxes (new + confirm), no login markers. Field names carry the j_id0 prefix exactly as
+# VisualForce emits them, which is why the kind detection matches by substring.
+CHANGE_PASSWORD_PAGE = f"""
+<html><head><title>Change Your Password</title></head><body>
+<form id="theForm" action="/apex/ChangePassword" method="post">
+<input type="hidden" name="com.salesforce.visualforce.ViewState" value="{CANARY}">
+<input type="hidden" name="com.salesforce.visualforce.ViewStateVersion" value="{CANARY}">
+<input type="hidden" name="j_id0:theForm:j_id5" value="{CANARY}">
+<input type="hidden" name="j_id0:theForm:j_id6" value="{CANARY}">
+<input type="hidden" name="j_id0:theForm:j_id7" value="{CANARY}">
+<input type="hidden" name="j_id0:theForm:j_id8" value="{CANARY}">
+<label>New Password</label>
+<input type="password" name="j_id0:theForm:newPassword" value="">
+<label>Confirm New Password</label>
+<input type="password" name="j_id0:theForm:confirmPassword" value="">
+<button type="submit">Continue</button>
+<div>Your password has expired. Set a new password to continue.</div>
+</form>
+<script>window.location.href = '{CANARY}';</script>
+</body></html>
+"""
+
+CONSENT_PAGE = f"""
+<html><head><title>Terms of Service</title></head><body>
+<form action="/apex/PrivacyConsent" method="post">
+<input type="hidden" name="com.salesforce.visualforce.ViewState" value="{CANARY}">
+<input type="checkbox" name="acceptTerms">
+<label>I accept the terms and the privacy policy</label>
+<button>Continue</button>
+</form></body></html>
+"""
+
+LOGIN_AGAIN_PAGE = f"""
+<html><head><title>Login</title></head><body>
+<form action="/s/login/" method="post">
+<input name="username" value="{CANARY}">
+<input type="password" name="pw" value="">
+<button>Log in</button></form></body></html>
+"""
+
+# The 300+ KB Lightning login page mentions privacy/terms in its footer. The v5.9.2
+# trace reported it as page_kind=privacy, which read like a consent wall when it was
+# simply the login page.
+LOGIN_PAGE = (
+    "<html><head><title>hOn Login</title></head><body>"
+    "<div>Sign in</div><a href='/privacy'>Privacy policy</a>"
+    "<a href='/terms'>Terms of use</a>"
+    "<script>var loginConfig = {\"fwuid\":\"FW\"};</script>"
+    "</body></html>"
+)
+
+
+class FakeResp:
+    def __init__(self, status=200, text="", json=None, headers=None) -> None:
+        self.status = status
+        self._text = text
+        self._json = json
+        self.headers = headers or {}
+
+    async def text(self):
+        return self._text
+
+    async def json(self, content_type=None):
+        if self._json is None:
+            raise ValueError("no json")
+        return self._json
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, responses) -> None:
+        self._responses = list(responses)
+        self.calls: list = []
+        self.cookie_jar = types.SimpleNamespace(clear_domain=lambda d: None)
+
+    def _next(self, method, url):
+        self.calls.append((method, str(url)))
+        if not self._responses:
+            raise AssertionError(f"unexpected call: {method} {url}")
+        return self._responses.pop(0)
+
+    def get(self, url, **kw):
+        return self._next("GET", url)
+
+    def post(self, url, **kw):
+        return self._next("POST", url)
+
+
+def _reported_chain(token_page: str):
+    """The reported flow (issue #67), up to and including the token page.
+
+    Mirrors the trace: the two manual redirects answer 200 with NO Location (so the
+    login URL is reused), the post-login page offers two ProgressiveLogin hrefs, and the
+    ProgressiveLogin page is a bare JS bounce with a single relative href.
+    """
+    return [
+        FakeResp(text="x url = '/s/login/p?startURL=%2Fhome' y"),
+        FakeResp(status=200, headers={}),
+        FakeResp(status=200, headers={}),
+        FakeResp(
+            text=(
+                "<html><head><title>hOn Login</title></head><body><div>Sign in</div>"
+                "<a href='/privacy'>Privacy policy</a><script>var ctx = "
+                '{"fwuid":"FW123","loaded":{"APPLICATION@x":"y"}};</script>'
+                "</body></html>"
+            )
+        ),
+        FakeResp(json={"events": [{"attributes": {"values": {"url": f"{AUTH}/tokpage"}}}]}),
+        FakeResp(
+            text=(
+                "<a href='/apex/ProgressiveLogin?startURL=%2Fhome'>a</a>"
+                "<a href='/apex/ProgressiveLogin?retURL=%2Fhome'>b</a>"
+            )
+        ),
+        FakeResp(text="<html><script>href = '/s/nextstep'</script></html>"),
+        FakeResp(text=token_page),
+    ]
+
+
+class PageIdentityTest(unittest.TestCase):
+    def test_login_page_is_no_longer_reported_as_a_consent_wall(self) -> None:
+        shape = summarize_html(LOGIN_PAGE)
+
+        self.assertTrue(shape.login)
+        self.assertTrue(shape.privacy)  # the footer words are still there
+        self.assertEqual("login", shape.page_kind)  # but they no longer win
+
+    def test_change_password_page_is_named_by_structure(self) -> None:
+        shape, page = analyze_page(f"{AUTH}/apex/ChangePassword?startURL=%2Fhome", CHANGE_PASSWORD_PAGE)
+
+        self.assertEqual(2, shape.password_inputs)
+        self.assertTrue(shape.password_change)
+        self.assertEqual("password_change", shape.page_kind)
+        self.assertIn("new_password", shape.input_kinds)
+        self.assertIn("confirm_password", shape.input_kinds)
+        self.assertIn("security", shape.input_kinds)  # the ViewState hidden fields
+        # The path names the step itself: the changepassword rule beats the generic
+        # /apex/ one, so the log says WHICH interstitial it was.
+        self.assertEqual("change_password", page.endpoint)
+        self.assertEqual(("apex", "changepassword"), page.path_markers)
+        self.assertEqual(("starturl",), page.query_names)
+        self.assertEqual("change_password", page.form_action)
+        self.assertEqual("post", page.form_method)
+        self.assertIn("password", page.title_markers)
+        self.assertIn("expir", page.text_markers)
+        self.assertIn("continu", page.text_markers)
+        self.assertTrue(page.js_redirect)
+        self.assertFalse(page.hon_scheme)
+        self.assertEqual(0, page.oauth_done_hits)
+
+    def test_script_bodies_are_not_read_as_page_text(self) -> None:
+        # Otherwise every marker in 300 KB of framework JS would be "present" and the
+        # vocabulary would say nothing at all.
+        page = summarize_page(
+            f"{AUTH}/s/x",
+            "<html><body><script>var terms='accept the privacy policy'</script>"
+            "<div>Hello</div></body></html>",
+        )
+
+        self.assertEqual((), page.text_markers)
+
+    def test_page_summary_keeps_no_url_or_content_material(self) -> None:
+        shape, page = analyze_page(
+            f"{AUTH}/apex/ChangePassword?startURL=%2F{CANARY}&secretName={CANARY}",
+            CHANGE_PASSWORD_PAGE,
+        )
+
+        rendered = repr((shape, page))
+        self.assertNotIn(CANARY, rendered)
+        self.assertNotIn("secretname", rendered)
+        self.assertEqual(1, page.unknown_query)  # counted, never named
+        self.assertEqual(12, len(page.path_hash))
+
+    def test_new_interstitial_endpoints_are_named(self) -> None:
+        cases = {
+            f"{AUTH}/s/changepassword?ec=1": "change_password",
+            f"{AUTH}/secur/setpassword.jsp": "set_password",
+            f"{AUTH}/s/forgotpassword": "reset_password",
+            f"{AUTH}/secur/frontdoor.jsp?sid=x": "secur",
+            f"{AUTH}/apex/SomeStep": "apex_page",
+        }
+        for url, expected in cases.items():
+            with self.subTest(url=url):
+                self.assertEqual(expected, classify_endpoint(url))
+
+
+class TokenPageVerdictTest(unittest.TestCase):
+    def _verdict(self, url: str, page_html: str) -> str:
+        shape, page = analyze_page(url, page_html)
+        return classify_token_page(shape, page)
+
+    def test_password_form_is_an_account_action(self) -> None:
+        verdict = self._verdict(f"{AUTH}/apex/ChangePassword", CHANGE_PASSWORD_PAGE)
+
+        self.assertEqual("password_change", verdict)
+        self.assertIn(verdict, ACCOUNT_ACTION_VERDICTS)
+
+    def test_consent_form_is_an_account_action(self) -> None:
+        verdict = self._verdict(f"{AUTH}/apex/PrivacyConsent", CONSENT_PAGE)
+
+        self.assertEqual("consent", verdict)
+        self.assertIn(verdict, ACCOUNT_ACTION_VERDICTS)
+
+    def test_a_returned_login_form_is_not_blamed_on_the_account(self) -> None:
+        verdict = self._verdict(f"{AUTH}/s/login/", LOGIN_AGAIN_PAGE)
+
+        self.assertEqual("login", verdict)
+        self.assertNotIn(verdict, ACCOUNT_ACTION_VERDICTS)
+
+    def test_a_present_but_unparsed_hand_off_accuses_our_parser(self) -> None:
+        verdict = self._verdict(
+            f"{AUTH}/finaltok",
+            "<html><body>href = 'hon://mobilesdk/detect/oauth/done"
+            "#access_token=AAA&amp;id_token=CCC'</body></html>",
+        )
+
+        self.assertEqual("token_link_unparsed", verdict)
+        self.assertNotIn(verdict, ACCOUNT_ACTION_VERDICTS)
+
+    def test_empty_body_is_named_empty(self) -> None:
+        self.assertEqual("empty", self._verdict(f"{AUTH}/finaltok", ""))
+
+
+class ReportedFailureTest(unittest.TestCase):
+    """End to end over the reported chain, with the diagnostics OFF and ON."""
+
+    def _auth(self, responses, trace=None):
+        return HonAuth(
+            FakeSession(responses), "user@x.it", "pw", HonDevice(), auth_trace=trace
+        )
+
+    def test_password_step_raises_an_actionable_code_without_diagnostics(self) -> None:
+        # The actionable error must NOT depend on the opt-in checkbox: a user who never
+        # enables diagnostics still has to be told what to do.
+        auth = self._auth(_reported_chain(CHANGE_PASSWORD_PAGE))
+
+        with self.assertRaises(AccountActionRequired) as caught:
+            asyncio.run(auth.authenticate())
+
+        err = caught.exception
+        self.assertIs(ec.ACCOUNT_ACTION_REQUIRED, err.error_code)
+        self.assertEqual("ADDHON-165", err.error_code.label)
+        self.assertIs(ec.ACCOUNT_ACTION_REQUIRED, ec.classify(err))
+        self.assertTrue(err.error_code.requires_reauth)
+        self.assertEqual("account_action", classify_failure_reason(err))
+        self.assertNotIn(CANARY, str(err))
+
+    def test_unknown_token_page_keeps_the_generic_code(self) -> None:
+        auth = self._auth(
+            _reported_chain("<html><body><div>nothing useful here</div></body></html>")
+        )
+
+        with self.assertRaises(NativeAuthError) as caught:
+            asyncio.run(auth.authenticate())
+
+        err = caught.exception
+        self.assertNotIsInstance(err, AccountActionRequired)
+        self.assertIs(ec.AUTH_GET_TOKEN, ec.classify(err))
+        self.assertEqual("incomplete_tokens", classify_failure_reason(err))
+
+    def test_trace_identifies_the_page_and_the_verdict(self) -> None:
+        trace = AuthDiagnosticTrace(enabled=True)
+        auth = self._auth(_reported_chain(CHANGE_PASSWORD_PAGE), trace=trace)
+        logger = logging.getLogger("tests.addhon.page_identity")
+
+        with self.assertRaises(AccountActionRequired):
+            asyncio.run(auth.authenticate())
+
+        with self.assertLogs(logger.name, level="WARNING") as captured:
+            trace.flush(
+                logger,
+                code="ADDHON-165",
+                phase="get_token",
+                reason="account_action",
+            )
+
+        joined = "\n".join(captured.output)
+        self.assertNotIn(CANARY, joined)
+        self.assertIn("event=verdict phase=token_response page=password_change", joined)
+        self.assertIn("event=page phase=token_response", joined)
+        self.assertIn("form_action=change_password", joined)
+        self.assertIn("page_kind=password_change", joined)
+        # The skeleton is emitted for the pages the flow did not expect, and NOT for the
+        # ordinary login stop.
+        self.assertIn("event=skeleton phase=token_response", joined)
+        self.assertNotIn("event=skeleton phase=login_page", joined)
+        self.assertIn("code=ADDHON-165", joined)
+        self.assertIn("reason=account_action", joined)
+
+    def test_consent_wall_without_a_next_hop_is_still_actionable(self) -> None:
+        # A consent form has no navigation href at all, so the flow used to die on the
+        # mute "get_token: no href" one step earlier than the token page.
+        responses = _reported_chain(CHANGE_PASSWORD_PAGE)[:5]
+        responses.append(FakeResp(text=CONSENT_PAGE))
+        auth = self._auth(responses)
+
+        with self.assertRaises(AccountActionRequired) as caught:
+            asyncio.run(auth.authenticate())
+
+        self.assertIn("post_login", str(caught.exception))
+        self.assertIs(ec.ACCOUNT_ACTION_REQUIRED, ec.classify(caught.exception))
+
+    def test_progressive_dead_end_is_still_actionable(self) -> None:
+        responses = _reported_chain(CHANGE_PASSWORD_PAGE)[:6]
+        responses.append(FakeResp(text=CHANGE_PASSWORD_PAGE.replace("href", "hxef")))
+        auth = self._auth(responses)
+
+        with self.assertRaises(AccountActionRequired) as caught:
+            asyncio.run(auth.authenticate())
+
+        self.assertIn("progressive_page", str(caught.exception))
+
+    def test_a_broken_classifier_still_raises_the_token_error(self) -> None:
+        # The classification is a diagnostic: if it blows up, the login must still fail
+        # with its own error instead of a crash from the diagnostics.
+        auth = self._auth(_reported_chain(CHANGE_PASSWORD_PAGE))
+
+        with patch(
+            "custom_components.addhon.client.transport.auth.analyze_page",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertRaises(NativeAuthError) as caught:
+                asyncio.run(auth.authenticate())
+
+        self.assertNotIsInstance(caught.exception, AccountActionRequired)
+        self.assertIs(ec.AUTH_GET_TOKEN, ec.classify(caught.exception))
+
+    def test_trace_stays_bounded_on_a_huge_hostile_page(self) -> None:
+        trace = AuthDiagnosticTrace(enabled=True)
+        huge = "<div>" + (CANARY + " password ") * 20000 + "</div>"
+        auth = self._auth(_reported_chain(huge), trace=trace)
+        logger = logging.getLogger("tests.addhon.page_identity.bounded")
+
+        with self.assertRaises(NativeAuthError):
+            asyncio.run(auth.authenticate())
+
+        with self.assertLogs(logger.name, level="WARNING") as captured:
+            trace.flush(
+                logger, code="ADDHON-130", phase="get_token", reason="incomplete_tokens"
+            )
+
+        joined = "\n".join(captured.output)
+        self.assertNotIn(CANARY, joined)
+        for line in captured.output:
+            self.assertLess(len(line), 4096)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auth_page_identity.py
+++ b/tests/test_auth_page_identity.py
@@ -324,6 +324,19 @@ class TokenPageVerdictTest(unittest.TestCase):
         self.assertEqual("token_link_unparsed", verdict)
         self.assertNotIn(verdict, ACCOUNT_ACTION_VERDICTS)
 
+    def test_an_echoed_hand_off_does_not_hide_the_password_form(self) -> None:
+        # The reported page carried HTML-escaped markup, and a Salesforce interstitial
+        # echoes the OAuth request it interrupted. Quoting hon://...oauth/done must not
+        # outrank two password boxes, or the real diagnosis flips to "our parser".
+        echoed = CHANGE_PASSWORD_PAGE.replace(
+            "<div>Your password",
+            "<div>hon://mobilesdk/detect/oauth/done#state=x&amp;y</div><div>Your password",
+        )
+
+        verdict = self._verdict(f"{AUTH}/apex/ChangePassword", echoed)
+
+        self.assertEqual("password_change", verdict)
+
     def test_empty_body_is_named_empty(self) -> None:
         self.assertEqual("empty", self._verdict(f"{AUTH}/finaltok", ""))
 

--- a/tests/test_auth_page_identity.py
+++ b/tests/test_auth_page_identity.py
@@ -333,9 +333,12 @@ class TokenPageVerdictTest(unittest.TestCase):
             "<div>hon://mobilesdk/detect/oauth/done#state=x&amp;y</div><div>Your password",
         )
 
-        verdict = self._verdict(f"{AUTH}/apex/ChangePassword", echoed)
+        shape, page = analyze_page(f"{AUTH}/apex/ChangePassword", echoed)
 
-        self.assertEqual("password_change", verdict)
+        self.assertEqual("password_change", classify_token_page(shape, page))
+        # page_kind must agree: it is what gates the event=skeleton emission, so an
+        # oauth_done classification here would drop the shape of this very page.
+        self.assertEqual("password_change", shape.page_kind)
 
     def test_empty_body_is_named_empty(self) -> None:
         self.assertEqual("empty", self._verdict(f"{AUTH}/finaltok", ""))

--- a/tests/test_config_flow_mfa.py
+++ b/tests/test_config_flow_mfa.py
@@ -119,8 +119,17 @@ class _FakeHass:
         self.config_entries = _FakeConfigEntries(entry)
         self.tasks: list = []
 
-    async def async_add_executor_job(self, func, *args):
-        return func(*args)
+    def async_add_executor_job(self, func, *args):
+        # HA's real one is SYNC and returns an awaitable Future, so it works both
+        # awaited (validate_input) and fire-and-forget (the async_remove fallback).
+        future = asyncio.get_running_loop().create_future()
+        try:
+            result = func(*args)
+        except Exception as err:  # noqa: BLE001 - mirror the executor's error carry
+            future.set_exception(err)
+        else:
+            future.set_result(result)
+        return future
 
     def async_create_task(self, coro, *args, **kwargs):
         # HA schedules the coroutine on the running loop and returns the task; mirroring
@@ -157,6 +166,9 @@ class _FakeMfaClient:
         return self._refresh_token
 
     async def async_close(self):
+        self.closed = True
+
+    def close_sync(self):
         self.closed = True
 
     def discard_auth_diagnostics(self):
@@ -389,7 +401,6 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
         # A loop already going away (or any scheduling refusal) must not silently leak
         # the held client: the teardown then runs on the calling thread.
         client = _FakeMfaClient()
-        client._close_sync = lambda: setattr(client, "closed", True)
 
         async def challenge(hass, data, **kwargs):
             raise _challenge(client)
@@ -402,7 +413,7 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
             raise RuntimeError("event loop is closed")
 
         flow.hass.async_create_task = _refuse
-        flow.async_remove()
+        flow.async_remove()  # falls back to the executor, never blocks the loop
 
         self.assertTrue(client.closed)
         self.assertTrue(client.diagnostics_discarded)

--- a/tests/test_config_flow_mfa.py
+++ b/tests/test_config_flow_mfa.py
@@ -385,6 +385,29 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(asyncio.iscoroutinefunction(ConfigFlow.async_remove))
 
+    async def test_async_remove_closes_the_client_when_scheduling_fails(self) -> None:
+        # A loop already going away (or any scheduling refusal) must not silently leak
+        # the held client: the teardown then runs on the calling thread.
+        client = _FakeMfaClient()
+        client._close_sync = lambda: setattr(client, "closed", True)
+
+        async def challenge(hass, data, **kwargs):
+            raise _challenge(client)
+
+        self._patch_validate(challenge)
+        flow = _make_flow(_FakeEntry())
+        await flow.async_step_user({"email": "p@x.com", "password": "p"})
+
+        def _refuse(coro, *args, **kwargs):
+            raise RuntimeError("event loop is closed")
+
+        flow.hass.async_create_task = _refuse
+        flow.async_remove()
+
+        self.assertTrue(client.closed)
+        self.assertTrue(client.diagnostics_discarded)
+        self.assertIsNone(flow._mfa_client)
+
     async def test_async_remove_closes_abandoned_client(self) -> None:
         client = _FakeMfaClient()
 

--- a/tests/test_config_flow_mfa.py
+++ b/tests/test_config_flow_mfa.py
@@ -9,6 +9,7 @@ re-prompt on a wrong code / resend. stdlib unittest with HA + voluptuous stubs.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 import unittest
@@ -116,9 +117,17 @@ class _FakeConfigEntries:
 class _FakeHass:
     def __init__(self, entry):
         self.config_entries = _FakeConfigEntries(entry)
+        self.tasks: list = []
 
     async def async_add_executor_job(self, func, *args):
         return func(*args)
+
+    def async_create_task(self, coro, *args, **kwargs):
+        # HA schedules the coroutine on the running loop and returns the task; mirroring
+        # that lets a test await the teardown that async_remove() only SCHEDULES.
+        task = asyncio.ensure_future(coro)
+        self.tasks.append(task)
+        return task
 
 
 class _FakeMfaClient:
@@ -368,6 +377,14 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("create_entry", result["type"])
         self.assertEqual("RT-NEW", result["data"]["refresh_token"])
 
+    async def test_async_remove_is_not_a_coroutine_function(self) -> None:
+        # data_entry_flow calls flow.async_remove() WITHOUT awaiting it. As a coroutine
+        # it was never executed: HA only logged "coroutine 'ConfigFlow.async_remove' was
+        # never awaited" and the held 2FA client kept its loop/thread/session.
+        from custom_components.addhon.config_flow import ConfigFlow
+
+        self.assertFalse(asyncio.iscoroutinefunction(ConfigFlow.async_remove))
+
     async def test_async_remove_closes_abandoned_client(self) -> None:
         client = _FakeMfaClient()
 
@@ -378,7 +395,8 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
         flow = _make_flow(_FakeEntry())
         await flow.async_step_user({"email": "p@x.com", "password": "p"})  # held client
         self.assertFalse(client.closed)
-        await flow.async_remove()  # HA removes the abandoned flow
+        flow.async_remove()  # HA removes the abandoned flow (SYNC call, never awaited)
+        await asyncio.gather(*flow.hass.tasks)
         self.assertTrue(client.closed)
         self.assertTrue(client.diagnostics_discarded)
 
@@ -394,7 +412,8 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
         flow = _make_flow(_FakeEntry())
         await flow.async_step_user({"email": "p@x.com", "password": "secret-pw"})
         self.assertIsNotNone(flow._mfa_data)  # cached during the challenge
-        await flow.async_remove()
+        flow.async_remove()
+        await asyncio.gather(*flow.hass.tasks)
         self.assertIsNone(flow._mfa_data)
         self.assertIsNone(flow._mfa_reauth_entry)
 

--- a/tests/test_config_flow_mfa.py
+++ b/tests/test_config_flow_mfa.py
@@ -397,6 +397,25 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(asyncio.iscoroutinefunction(ConfigFlow.async_remove))
 
+    async def test_async_remove_closes_the_client_without_hass(self) -> None:
+        # The other fallback: async_remove() before self.hass is assigned has neither a
+        # loop nor an executor, so the teardown must happen on the calling thread.
+        client = _FakeMfaClient()
+
+        async def challenge(hass, data, **kwargs):
+            raise _challenge(client)
+
+        self._patch_validate(challenge)
+        flow = _make_flow(_FakeEntry())
+        await flow.async_step_user({"email": "p@x.com", "password": "p"})
+        del flow.hass
+
+        flow.async_remove()
+
+        self.assertTrue(client.closed)
+        self.assertTrue(client.diagnostics_discarded)
+        self.assertIsNone(flow._mfa_client)
+
     async def test_async_remove_closes_the_client_when_scheduling_fails(self) -> None:
         # A loop already going away (or any scheduling refusal) must not silently leak
         # the held client: the teardown then runs on the calling thread.

--- a/tests/test_config_flow_mfa.py
+++ b/tests/test_config_flow_mfa.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -145,6 +146,7 @@ class _FakeMfaClient:
         self.fail_code = fail_code
         self.send_raises = send_raises
         self.closed = False
+        self.closed_on_thread = ""
         self.sent = 0
         self.submitted: list[str] = []
         self.diagnostics_discarded = False
@@ -170,6 +172,7 @@ class _FakeMfaClient:
 
     def close_sync(self):
         self.closed = True
+        self.closed_on_thread = threading.current_thread().name
 
     def discard_auth_diagnostics(self):
         self.diagnostics_discarded = True
@@ -397,6 +400,41 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(asyncio.iscoroutinefunction(ConfigFlow.async_remove))
 
+    async def _wait_closed(self, client, timeout: float = 2.0) -> bool:
+        """Await a teardown that may have been handed to another thread."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while not client.closed and loop.time() < deadline:
+            await asyncio.sleep(0.01)
+        return client.closed
+
+    async def test_async_remove_never_closes_on_the_calling_thread(self) -> None:
+        # The teardown waits on the client's dedicated loop and joins its thread, so even
+        # when HA refuses BOTH of its schedulers it must not run here: HA's event loop
+        # would stall for the whole teardown timeout.
+        client = _FakeMfaClient()
+
+        async def challenge(hass, data, **kwargs):
+            raise _challenge(client)
+
+        self._patch_validate(challenge)
+        flow = _make_flow(_FakeEntry())
+        await flow.async_step_user({"email": "p@x.com", "password": "p"})
+
+        def _refuse(*args, **kwargs):
+            raise RuntimeError("event loop is closed")
+
+        flow.hass.async_create_task = _refuse
+        flow.hass.async_add_executor_job = _refuse
+
+        flow.async_remove()
+
+        self.assertTrue(await self._wait_closed(client))
+        self.assertNotEqual(
+            threading.current_thread().name, client.closed_on_thread
+        )
+        self.assertIsNone(flow._mfa_client)
+
     async def test_async_remove_closes_the_client_without_hass(self) -> None:
         # The other fallback: async_remove() before self.hass is assigned has neither a
         # loop nor an executor, so the teardown must happen on the calling thread.
@@ -412,7 +450,7 @@ class MfaFlowTest(unittest.IsolatedAsyncioTestCase):
 
         flow.async_remove()
 
-        self.assertTrue(client.closed)
+        self.assertTrue(await self._wait_closed(client))
         self.assertTrue(client.diagnostics_discarded)
         self.assertIsNone(flow._mfa_client)
 

--- a/tests/test_transport_auth.py
+++ b/tests/test_transport_auth.py
@@ -182,7 +182,7 @@ class NativeAuthFlowTest(unittest.TestCase):
             name: Mock(side_effect=AssertionError(f"{name} was called"))
             for name in (
                 "summarize_response",
-                "summarize_html",
+                "analyze_page",
                 "summarize_links",
                 "summarize_json",
                 "summarize_tokens",


### PR DESCRIPTION
Automated release PR for `v5.9.3`.

<!-- release-tag: v5.9.3 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer detection of post-login account steps, including password changes and consent pages.
  * Added a dedicated error message instructing users to complete required account actions on the hOn website or app.
  * Expanded optional authentication diagnostics with page identity and actionable failure details.

* **Bug Fixes**
  * Prevented MFA cleanup from being skipped when a configuration flow is removed.
  * Improved handling of incomplete or unexpected login redirects.

* **Documentation**
  * Documented post-login interstitial handling and updated protocol guidance.

* **Chores**
  * Updated the integration to version 5.9.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release improves authentication diagnostics and safely cleans up MFA clients when configuration flows are removed.
- Detects password-change and consent interstitials and reports an actionable account-action error.
- Adds privacy-preserving page identity, structural diagnostics, and token-page verdicts.
- Reworks MFA teardown to avoid blocking Home Assistant’s event loop.
- Updates translations, protocol documentation, tests, and the integration version to 5.9.3.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported event-loop-blocking MFA cleanup fallback has been replaced with off-loop teardown paths.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/config_flow.py | Replaces the ineffective coroutine removal hook with synchronous detachment and non-blocking teardown scheduling. |
| custom_components/addhon/hon_client.py | Exposes the existing blocking client teardown through a public synchronous method for off-loop cleanup. |
| custom_components/addhon/client/auth_diagnostics.py | Adds bounded structural page analysis, page identity events, and account-interstitial classification. |
| custom_components/addhon/client/transport/auth.py | Integrates page diagnostics and raises a dedicated error for structurally detected account actions. |
| custom_components/addhon/error_codes.py | Registers and classifies the new account-action-required authentication error. |
| tests/test_config_flow_mfa.py | Covers synchronous flow removal, scheduler fallbacks, off-thread teardown, and MFA state cleanup. |
| tests/test_transport_auth.py | Exercises authentication interstitial classification and related token-flow behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Configuration flow removed] --> B[Detach MFA client and clear cached credentials]
    B --> C{Schedule async teardown on HA loop}
    C -->|Accepted| D[async_close delegates blocking close to executor]
    C -->|Rejected| E{Submit synchronous close to HA executor}
    E -->|Accepted| F[close_sync runs in executor]
    E -->|Rejected| G{Start dedicated daemon teardown thread}
    G -->|Started| H[close_sync runs outside event loop]
    G -->|Failed| I[Log cleanup warning]
    D --> J[Discard diagnostics and release client resources]
    F --> J
    H --> J
```

<sub>Reviews (3): Last reviewed commit: ["fix(config-flow): never tear the 2FA cli..."](https://github.com/tis24dev/addhon/commit/78f4b049eed5e73fc98b72fb16c9af80c9632e19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47148285)</sub>

<!-- /greptile_comment -->