### PR TITLE
Release v5.11.0

### DIFF
--- a/custom_components/addhon/air_purifier.py
+++ b/custom_components/addhon/air_purifier.py
@@ -40,14 +40,16 @@ AP_PRESET_TO_MODE = {preset: raw for raw, preset in AP_MODE_TO_PRESET.items()}
 # The panel light has three discrete steps, not a brightness scale, so it is
 # offered as named positions rather than a percentage the device cannot honour.
 #
-# The ENCODING is the one open question of this feature: this mapping reads a
-# higher raw value as a dimmer panel, which the device's own behaviour supports
-# (stopping the purifier moves lightStatus to 2) while the beta tester reports the
-# opposite from looking at the panel. Both readings cannot be right, and the
-# capture that would settle it disagrees with itself: the appliance attributes and
-# the activity record report 0 and 2 for the same instant. Kept in ONE dict so
-# settling it is a single edit, here, with no entity or option name changing.
-AP_LIGHT_TO_OPTION = {"2": "off", "1": "low", "0": "high"}
+# The encoding is DIRECT, and this is measured rather than inferred: two captures
+# taken from the same HHP50CA011 straight after driving the official application's
+# own slider report lightStatus 2 at 100% and 0 at Off, with the appliance
+# attributes, the shadow parameters and the settings command all agreeing in both.
+#
+# It used to read the other way round, from the device moving lightStatus to 2
+# when the purifier stops. That inference was wrong, and it cost the beta tester a
+# control that did the opposite of what it said: asking for 100% sent raw 0 and
+# switched the panel off.
+AP_LIGHT_TO_OPTION = {"0": "off", "1": "low", "2": "high"}
 AP_OPTION_TO_LIGHT = {option: raw for raw, option in AP_LIGHT_TO_OPTION.items()}
 
 # Display order of the offered positions, dimmest first. Independent of the raw

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -700,6 +700,11 @@ def _entity_inventory(
         section = per_appliance[appliance_id]
         bucket = section["by_domain"].setdefault(domain, [])
         if len(bucket) >= _ENTITY_MAX_PER_DOMAIN:
+            # Marked on the section that actually dropped a row, not entry-wide:
+            # a complete inventory carrying someone else's truncation flag reads
+            # as incomplete, and the reader stops trusting the one thing this
+            # section exists to state.
+            section["truncated"] = True
             truncated = True
             continue
         key = _entity_row(unique_id, appliance_id)
@@ -725,8 +730,6 @@ def _entity_inventory(
         for field in ("disabled", "hidden", "not_created"):
             if field in section and isinstance(section[field], list):
                 section[field] = sorted(section[field])
-        if truncated:
-            section["truncated"] = True
 
     platforms = {
         "status": status,

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -20,10 +20,26 @@ Per appliance the dump carries, beyond the bare key list it used to emit:
                     currently reporting that this code does NOT handle. Passive: it
                     surfaces a firmware ahead of the integration without any entity
                     being guessed into existence.
+  * `entities`    - what Home Assistant ACTUALLY has for this appliance, read from
+                    the entity registry and cross-checked against the live state
+                    machine. `coverage` above says what the code could map for this
+                    TYPE; it is computed from static tables and stays identical
+                    whether an entity was created or the whole platform crashed.
+                    That gap is why "the control is missing from Home Assistant"
+                    used to be unanswerable from a dump and needed the log as well.
+
+The entry-level `platforms` block is the same reading one level up, and it exists
+for the case the per-appliance one cannot cover: when setup fails there are no
+appliances at all, and the registry is owned by Home Assistant core, so it is
+still readable. Its per-domain `account` counts are the discriminator between a
+platform that DIED and a device that was legitimately gated out: the two account
+debug entities are created unconditionally, so a domain missing them never ran.
 
 Identity (id/serial/mac and credential-ish keys) is redacted. The device nickname
 (`name`) is kept readable on purpose, to correlate the dump with the physical
-appliance.
+appliance. The entity inventory deliberately emits neither `entity_id` (its
+object_id is the nickname slug) nor a raw `unique_id` (its prefix is the
+appliance id): only the entity domain and the code-authored unique_id suffix.
 """
 from __future__ import annotations
 
@@ -155,6 +171,11 @@ _COVERAGE_META_PARAMS = frozenset(
 # Bounds for the future-capability section. It is passive evidence, not a report:
 # a firmware declaring hundreds of values must add a hint to the dump, never bloat
 # it. Truncation is announced with a `truncated` flag rather than silently applied.
+# Bound for the entity inventory, per appliance and per domain. An appliance has a
+# few dozen entities today; the cap is a runaway guard, not a filter, and like the
+# future-capability bounds it announces itself rather than truncating silently.
+_ENTITY_MAX_PER_DOMAIN = 80
+
 _FUTURE_MAX_ENTRIES = 40
 _FUTURE_MAX_VALUES = 20
 # A separate CHARACTER bound. An unhandled state value is one scalar, so it needs a
@@ -505,8 +526,15 @@ def _future_capabilities(app_type, attributes: Mapping, appliance) -> dict:
     return section
 
 
-def _appliance_block(appliance_id: str, data: Mapping) -> dict:
-    """Build the (redacted) diagnostics block for a single appliance."""
+def _appliance_block(
+    appliance_id: str, data: Mapping, entities: Mapping | None = None
+) -> dict:
+    """Build the (redacted) diagnostics block for a single appliance.
+
+    `entities` is the registry-derived inventory for THIS appliance, already
+    computed once for the whole dump. It defaults to None so the helper stays
+    hass-less and pure, and so a caller with no registry still produces a block.
+    """
     appliance = data.get("appliance")
     app_type = data.get("type")
     attributes = data.get("attributes")
@@ -540,9 +568,203 @@ def _appliance_block(appliance_id: str, data: Mapping) -> dict:
         "attributes": dict(attributes),
         "commands": commands,
         "coverage": coverage,
+        # Next to coverage on purpose: one says what the code could map for this
+        # type, the other what Home Assistant actually holds. Reading them together
+        # is the whole point, and a disagreement between them IS the finding.
+        "entities": dict(entities) if isinstance(entities, Mapping) else None,
         "future_capabilities": future,
     }
     return _redact(block)
+
+
+def _registry_entries(hass: HomeAssistant, entry: ConfigEntry) -> list | None:
+    """Every registry row of this config entry, or None when unreadable.
+
+    The import is function-local, mirroring `_remove_legacy_entities`: the module
+    must stay importable where `homeassistant.helpers.entity_registry` is not
+    installed, and the registry is only ever needed while a dump is being built.
+
+    None and [] mean DIFFERENT things and must never be folded together: [] is
+    "Home Assistant remembers nothing for this entry", which is a finding, while
+    None is "this dump could not look", which is the absence of one. Reporting the
+    second as the first would invent the exact failure the section exists to
+    detect.
+    """
+    try:
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        if registry is None:
+            return None
+        entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: entity registry unreadable", exc_info=True)
+        return None
+    return list(entries)
+
+
+def _states_getter(hass: HomeAssistant):
+    """`hass.states.get`, or None where there is no state machine to ask."""
+    try:
+        return getattr(getattr(hass, "states", None), "get", None)
+    except Exception:  # noqa: BLE001 - same rule as above
+        return None
+
+
+def _entity_row(unique_id: str, appliance_id: str) -> str:
+    """The unique_id with its appliance prefix removed.
+
+    Every entity in this integration is named `f"{appliance_id}_{suffix}"` where the
+    suffix is a constant written in this repository, so what is emitted is drawn
+    from a closed, already-public vocabulary. Slicing (rather than masking) is what
+    keeps the appliance id out: the caller has already proven the prefix matches.
+    """
+    return unique_id[len(appliance_id) + 1:]
+
+
+def _entity_inventory(
+    entries: list | None,
+    appliance_ids: list,
+    entry_id: str,
+    state_get,
+) -> tuple[dict, dict]:
+    """Split the registry rows into a per-appliance view and an entry-wide one.
+
+    Returns ``(per_appliance, platforms)``. Pure: it takes the rows, never `hass`.
+
+    Three facts drive the shape:
+
+    - A row is attributed by unique_id PREFIX, longest id first. Prefixes nest for
+      real (a multi-zone appliance expands into `<id>`, `<id>_z1`), and the
+      mandatory separator plus longest-first order resolves that. Suffix matching,
+      which the legacy cleanup documents as ambiguous, is never used.
+    - A DISABLED row has no state by construction: Home Assistant does not add
+      disabled entities to the state machine. Consulting the state machine for one
+      would report every user-disabled entity as "the platform failed", which is
+      the single most common reason a control is missing and the least alarming.
+    - A row that is enabled and yet has no live state (or a `restored` one) is the
+      interesting case: Home Assistant remembers the entity from an earlier run but
+      nothing re-created it now. That is what a dead platform looks like, and it is
+      invisible to the registry alone, which survives reloads.
+    """
+    unavailable = {"status": "unavailable"}
+    ids = sorted(
+        (i for i in appliance_ids if isinstance(i, str) and i), key=len, reverse=True
+    )
+    if entries is None:
+        return ({appliance_id: dict(unavailable) for appliance_id in ids}, dict(unavailable))
+
+    status = "ok" if callable(state_get) else "registry_only"
+    # Seeded for EVERY appliance, before a single row is read: an appliance with no
+    # rows must render as "nothing was created", never as "nothing was looked at".
+    per_appliance: dict = {
+        appliance_id: {"status": status, "by_domain": {}} for appliance_id in ids
+    }
+    account: dict = {}
+    account_not_created: dict = {}
+    unattributed = 0
+    truncated = False
+
+    for row in entries:
+        unique_id = getattr(row, "unique_id", None) or ""
+        entity_id = getattr(row, "entity_id", None) or ""
+        domain = entity_id.split(".", 1)[0]
+        if not unique_id or not domain:
+            unattributed += 1
+            continue
+        if entry_id and unique_id.startswith(f"{entry_id}_diag_"):
+            # Account-level debug entities: they belong to no appliance, and they
+            # are created unconditionally. A domain missing from here is a domain
+            # whose platform did not finish, which is what separates a dead
+            # platform from a device that was simply gated out.
+            #
+            # Counted the same way an appliance row is: a registry row left over
+            # from an earlier run proves the platform ran ONCE, not that it ran
+            # now, and taking it at face value would clear the very platform that
+            # just died. Disabled rows are skipped for the same reason as below.
+            account[domain] = account.get(domain, 0) + 1
+            if (
+                callable(state_get)
+                and not _enum_text(getattr(row, "disabled_by", None))
+                and _is_restored(state_get, entity_id)
+            ):
+                account_not_created[domain] = account_not_created.get(domain, 0) + 1
+            continue
+        appliance_id = next(
+            (i for i in ids if unique_id.startswith(f"{i}_")), None
+        )
+        if appliance_id is None:
+            unattributed += 1
+            continue
+
+        section = per_appliance[appliance_id]
+        bucket = section["by_domain"].setdefault(domain, [])
+        if len(bucket) >= _ENTITY_MAX_PER_DOMAIN:
+            truncated = True
+            continue
+        key = _entity_row(unique_id, appliance_id)
+        bucket.append(key)
+        disabled_by = _enum_text(getattr(row, "disabled_by", None))
+        hidden_by = _enum_text(getattr(row, "hidden_by", None))
+        if disabled_by:
+            section.setdefault("disabled", {})[key] = disabled_by
+            continue
+        if hidden_by:
+            section.setdefault("hidden", {})[key] = hidden_by
+        if not callable(state_get):
+            continue
+        if _is_restored(state_get, entity_id):
+            section.setdefault("not_created", []).append(key)
+
+    totals: dict = {}
+    for section in per_appliance.values():
+        for domain, keys in section["by_domain"].items():
+            totals[domain] = totals.get(domain, 0) + len(keys)
+        for domain in section["by_domain"]:
+            section["by_domain"][domain] = sorted(section["by_domain"][domain])
+        for field in ("disabled", "hidden", "not_created"):
+            if field in section and isinstance(section[field], list):
+                section[field] = sorted(section[field])
+        if truncated:
+            section["truncated"] = True
+
+    platforms = {
+        "status": status,
+        "appliance_totals": totals,
+        "account": account,
+        "account_not_created": account_not_created,
+        "unattributed": unattributed,
+    }
+    if truncated:
+        platforms["truncated"] = True
+    return per_appliance, platforms
+
+
+def _enum_text(value) -> str | None:
+    """A registry flag as plain text: these are enums whose `.value` is the token."""
+    if value is None:
+        return None
+    inner = getattr(value, "value", value)
+    return str(inner)
+
+
+def _is_restored(state_get, entity_id: str) -> bool:
+    """True when the registry remembers the entity but nothing created it now.
+
+    Home Assistant writes a placeholder state carrying ``restored: True`` for a
+    registered entity no platform added, so the two cases (no state at all, and a
+    restored one) are the same finding.
+    """
+    try:
+        state = state_get(entity_id)
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        return False
+    if state is None:
+        return True
+    attributes = getattr(state, "attributes", None)
+    if isinstance(attributes, Mapping):
+        return bool(attributes.get("restored"))
+    return False
 
 
 def _coordinator(hass: HomeAssistant, entry: ConfigEntry):
@@ -594,12 +816,21 @@ async def async_get_config_entry_diagnostics(
         coordinator is not None,
     )
 
-    appliances: list[dict] = []
     coord_data = getattr(coordinator, "data", None)
-    if isinstance(coord_data, Mapping):
-        for appliance_id, data in coord_data.items():
-            if isinstance(data, Mapping):
-                appliances.append(_appliance_block(appliance_id, data))
+    coord_data = coord_data if isinstance(coord_data, Mapping) else {}
+    inventory, platforms = _entity_inventory(
+        _registry_entries(hass, entry),
+        list(coord_data),
+        getattr(entry, "entry_id", "") or "",
+        _states_getter(hass),
+    )
+
+    appliances: list[dict] = []
+    for appliance_id, data in coord_data.items():
+        if isinstance(data, Mapping):
+            appliances.append(
+                _appliance_block(appliance_id, data, inventory.get(appliance_id))
+            )
 
     return {
         "entry": {
@@ -611,6 +842,12 @@ async def async_get_config_entry_diagnostics(
             "options": dict(entry.options),
         },
         "last_error": _last_error(hass, entry),
+        # Entry-wide, next to last_error rather than inside an appliance: a failed
+        # setup leaves no appliances at all, and this is exactly the dump where the
+        # question "did anything get created" needs an answer. Closed-domain
+        # primitives only (platform domains, counts, a status token), so like
+        # last_error it is leak-proof by construction and skips _redact.
+        "platforms": platforms,
         "appliances": appliances,
     }
 
@@ -640,4 +877,17 @@ async def async_get_device_diagnostics(
     data = coord_data.get(appliance_id)
     if not isinstance(data, Mapping):
         return {}
-    return {"appliance": _appliance_block(appliance_id, data)}
+    # The inventory is built over EVERY appliance id, not just this one: attribution
+    # is by unique_id prefix and those prefixes nest, so hiding the siblings would
+    # let a longer id's rows fall into this block.
+    inventory, _platforms = _entity_inventory(
+        _registry_entries(hass, entry),
+        list(coord_data),
+        getattr(entry, "entry_id", "") or "",
+        _states_getter(hass),
+    )
+    return {
+        "appliance": _appliance_block(
+            appliance_id, data, inventory.get(appliance_id)
+        )
+    }

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -611,6 +611,14 @@ def _states_getter(hass: HomeAssistant):
         return None
 
 
+# A zoned appliance id is `<base>_z<N>` (client/engine/appliance.py `_check_name_zone`),
+# so the base id is a proper prefix of its own zones'. Longest-first matching handles
+# that while every zone is present, but a zone the current poll dropped would have its
+# rows fall back onto the base appliance. No entity of the base appliance has a
+# unique_id suffix in this shape, so it is a safe tell.
+_ZONE_SUFFIX_RE = re.compile(r"^z\d+_")
+
+
 def _entity_row(unique_id: str, appliance_id: str) -> str:
     """The unique_id with its appliance prefix removed.
 
@@ -693,6 +701,15 @@ def _entity_inventory(
         appliance_id = next(
             (i for i in ids if unique_id.startswith(f"{i}_")), None
         )
+        if appliance_id is not None and _ZONE_SUFFIX_RE.match(
+            _entity_row(unique_id, appliance_id)
+        ):
+            # The row belongs to a ZONE of this appliance, and that zone is not in
+            # the data this dump was built from: the poll dropped it, or the cloud
+            # stopped declaring it. Attributing it to the base appliance would put
+            # an entity in a block that does not own it, and would drag its
+            # not_created finding along with it.
+            appliance_id = None
         if appliance_id is None:
             unattributed += 1
             continue
@@ -709,17 +726,27 @@ def _entity_inventory(
             continue
         key = _entity_row(unique_id, appliance_id)
         bucket.append(key)
+        # Qualified with the domain OUTSIDE by_domain, which is the only structure
+        # carrying it implicitly. Home Assistant scopes unique_id uniqueness to the
+        # domain and this integration relies on that: a wine cooler holds both a
+        # `light` switch and a `light` binary sensor, and the purifier's panel light
+        # became a select keeping the light's unique_id. Bare suffixes would let one
+        # overwrite the other in these maps, silently dropping a finding, and would
+        # leave the reader unable to tell which of the two a finding is about.
+        # It LOOKS like an entity_id and is not one: the right-hand side is the
+        # code-authored unique_id suffix, never the nickname-derived object_id.
+        tagged = f"{domain}.{key}"
         disabled_by = _enum_text(getattr(row, "disabled_by", None))
         hidden_by = _enum_text(getattr(row, "hidden_by", None))
         if disabled_by:
-            section.setdefault("disabled", {})[key] = disabled_by
+            section.setdefault("disabled", {})[tagged] = disabled_by
             continue
         if hidden_by:
-            section.setdefault("hidden", {})[key] = hidden_by
+            section.setdefault("hidden", {})[tagged] = hidden_by
         if not callable(state_get):
             continue
         if _is_restored(state_get, entity_id):
-            section.setdefault("not_created", []).append(key)
+            section.setdefault("not_created", []).append(tagged)
 
     totals: dict = {}
     for section in per_appliance.values():

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.10.0-beta1"
+  "version": "5.11.0"
 }

--- a/tests/fixtures/contracts/air_purifier.json
+++ b/tests/fixtures/contracts/air_purifier.json
@@ -844,7 +844,7 @@
     "initial_shadow": {
       "onOffStatus": "1",
       "machMode": "2",
-      "lightStatus": "0",
+      "lightStatus": "2",
       "lockStatus": "0",
       "touchToneStatus": "1",
       "aromaStatus": "0",
@@ -853,14 +853,14 @@
     },
     "command_name": "settings",
     "values": {
-      "lightStatus": "2"
+      "lightStatus": "0"
     },
     "action": "light_off",
     "expected_payload": {
-      "lightStatus": "2"
+      "lightStatus": "0"
     },
     "expected_shadow_delta": {
-      "lightStatus": "2"
+      "lightStatus": "0"
     },
     "must_not_change": [
       "onOffStatus",
@@ -990,7 +990,7 @@
     "initial_shadow": {
       "onOffStatus": "1",
       "machMode": "2",
-      "lightStatus": "2",
+      "lightStatus": "0",
       "lockStatus": "0",
       "touchToneStatus": "1",
       "aromaStatus": "0",
@@ -1145,14 +1145,14 @@
     },
     "command_name": "settings",
     "values": {
-      "lightStatus": "0"
+      "lightStatus": "2"
     },
     "action": "light_100",
     "expected_payload": {
-      "lightStatus": "0"
+      "lightStatus": "2"
     },
     "expected_shadow_delta": {
-      "lightStatus": "0"
+      "lightStatus": "2"
     },
     "must_not_change": [
       "onOffStatus",

--- a/tests/test_air_purifier_contracts.py
+++ b/tests/test_air_purifier_contracts.py
@@ -188,9 +188,9 @@ _INTENT_FOR_CASE = {
     "preset_sleep": ("set_preset", {"value": "1"}),
     "preset_auto": ("set_preset", {"value": "2"}),
     "preset_max": ("set_preset", {"value": "4"}),
-    "light_off": ("set_light", {"value": "2"}),
+    "light_off": ("set_light", {"value": "0"}),
     "light_50": ("set_light", {"value": "1"}),
-    "light_100": ("set_light", {"value": "0"}),
+    "light_100": ("set_light", {"value": "2"}),
     "lock_on": ("set_lock", {"value": "1"}),
     "lock_off": ("set_lock", {"value": "0"}),
     "tone_on": ("set_tone", {"value": "1"}),
@@ -249,8 +249,8 @@ def _full_capabilities():
 def test_ap_mappings_are_exact() -> None:
     assert air_purifier.AP_MODE_TO_PRESET == {"1": "sleep", "2": "auto", "4": "max"}
     assert air_purifier.AP_PRESET_TO_MODE == {"sleep": "1", "auto": "2", "max": "4"}
-    assert air_purifier.AP_LIGHT_TO_OPTION == {"2": "off", "1": "low", "0": "high"}
-    assert air_purifier.AP_OPTION_TO_LIGHT == {"off": "2", "low": "1", "high": "0"}
+    assert air_purifier.AP_LIGHT_TO_OPTION == {"0": "off", "1": "low", "2": "high"}
+    assert air_purifier.AP_OPTION_TO_LIGHT == {"off": "0", "low": "1", "high": "2"}
     assert air_purifier.AP_LIGHT_OPTION_ORDER == ("off", "low", "high")
     assert air_purifier.AP_AROMA_TO_OPTION == {
         "0": "off", "1": "soft", "2": "mid", "3": "h_biotics", "4": "custom",

--- a/tests/test_air_purifier_entities.py
+++ b/tests/test_air_purifier_entities.py
@@ -1126,7 +1126,7 @@ class AirPurifierPanelLightSetupTest(unittest.IsolatedAsyncioTestCase):
 
 class AirPurifierPanelLightStateTest(unittest.IsolatedAsyncioTestCase):
     async def test_each_raw_level_maps_to_its_position(self) -> None:
-        for raw, option in (("2", "off"), ("1", "low"), ("0", "high")):
+        for raw, option in (("0", "off"), ("1", "low"), ("2", "high")):
             entities, _client, _coord = await _build_panel_light(
                 {**FULL_ATTRIBUTES, "lightStatus": raw}
             )
@@ -1168,7 +1168,7 @@ class AirPurifierPanelLightStateTest(unittest.IsolatedAsyncioTestCase):
 
 class AirPurifierPanelLightWriteTest(unittest.IsolatedAsyncioTestCase):
     async def test_each_position_sends_its_raw_level(self) -> None:
-        for option, raw in (("off", "2"), ("low", "1"), ("high", "0")):
+        for option, raw in (("off", "0"), ("low", "1"), ("high", "2")):
             entities, client, coordinator = await _build_panel_light()
             await entities[0].async_select_option(option)
             self.assertEqual(
@@ -1189,7 +1189,7 @@ class AirPurifierPanelLightWriteTest(unittest.IsolatedAsyncioTestCase):
             {**FULL_ATTRIBUTES, "onOffStatus": "0"}
         )
         await entities[0].async_select_option("high")
-        self.assertEqual([("settings", {"lightStatus": "0"})], _sent(client))
+        self.assertEqual([("settings", {"lightStatus": "2"})], _sent(client))
 
 
 class AirPurifierPanelLightErrorTest(unittest.IsolatedAsyncioTestCase):
@@ -2412,7 +2412,7 @@ class ShadowSpellingTest(unittest.IsolatedAsyncioTestCase):
         entities, _client, _coord = await _build_panel_light(
             _shadow(lightStatus="0.0")
         )
-        self.assertEqual("high", entities[0].current_option)
+        self.assertEqual("off", entities[0].current_option)
 
     async def test_a_decimal_toggle_still_reads_on(self) -> None:
         entities, _client, _coord = await _build_switches(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1151,7 +1151,7 @@ class EntityInventoryTest(unittest.TestCase):
         rows = self._rows(AP_ROWS[:1], disabled_by="user") + self._rows(AP_ROWS[1:])
         live = FakeStates(live=[eid for _uid, eid in AP_ROWS[1:]])
         _result, entities = self._dump(rows, states=live)
-        self.assertEqual({"child_lock": "user"}, entities["disabled"])
+        self.assertEqual({"switch.child_lock": "user"}, entities["disabled"])
         self.assertNotIn("not_created", entities)
         self.assertIn("child_lock", entities["by_domain"]["switch"])
 
@@ -1161,14 +1161,16 @@ class EntityInventoryTest(unittest.TestCase):
         rows = self._rows(AP_ROWS[:1], hidden_by="user") + self._rows(AP_ROWS[1:])
         live = FakeStates(live=[eid for _uid, eid in AP_ROWS])
         _result, entities = self._dump(rows, states=live)
-        self.assertEqual({"child_lock": "user"}, entities["hidden"])
+        self.assertEqual({"switch.child_lock": "user"}, entities["hidden"])
 
     def test_a_row_with_no_live_entity_is_reported_as_not_created(self) -> None:
         """The registry survives reloads, so a platform that broke AFTER a working
         install still has its rows. Only the state machine tells them apart."""
         live = FakeStates(live=[eid for _uid, eid in AP_ROWS[2:]])
         _result, entities = self._dump(self._rows(), states=live)
-        self.assertEqual(["child_lock", "touch_tone"], entities["not_created"])
+        self.assertEqual(
+            ["switch.child_lock", "switch.touch_tone"], entities["not_created"]
+        )
 
     def test_a_restored_state_counts_as_not_created(self) -> None:
         """Home Assistant leaves a placeholder state carrying restored=True for a
@@ -1178,7 +1180,7 @@ class EntityInventoryTest(unittest.TestCase):
             restored=[AP_ROWS[0][1]],
         )
         _result, entities = self._dump(self._rows(), states=states)
-        self.assertEqual(["child_lock"], entities["not_created"])
+        self.assertEqual(["switch.child_lock"], entities["not_created"])
 
     def test_without_a_state_machine_the_status_says_so(self) -> None:
         """FakeHass has no `states`. The section must not claim a cross-check it
@@ -1326,6 +1328,175 @@ class EntityInventoryTest(unittest.TestCase):
         )
 
 
+class EntityInventoryScopeTest(unittest.TestCase):
+    """The claims the single-appliance tests structurally cannot make."""
+
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def test_two_entities_sharing_a_suffix_across_domains_do_not_collide(self) -> None:
+        """A wine cooler holds a `light` SWITCH and a `light` BINARY SENSOR: same
+        unique_id suffix, different domains, both legitimate. Keyed by the bare
+        suffix, one silently overwrote the other and the reader could not tell
+        which entity a finding was about."""
+        rows = [
+            FakeRegistryEntry("wc-1_light", "switch.cantina_light", disabled_by="user"),
+            FakeRegistryEntry("wc-1_light", "binary_sensor.cantina_light"),
+        ]
+        inventory, _platforms = diagnostics._entity_inventory(
+            rows, ["wc-1"], "e1", FakeStates().get
+        )
+        section = inventory["wc-1"]
+
+        self.assertEqual({"switch.light": "user"}, section["disabled"])
+        self.assertEqual(["binary_sensor.light"], section["not_created"])
+        self.assertEqual(
+            {"switch": ["light"], "binary_sensor": ["light"]}, section["by_domain"]
+        )
+
+    def test_a_zone_row_never_lands_on_the_base_appliance(self) -> None:
+        """A zoned appliance is `<base>_z1`. When the poll drops the zone but its
+        registry rows survive, the row must not fall back onto the base appliance
+        and drag its not_created finding with it."""
+        rows = [
+            FakeRegistryEntry("ac-1_child_lock", "switch.ac_child_lock"),
+            FakeRegistryEntry("ac-1_z1_purifier", "fan.ac_zone_one"),
+        ]
+        inventory, platforms = diagnostics._entity_inventory(
+            rows, ["ac-1"], "e1", FakeStates().get
+        )
+
+        self.assertEqual({"switch": ["child_lock"]}, inventory["ac-1"]["by_domain"])
+        self.assertEqual(["switch.child_lock"], inventory["ac-1"]["not_created"])
+        self.assertEqual(1, platforms["unattributed"])
+
+    def test_a_present_zone_still_gets_its_own_rows(self) -> None:
+        """The guard above must not cost a correctly-declared zone its entities."""
+        rows = [
+            FakeRegistryEntry("ac-1_child_lock", "switch.ac_child_lock"),
+            FakeRegistryEntry("ac-1_z1_purifier", "fan.ac_zone_one"),
+        ]
+        inventory, platforms = diagnostics._entity_inventory(
+            rows, ["ac-1", "ac-1_z1"], "e1", None
+        )
+
+        self.assertEqual({"switch": ["child_lock"]}, inventory["ac-1"]["by_domain"])
+        self.assertEqual({"fan": ["purifier"]}, inventory["ac-1_z1"]["by_domain"])
+        self.assertEqual(0, platforms["unattributed"])
+
+    def test_only_the_zone_shape_is_treated_as_a_zone(self) -> None:
+        """The guard keys on the `z<N>_` shape the id builder produces, not on the
+        letter: a future entity key that merely starts with a z stays attributed."""
+        rows = [FakeRegistryEntry("ac-1_zone_mode", "select.ac_zone_mode")]
+        inventory, platforms = diagnostics._entity_inventory(
+            rows, ["ac-1"], "e1", None
+        )
+
+        self.assertEqual({"select": ["zone_mode"]}, inventory["ac-1"]["by_domain"])
+        self.assertEqual(0, platforms["unattributed"])
+
+    def test_the_entry_dump_keeps_two_appliances_apart(self) -> None:
+        """Attribution through the real entry point, which every other dump-level
+        test cannot check because it builds a single appliance."""
+        coord = _build_ap_coordinator()
+        coord.data["ap-unique_z1"] = dict(coord.data[AP_ID])
+        rows = [
+            FakeRegistryEntry("ap-unique_child_lock", "switch.first_child_lock"),
+            FakeRegistryEntry("ap-unique_z1_purifier", "fan.second"),
+        ]
+        hass = RegistryHass(coord, rows=rows, states=FakeStates())
+        _install_registry(hass)
+        result = _run(
+            diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+        )
+        # Blocks come out in coordinator order: the base appliance, then its zone.
+        base, zone = result["appliances"]
+
+        self.assertEqual({"switch": ["child_lock"]}, base["entities"]["by_domain"])
+        self.assertEqual({"fan": ["purifier"]}, zone["entities"]["by_domain"])
+        self.assertEqual(
+            {"switch": 1, "fan": 1}, result["platforms"]["appliance_totals"]
+        )
+
+    def test_the_device_dump_carries_only_its_own_appliance(self) -> None:
+        """The device hook builds the inventory over EVERY id on purpose; this pins
+        that the sibling's rows do not leak into the requested block."""
+        coord = _build_ap_coordinator()
+        coord.data["ap-unique_z1"] = dict(coord.data[AP_ID])
+        rows = [
+            FakeRegistryEntry("ap-unique_child_lock", "switch.first_child_lock"),
+            FakeRegistryEntry("ap-unique_z1_purifier", "fan.second"),
+        ]
+        hass = RegistryHass(coord, rows=rows, states=FakeStates())
+        _install_registry(hass)
+        result = _run(
+            diagnostics.async_get_device_diagnostics(
+                hass, FakeEntry(), FakeDevice(identifiers={(DOMAIN, AP_ID)})
+            )
+        )
+        self.assertEqual(
+            {"switch": ["child_lock"]},
+            result["appliance"]["entities"]["by_domain"],
+        )
+
+    def test_the_entry_totals_add_the_appliances_up(self) -> None:
+        """appliance_totals was only ever asserted negatively, so the accumulation
+        itself was never exercised."""
+        rows = [
+            FakeRegistryEntry("ap-a_child_lock", "switch.a_child_lock"),
+            FakeRegistryEntry("ap-a_touch_tone", "switch.a_touch_tone"),
+            FakeRegistryEntry("ap-b_child_lock", "switch.b_child_lock"),
+            FakeRegistryEntry("ap-b_purifier", "fan.b"),
+        ]
+        inventory, platforms = diagnostics._entity_inventory(
+            rows, ["ap-a", "ap-b"], "e1", None
+        )
+
+        self.assertEqual({"switch": 3, "fan": 1}, platforms["appliance_totals"])
+        counted = sum(
+            len(keys)
+            for section in inventory.values()
+            for keys in section["by_domain"].values()
+        )
+        self.assertEqual(sum(platforms["appliance_totals"].values()), counted)
+
+    def test_a_hidden_entity_is_still_checked_for_life(self) -> None:
+        """Deliberately asymmetric with the disabled case: hidden entities ARE
+        added by their platform and do get a state, so a hidden row with no state
+        is the same finding as any other."""
+        rows = [
+            FakeRegistryEntry(
+                "ap-1_child_lock", "switch.p_child_lock", hidden_by="integration"
+            )
+        ]
+        inventory, _platforms = diagnostics._entity_inventory(
+            rows, ["ap-1"], "e1", FakeStates().get
+        )
+        section = inventory["ap-1"]
+
+        self.assertEqual({"switch.child_lock": "integration"}, section["hidden"])
+        self.assertEqual(["switch.child_lock"], section["not_created"])
+
+    def test_the_lists_come_out_sorted(self) -> None:
+        """Fed in reverse order, so a test that never observes ordering cannot
+        pass by accident."""
+        rows = [
+            FakeRegistryEntry("ap-1_touch_tone", "switch.p_tt"),
+            FakeRegistryEntry("ap-1_child_lock", "switch.p_cl"),
+            FakeRegistryEntry("ap-1_aroma", "select.p_aroma"),
+        ]
+        inventory, _platforms = diagnostics._entity_inventory(
+            rows, ["ap-1"], "e1", FakeStates().get
+        )
+        section = inventory["ap-1"]
+
+        self.assertEqual(["child_lock", "touch_tone"], section["by_domain"]["switch"])
+        self.assertEqual(
+            ["select.aroma", "switch.child_lock", "switch.touch_tone"],
+            section["not_created"],
+        )
+
+
 class EntityInventoryIdentityTest(unittest.TestCase):
     def tearDown(self) -> None:
         _restore_registry()
@@ -1350,7 +1521,9 @@ class EntityInventoryIdentityTest(unittest.TestCase):
 
         self.assertNotIn(AP_ID, encoded)
         self.assertNotIn("purificatore_di_mario", encoded)
-        self.assertNotIn("switch.", encoded)
+        # The qualified key looks like an entity_id and is not one: its right-hand
+        # side is the code-authored unique_id suffix, never the nickname slug.
+        self.assertNotIn("switch.purificatore", encoded)
         self.assertIn("child_lock", encoded)
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1034,5 +1034,306 @@ class FutureCapabilityCaptureTest(unittest.TestCase):
         self.assertEqual("4", block["attributes"]["pollenLevel"])
 
 
+# --- the entity inventory ------------------------------------------------------
+
+
+class FakeRegistryEntry:
+    """A registry row, with only the fields the inventory is allowed to read."""
+
+    def __init__(self, unique_id, entity_id, disabled_by=None, hidden_by=None):
+        self.unique_id = unique_id
+        self.entity_id = entity_id
+        self.disabled_by = disabled_by
+        self.hidden_by = hidden_by
+
+
+class FakeState:
+    def __init__(self, restored=False):
+        self.attributes = {"restored": True} if restored else {}
+
+
+class FakeStates:
+    """The state machine: only the entities a platform actually added are live."""
+
+    def __init__(self, live=(), restored=()):
+        self._states = {entity_id: FakeState() for entity_id in live}
+        self._states.update(
+            {entity_id: FakeState(restored=True) for entity_id in restored}
+        )
+
+    def get(self, entity_id):
+        return self._states.get(entity_id)
+
+
+class RegistryHass(FakeHass):
+    def __init__(self, coordinator, rows=None, states=None, entry_id="e1"):
+        super().__init__(coordinator, entry_id)
+        self.rows = [] if rows is None else rows
+        if states is not None:
+            self.states = states
+
+
+def _install_registry(hass, rows=None, raises=False, registry=object()):
+    """Point the stubbed entity_registry at THIS hass, for one test."""
+    import homeassistant.helpers.entity_registry as er
+
+    def async_get(_hass):
+        if raises:
+            raise RuntimeError("registry not loaded")
+        return registry
+
+    def async_entries_for_config_entry(_registry, _entry_id):
+        return hass.rows if rows is None else rows
+
+    er.async_get = async_get
+    er.async_entries_for_config_entry = async_entries_for_config_entry
+
+
+def _restore_registry():
+    import homeassistant.helpers.entity_registry as er
+
+    er.async_get = lambda hass: None
+    er.async_entries_for_config_entry = lambda registry, entry_id: []
+
+
+AP_ROWS = (
+    ("ap-unique_child_lock", "switch.purificatore_child_lock"),
+    ("ap-unique_touch_tone", "switch.purificatore_touch_tone"),
+    ("ap-unique_purifier", "fan.purificatore"),
+    ("ap-unique_aroma", "select.purificatore_aroma"),
+)
+
+
+class EntityInventoryTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def _dump(self, rows, states=None, raises=False):
+        coord = _build_ap_coordinator()
+        hass = RegistryHass(coord, rows=rows, states=states)
+        _install_registry(hass, raises=raises)
+        result = _run(
+            diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+        )
+        return result, result["appliances"][0]["entities"]
+
+    def _rows(self, pairs=AP_ROWS, **kwargs):
+        return [FakeRegistryEntry(uid, eid, **kwargs) for uid, eid in pairs]
+
+    def test_the_registered_entities_are_listed_per_domain(self) -> None:
+        live = FakeStates(live=[eid for _uid, eid in AP_ROWS])
+        _result, entities = self._dump(self._rows(), states=live)
+        self.assertEqual(
+            {
+                "switch": ["child_lock", "touch_tone"],
+                "fan": ["purifier"],
+                "select": ["aroma"],
+            },
+            entities["by_domain"],
+        )
+        self.assertEqual("ok", entities["status"])
+
+    def test_an_appliance_with_no_rows_reports_nothing_created(self) -> None:
+        """NOT "unavailable": the dump looked and found nothing, which is the whole
+        finding. Reporting it as a failed lookup would erase it."""
+        _result, entities = self._dump([], states=FakeStates())
+        self.assertEqual("ok", entities["status"])
+        self.assertEqual({}, entities["by_domain"])
+
+    def test_an_unreadable_registry_is_not_an_empty_one(self) -> None:
+        result, entities = self._dump(self._rows(), raises=True)
+        self.assertEqual({"status": "unavailable"}, entities)
+        self.assertEqual({"status": "unavailable"}, result["platforms"])
+
+    def test_a_disabled_entity_is_reported_as_disabled_not_as_missing(self) -> None:
+        """Home Assistant writes no state for a disabled entity, so a naive live
+        check would report every user-disabled control as a platform crash."""
+        rows = self._rows(AP_ROWS[:1], disabled_by="user") + self._rows(AP_ROWS[1:])
+        live = FakeStates(live=[eid for _uid, eid in AP_ROWS[1:]])
+        _result, entities = self._dump(rows, states=live)
+        self.assertEqual({"child_lock": "user"}, entities["disabled"])
+        self.assertNotIn("not_created", entities)
+        self.assertIn("child_lock", entities["by_domain"]["switch"])
+
+    def test_a_hidden_entity_is_reported_as_hidden(self) -> None:
+        """"Hidden" is what "I cannot see it in Home Assistant" usually means, and
+        it is invisible in every other section of the dump."""
+        rows = self._rows(AP_ROWS[:1], hidden_by="user") + self._rows(AP_ROWS[1:])
+        live = FakeStates(live=[eid for _uid, eid in AP_ROWS])
+        _result, entities = self._dump(rows, states=live)
+        self.assertEqual({"child_lock": "user"}, entities["hidden"])
+
+    def test_a_row_with_no_live_entity_is_reported_as_not_created(self) -> None:
+        """The registry survives reloads, so a platform that broke AFTER a working
+        install still has its rows. Only the state machine tells them apart."""
+        live = FakeStates(live=[eid for _uid, eid in AP_ROWS[2:]])
+        _result, entities = self._dump(self._rows(), states=live)
+        self.assertEqual(["child_lock", "touch_tone"], entities["not_created"])
+
+    def test_a_restored_state_counts_as_not_created(self) -> None:
+        """Home Assistant leaves a placeholder state carrying restored=True for a
+        registered entity nothing added; that is the same finding as no state."""
+        states = FakeStates(
+            live=[eid for _uid, eid in AP_ROWS[1:]],
+            restored=[AP_ROWS[0][1]],
+        )
+        _result, entities = self._dump(self._rows(), states=states)
+        self.assertEqual(["child_lock"], entities["not_created"])
+
+    def test_without_a_state_machine_the_status_says_so(self) -> None:
+        """FakeHass has no `states`. The section must not claim a cross-check it
+        could not run, and must not invent a not_created list."""
+        _result, entities = self._dump(self._rows())
+        self.assertEqual("registry_only", entities["status"])
+        self.assertNotIn("not_created", entities)
+
+    def test_account_entities_are_counted_by_domain_never_attributed(self) -> None:
+        """They are created unconditionally, so a domain missing from here is a
+        platform that did not finish. That is what separates a dead platform from a
+        device that was gated out."""
+        rows = self._rows() + self._rows(
+            (
+                ("e1_diag_debug_logging", "switch.addhon_debug_logging"),
+                ("e1_diag_mqtt_realtime_debug", "switch.addhon_mqtt_debug"),
+            )
+        )
+        result, entities = self._dump(rows, states=FakeStates())
+        self.assertEqual({"switch": 2}, result["platforms"]["account"])
+        self.assertNotIn("diag_debug_logging", entities["by_domain"].get("switch", []))
+
+    def test_a_dead_platform_is_distinguishable_from_a_gated_device(self) -> None:
+        """The reported case. No switch row anywhere INCLUDING the unconditional
+        account ones means the switch platform never finished; a gated device would
+        still leave those two behind."""
+        rows = self._rows(AP_ROWS[2:])
+        result, entities = self._dump(rows, states=FakeStates())
+        self.assertEqual({}, result["platforms"]["account"])
+        self.assertNotIn("switch", entities["by_domain"])
+        self.assertNotIn("switch", result["platforms"]["appliance_totals"])
+
+    def test_a_leftover_account_row_does_not_clear_a_dead_platform(self) -> None:
+        """The harder half of the same case: the platform ran on an EARLIER install,
+        so its unconditional account entity is still in the registry. Counting that
+        row at face value would vouch for the platform that just died."""
+        account = (("e1_diag_debug_logging", "switch.addhon_debug_logging"),)
+        rows = self._rows(AP_ROWS[2:]) + self._rows(account)
+        states = FakeStates(
+            live=[eid for _uid, eid in AP_ROWS[2:]],
+            restored=[account[0][1]],
+        )
+        result, _entities = self._dump(rows, states=states)
+        self.assertEqual({"switch": 1}, result["platforms"]["account"])
+        self.assertEqual({"switch": 1}, result["platforms"]["account_not_created"])
+
+    def test_a_live_account_row_clears_the_platform(self) -> None:
+        """The other side of it: the account entity is alive, so the platform ran,
+        and a missing appliance control is a capability gate rather than a crash."""
+        account = (("e1_diag_debug_logging", "switch.addhon_debug_logging"),)
+        rows = self._rows(AP_ROWS[2:]) + self._rows(account)
+        states = FakeStates(
+            live=[eid for _uid, eid in AP_ROWS[2:]] + [account[0][1]]
+        )
+        result, _entities = self._dump(rows, states=states)
+        self.assertEqual({"switch": 1}, result["platforms"]["account"])
+        self.assertEqual({}, result["platforms"]["account_not_created"])
+
+    def test_a_disabled_account_row_is_not_reported_as_uncreated(self) -> None:
+        """A user who disabled the debug switch has no state either, and that must
+        not read as a dead platform."""
+        account = (("e1_diag_debug_logging", "switch.addhon_debug_logging"),)
+        rows = self._rows(AP_ROWS[2:]) + self._rows(account, disabled_by="user")
+        states = FakeStates(live=[eid for _uid, eid in AP_ROWS[2:]])
+        result, _entities = self._dump(rows, states=states)
+        self.assertEqual({"switch": 1}, result["platforms"]["account"])
+        self.assertEqual({}, result["platforms"]["account_not_created"])
+
+    def test_a_row_of_another_config_entry_shape_is_counted_unattributed(self) -> None:
+        rows = self._rows((("someone-else_child_lock", "switch.other_child_lock"),))
+        result, _entities = self._dump(rows, states=FakeStates())
+        self.assertEqual(1, result["platforms"]["unattributed"])
+
+    def test_the_longest_appliance_prefix_wins(self) -> None:
+        """Prefixes nest for real: a multi-zone appliance expands into `<id>` and
+        `<id>_z1`, so the shorter id must not swallow the longer id's rows."""
+        inventory, _platforms = diagnostics._entity_inventory(
+            [FakeRegistryEntry("ap-unique_z1_purifier", "fan.zone_one")],
+            ["ap-unique", "ap-unique_z1"],
+            "e1",
+            None,
+        )
+        self.assertEqual({}, inventory["ap-unique"]["by_domain"])
+        self.assertEqual(
+            {"fan": ["purifier"]}, inventory["ap-unique_z1"]["by_domain"]
+        )
+
+    def test_a_non_string_appliance_id_cannot_break_the_dump(self) -> None:
+        inventory, platforms = diagnostics._entity_inventory(
+            [FakeRegistryEntry("ap-unique_purifier", "fan.p")],
+            [None, 7, "ap-unique"],
+            "e1",
+            None,
+        )
+        self.assertEqual({"fan": ["purifier"]}, inventory["ap-unique"]["by_domain"])
+        self.assertEqual(0, platforms["unattributed"])
+
+    def test_the_inventory_is_bounded(self) -> None:
+        cap = diagnostics._ENTITY_MAX_PER_DOMAIN
+        rows = self._rows(
+            tuple(
+                (f"ap-unique_sensor_{n}", f"sensor.p_{n}") for n in range(cap + 5)
+            )
+        )
+        result, entities = self._dump(rows, states=FakeStates())
+        self.assertEqual(cap, len(entities["by_domain"]["sensor"]))
+        self.assertTrue(entities["truncated"])
+        self.assertTrue(result["platforms"]["truncated"])
+
+    def test_the_device_dump_carries_the_same_inventory(self) -> None:
+        """The tester downloads diagnostics from the DEVICE page, not the entry."""
+        coord = _build_ap_coordinator()
+        hass = RegistryHass(
+            coord,
+            rows=self._rows(),
+            states=FakeStates(live=[eid for _uid, eid in AP_ROWS]),
+        )
+        _install_registry(hass)
+        device = FakeDevice(identifiers={(DOMAIN, AP_ID)})
+        result = _run(
+            diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+        )
+        self.assertEqual(
+            ["child_lock", "touch_tone"],
+            result["appliance"]["entities"]["by_domain"]["switch"],
+        )
+
+
+class EntityInventoryIdentityTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def test_no_raw_identifier_reaches_the_dump(self) -> None:
+        """The appliance id here is NOT MAC-shaped on purpose: the module's MAC
+        regex would mask a colon-separated id on its own, and a test built on one
+        would pass even if the inventory emitted the raw unique_id."""
+        import json
+
+        rows = [
+            FakeRegistryEntry(
+                f"{AP_ID}_child_lock", "switch.purificatore_di_mario_child_lock"
+            )
+        ]
+        coord = _build_ap_coordinator()
+        hass = RegistryHass(coord, rows=rows, states=FakeStates())
+        _install_registry(hass)
+        encoded = json.dumps(
+            _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        )
+
+        self.assertNotIn(AP_ID, encoded)
+        self.assertNotIn("purificatore_di_mario", encoded)
+        self.assertNotIn("switch.", encoded)
+        self.assertIn("child_lock", encoded)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1288,6 +1288,25 @@ class EntityInventoryTest(unittest.TestCase):
         self.assertTrue(entities["truncated"])
         self.assertTrue(result["platforms"]["truncated"])
 
+    def test_only_the_appliance_that_lost_rows_is_marked_truncated(self) -> None:
+        """A complete inventory carrying someone else's truncation flag reads as
+        incomplete. With one appliance the flag's scope is unobservable, so this
+        needs a second, small one."""
+        cap = diagnostics._ENTITY_MAX_PER_DOMAIN
+        big = [
+            FakeRegistryEntry(f"ap-unique_sensor_{n}", f"sensor.p_{n}")
+            for n in range(cap + 5)
+        ]
+        small = [FakeRegistryEntry("ap-two_purifier", "fan.second")]
+
+        inventory, platforms = diagnostics._entity_inventory(
+            big + small, ["ap-unique", "ap-two"], "e1", None
+        )
+
+        self.assertTrue(inventory["ap-unique"]["truncated"])
+        self.assertNotIn("truncated", inventory["ap-two"])
+        self.assertTrue(platforms["truncated"])
+
     def test_the_device_dump_carries_the_same_inventory(self) -> None:
         """The tester downloads diagnostics from the DEVICE page, not the entry."""
         coord = _build_ap_coordinator()

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -85,8 +85,12 @@ _FILES = {
     # The dump builder walks the entity registry like __init__.py does, so it gets
     # the same forbidden attributes: entity_id embeds the nickname slug and
     # unique_id embeds the appliance id. `row` is the loop variable it walks with.
+    # Both spellings are forbidden: the registry walk reads them as attributes
+    # (row.unique_id) and immediately binds them as plain locals, so an
+    # attribute-only rule would let a later `_LOGGER.debug("uid=%s", unique_id)`
+    # straight through.
     "diagnostics.py": (
-        frozenset({"appliance_id", "row", "entries"}),
+        frozenset({"appliance_id", "row", "entries", "entity_id", "unique_id"}),
         frozenset({"entity_id", "unique_id"}),
     ),
     # Setup orchestration: the raw cloud appliance dict (CR#2 malformed-appliance

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -82,7 +82,13 @@ _FILES = {
         _ENTITY_NAMES,
         _ENTITY_ATTRS | frozenset({"entity_id", "unique_id"}),
     ),
-    "diagnostics.py": (frozenset({"appliance_id"}), frozenset()),
+    # The dump builder walks the entity registry like __init__.py does, so it gets
+    # the same forbidden attributes: entity_id embeds the nickname slug and
+    # unique_id embeds the appliance id. `row` is the loop variable it walks with.
+    "diagnostics.py": (
+        frozenset({"appliance_id", "row", "entries"}),
+        frozenset({"entity_id", "unique_id"}),
+    ),
     # Setup orchestration: the raw cloud appliance dict (CR#2 malformed-appliance
     # log). It must never be passed bare to _LOGGER -- key-name redaction cannot mask
     # nested identity (attributes[].parValue), so the malformed path logs structure


### PR DESCRIPTION
Automated release PR for `v5.11.0`.

<!-- release-tag: v5.11.0 -->

## Summary by Sourcery

Add entity registry–backed inventories to diagnostics and correct air purifier panel light level mappings for the v5.11.0 release.

Bug Fixes:
- Fix air purifier panel light mapping so on/off and brightness levels align with the device’s actual behaviour.

Enhancements:
- Extend diagnostics to include a per-appliance and entry-level entity inventory derived from the Home Assistant entity registry and state machine, including platform-level status and counts.
- Ensure diagnostics redaction avoids leaking raw entity identifiers by emitting only domains and static unique_id suffixes and updating log-identity redaction rules accordingly.

Tests:
- Add comprehensive tests for the new entity inventory behaviour, including disabled/hidden entities, restored states, account-level entities, truncation, and device-level diagnostics output.
- Update air purifier contracts and entity tests to validate the corrected panel light mapping and behaviour across read/write paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics now provide detailed appliance entity inventories, including platform status and entity availability states.
  * Inventory details are included in both configuration-entry and device diagnostics, with limits to prevent excessive output.

* **Bug Fixes**
  * Corrected air-purifier light mappings: off, low, and high now correspond to raw values 0, 1, and 2 respectively.

* **Chores**
  * Updated the integration version to 5.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Diagnostics now include registry-backed per-appliance entity inventories and entry-wide platform counts, while the air-purifier panel-light mapping is corrected for the v5.11.0 release.
- Adds entity status, domain counts, account entities, and scoped truncation reporting to diagnostics.
- Redacts entity identity by exposing only domains and static unique-ID suffixes.
- Corrects panel-light values to map raw `0`, `1`, and `2` to off, low, and high.
- Updates the integration version and expands diagnostics and air-purifier tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported truncation-scope issue is fixed by marking only the appliance section that actually drops rows.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/diagnostics.py | Adds registry-backed entity inventories and correctly scopes per-appliance truncation to the inventory that actually omitted rows. |
| custom_components/addhon/air_purifier.py | Corrects the panel-light read/write mapping to the measured device encoding. |
| custom_components/addhon/manifest.json | Updates the integration release version to 5.11.0. |
| tests/test_diagnostics.py | Adds comprehensive inventory coverage, including a regression test proving truncation does not leak between appliances. |
| tests/test_air_purifier_entities.py | Updates entity behavior tests for the corrected panel-light encoding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep the inventory findings attribu..."](https://github.com/tis24dev/addhon/commit/b963b623fd646ea9a94d186edb904e170a178bae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50629787)</sub>

<!-- /greptile_comment -->