### PR TITLE
Release v5.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,29 @@ jobs:
           # but every client-side hook is bypassable with --no-verify and a
           # contributor may not have installed it at all. Same matcher on both
           # sides, so they cannot disagree about what is forbidden.
-          git log --format='%B' "$BASE..$HEAD" | ./scripts/no-assistant-trailer.sh
+          #
+          # Run the BASE branch's copy of the checker, never the pull request's.
+          # `on: pull_request` builds the workflow from the PR head, so a branch
+          # that edits `scripts/no-assistant-trailer.sh` to exit 0 would grade
+          # its own homework. Taking the script from `$BASE` removes that lever:
+          # neutering the check now requires editing this workflow file, which
+          # is a visible line in the diff a reviewer is already reading.
+          #
+          # It does NOT make the check tamper-proof -- the workflow is part of
+          # the same PR. Only a repository ruleset or a required workflow, which
+          # live in settings rather than in the tree, can close that, and this
+          # step is deliberately cheap rather than a substitute for one.
+          CHECKER="$RUNNER_TEMP/no-assistant-trailer.sh"
+          if git cat-file -e "$BASE:scripts/no-assistant-trailer.sh" 2>/dev/null; then
+            git show "$BASE:scripts/no-assistant-trailer.sh" > "$CHECKER"
+          else
+            # The base predates the checker: only true for the pull request that
+            # introduces it. Say so out loud rather than failing a legitimate
+            # branch or silently using the untrusted copy without a word.
+            echo "::warning::base has no checker yet; using this branch's copy"
+            cp scripts/no-assistant-trailer.sh "$CHECKER"
+          fi
+          git log --format='%B' "$BASE..$HEAD" | sh "$CHECKER"
 
   hassfest:
     name: hassfest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,33 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q
 
+  commit-trailers:
+    name: commit trailers
+    # PRs only: the check needs a base to diff against, and a push to `dev`
+    # arrives after the PR that carried it has already been gated here.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          # Full history: the check walks base..head, and a shallow clone has
+          # neither end of that range.
+          fetch-depth: 0
+
+      - name: Reject AI-assistant authorship trailers
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The server-side half of the guard. The local `commit-msg` hook
+          # (scripts/hooks/commit-msg) catches this before the object exists,
+          # but every client-side hook is bypassable with --no-verify and a
+          # contributor may not have installed it at all. Same matcher on both
+          # sides, so they cannot disagree about what is forbidden.
+          git log --format='%B' "$BASE..$HEAD" | ./scripts/no-assistant-trailer.sh
+
   hassfest:
     name: hassfest
     runs-on: ubuntu-latest

--- a/custom_components/addhon/air_purifier.py
+++ b/custom_components/addhon/air_purifier.py
@@ -34,6 +34,10 @@ from .hon_commands import (
 # if a schema starts enumerating it.
 AP_WRITABLE_MODES = frozenset({"1", "2", "4"})
 
+# The off-state sentinel itself. Never writable (above), always HANDLED: fan.py's
+# `preset_mode` reads it and reports no active preset.
+AP_MODE_OFF = "0"
+
 AP_MODE_TO_PRESET = {"1": "sleep", "2": "auto", "4": "max"}
 AP_PRESET_TO_MODE = {preset: raw for raw, preset in AP_MODE_TO_PRESET.items()}
 
@@ -140,7 +144,13 @@ AP_ENTITY_PARAMS = frozenset(
 # range has no enumerable "unhandled value".
 AP_HANDLED_VALUES: dict[str, frozenset[str]] = {
     _POWER_ATTR: _TOGGLE_VALUES,
-    _MODE_PARAM: AP_WRITABLE_MODES,
+    # WRITABLE and HANDLED are not the same set. `0` may never be written (it is the
+    # off-state sentinel, see AP_WRITABLE_MODES above) but it is very much handled:
+    # fan.py reads it and reports "no active preset". Reusing AP_WRITABLE_MODES here
+    # made every dump from a switched-off purifier announce machMode=0 as a future
+    # capability -- the gold signal firing on an idle appliance, sending the
+    # maintainer to investigate a mode that already ships.
+    _MODE_PARAM: AP_WRITABLE_MODES | {AP_MODE_OFF},
     _LIGHT_PARAM: frozenset(AP_LIGHT_TO_OPTION),
     _LOCK_PARAM: _TOGGLE_VALUES,
     _TONE_PARAM: _TOGGLE_VALUES,

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1254,7 +1254,9 @@ def _attribute_timestamps(
     Three values are returned, deliberately out of ONE pass:
 
       [0] `{parameter name: ISO text or None}`, one row for each value that
-          exposes a `last_update` surface. That set is also the only honest
+          exposes a `last_update` surface, in `attributes`' own key order --
+          the map this one is emitted beside and the only map it is ever read
+          with; the return statement says why. That set is also the only honest
           answer to "which of these keys are shadow parameters", a bit the dump
           carries today only by duplicating the whole `attributes["parameters"]`
           sub-map.
@@ -1431,11 +1433,66 @@ def _attribute_timestamps(
                 truncated = True
                 continue
             rows[key] = _stamp_text(raw)
-    # Sorted ONCE, at the end, and not per source: the two sources are each
+    # Ordered ONCE, at the end, and not per source: the two sources are each
     # walked in sorted order but a bare key and a nested one can both be
     # productive, and a map whose second half restarts the alphabet reads as a
     # rendering bug.
-    return dict(sorted(rows.items())), truncated, newest
+    #
+    # The order taken is `attributes`' OWN enumeration and not the alphabet,
+    # because this map is never read alone. The one question it exists to answer
+    # -- "when did tempZ3 last move" -- is asked with `attributes` already open
+    # at tempZ3, and the sibling keeps the cloud's merge order, so an
+    # alphabetical map made the reader find one name at two unrelated ranks in
+    # two adjacent sections. Measured on the four archived live dumps
+    # (diagnostics/live-2026-06-22), same name, both maps: mean displacement 4.5
+    # rows on the REF, 15.7 on the TD, 24.6 on the AC, 42.4 on the WM, worst
+    # case 100, and 66 places where reading the rows top to bottom sent the eye
+    # BACKWARDS up the sibling. Following the sibling makes every one of those
+    # zero, and it is free here: the shadow parameters are a CONTIGUOUS run
+    # inside `attributes` on all four appliances (`hon_client._get_attributes`
+    # flattens them in one update), so the map is now that same run, reprinted
+    # with the instants.
+    #
+    # `sorted` survives as the FALLBACK, for rows `attributes` does not
+    # enumerate at all: the nested-only keys of the degraded merge path, where
+    # `dict(params)` raised and nothing was flattened. There are none on any
+    # archived appliance -- zero across all four dumps and entry.json -- so this
+    # is the corner and not the case. They keep the order they have today and
+    # land together after everything ranked, rather than being interleaved at
+    # rank zero among names they have no relationship to.
+    #
+    # WHICH rows survive does not move: the cap is applied during the walk, and
+    # the walk is untouched. Only the printing order changes, and it changes for
+    # the better under the cap too -- `_appliance_block` keeps the
+    # `attributes["parameters"]` sub-map whenever this map is truncated, and the
+    # surviving rows are now a SUBSEQUENCE of it, so the dropped names show up
+    # as holes in an aligned scan instead of having to be diffed across two
+    # different orders.
+    try:
+        order = {str(name): position for position, name in enumerate(attributes)}
+    except Exception:
+        # Not the same formality as the guard on the walk above. That one had
+        # already decided this mapping could not be listed and CONTINUED, so the
+        # rows in hand may have come entirely from the nested sub-map and be
+        # perfectly good; an unguarded second enumeration here would throw them
+        # away along with the whole dump, from the helper that makes the FIRST
+        # read of `attributes` in the block. Unranked, every row falls into one
+        # bucket and the tiebreaker below emits exactly the alphabetical map
+        # this line returned before.
+        _LOGGER.debug(
+            "Diagnostics debug: attribute order unreadable", exc_info=True
+        )
+        order = {}
+    return (
+        dict(
+            sorted(
+                rows.items(),
+                key=lambda row: (order.get(row[0], len(order)), row[0]),
+            )
+        ),
+        truncated,
+        newest,
+    )
 
 
 def _attribute_values(attributes: Mapping) -> Mapping:

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -532,14 +532,32 @@ def _source_row(read=(), write=()) -> dict[str, list[str]] | None:
     return row or None
 
 
+def _note_missing_registry(module: str, failed: list[str]) -> None:
+    """Record one platform module that would not import, and log why.
+
+    Separate from the `except` bodies that call it so that each of them stays two
+    statements long: the seven of them are already the widest thing in
+    `_mapped_sets`, and a walk of tables reads badly when two thirds of it is
+    error handling. `exc_info` is passed HERE and not once at the end, because
+    the traceback a maintainer needs is the one from the import that failed and
+    not from whichever ran last.
+    """
+    failed.append(module)
+    _LOGGER.debug(
+        "Diagnostics debug: registry module %s unavailable", module, exc_info=True
+    )
+
+
 def _mapped_sets(
     app_type,
-) -> tuple[set[str], set[str], dict[str, dict[str, list[str]] | None] | None]:
-    """(mapped attribute keys, mapped writable command params, entity sources).
+) -> tuple[
+    set[str], set[str], dict[str, dict[str, list[str]] | None] | None, list[str]
+]:
+    """(mapped attribute keys, mapped params, entity sources, missing modules).
 
     Registries are imported lazily so diagnostics.py keeps a tiny top-level import
-    surface and cannot be caught in an import cycle; on any import hiccup it degrades
-    to the documented custom set rather than crashing the dump.
+    surface and cannot be caught in an import cycle, and each import is guarded on
+    its OWN, so an import hiccup costs that module's tables and never the dump.
 
     The THIRD value is the static per-type index behind `entities.sources`: which
     raw parameter each entity of this type reads and writes, keyed by the same
@@ -555,40 +573,103 @@ def _mapped_sets(
     null claiming nothing could be looked at. One walk, one degradation decision,
     and the two sections can never disagree about whether the tables were read.
 
-    The price of that is stated plainly: this block now imports `select` and
-    `program_options` as well, so a break in either degrades the COVERAGE axes
-    too, where before it could not. That is the intended trade -- a dump that
-    under-reports both axes is diagnosable, a dump whose two halves disagree is
-    not -- and it is why `_coverage` prints `registries_unavailable` on that
-    path: the sources half announces the degradation with a null, but there is
-    no sources half at all in a device dump or on an appliance with no registry
-    inventory, and a coverage section that under-reports in silence would be
-    read as fact.
+    One walk, however, must NOT mean one failure. Each import therefore gets its
+    OWN `try` and its own empty stand-in, so a module that will not import costs
+    its own tables and nothing else. Rebuilt on the four archived live
+    appliances, a single unimportable module used to roughly double or triple
+    `attributes_unmapped` on every one of them, and to invent three
+    `command_params_unmapped` entries (`tempSelZ1`, `tempSelZ2`, `tempSelZ3`)
+    about setpoints that exist and work. The exact pairs are deliberately not
+    quoted: they move with every table row added, and reconstructing an appliance
+    from an archived dump gives a different denominator than the live object did,
+    so three mutually inconsistent sets of them were produced while this was
+    being written. The blast radius is the claim; the figures are not. Fabricating
+    entries on the list this module calls the gold signal is the one thing that
+    list may not do, and it is a strictly worse failure than the silence the
+    single `try` was chosen over: silence is unhelpful, an accusation is wrong.
+    Per import, `select` costs the REF nothing measurable at all and the AC one
+    name (`windDirectionHorizontal`), which is what it actually owns there.
 
-    A None third value (never an empty dict) is what the degraded path returns, so
-    that one unreadable registry costs the reader ONE null instead of a null per
-    entity, which would read as "every entity was looked up and none was found".
+    The benefit is real for FIVE of the seven, not all of them, and the two
+    exceptions are worth naming because the obvious worked example is one of
+    them. `binary_sensor`, `number`, `select`, `sensor` and `switch` are leaves:
+    nothing else here imports them, so each really does degrade alone.
+    `air_purifier` is imported by all five and `program_options` by three, and
+    Home Assistant loads the platform modules at platform setup -- so a genuinely
+    broken `air_purifier.py` means its five importers never loaded either, they
+    are absent from `sys.modules`, this walk re-imports them and they fail again.
+    Breaking it costs six of the seven tables no matter how the guards are
+    arranged. Take `sensor` on a fridge, or `select` on an AC, as the case this
+    isolation actually rescues.
+
+    `registries_unavailable` NAMES the modules that failed instead of saying
+    `True`, because with per-import degradation the flag no longer means "every
+    number in this dict was measured against nothing". It means "the tables these
+    modules own are missing from the numerators", and only the list tells the
+    reader whether that touches the axis they came to read: `sensor` missing
+    invalidates `attributes_unmapped`, `air_purifier` missing invalidates
+    nothing at all on a fridge.
+
+    A None third value is reserved for the TOTAL collapse -- nothing at all could
+    be named -- so that a dump which could not look at any table costs the reader
+    ONE null instead of a null per entity, which would read as "every entity was
+    looked up and none was found". A partial failure returns the rows it did
+    read, and the entities whose table was lost take their own explicit null in
+    `entities.sources`: that is the narrower and truer statement, and it names
+    them one by one instead of blanking the whole map.
     """
     mapped_attrs: set[str] = set(_CUSTOM_MAPPED_ATTRS.get(app_type, ()))
     mapped_params: set[str] = set()
     sources: dict[str, dict[str, list[str]] | None] = {}
+    unavailable: list[str] = []
+    # Seven imports, seven guards. Written out rather than driven by a table of
+    # module/name strings on purpose: `from .sensor import SENSORS` is a spelling
+    # a linter, a grep and `rename` all understand, and this walk is already one
+    # rename away from silently collapsing a numerator (there is no test that can
+    # see a table nobody added here).
     try:
         from .air_purifier import AP_ENTITY_PARAMS
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        AP_ENTITY_PARAMS = frozenset()
+        _note_missing_registry("air_purifier", unavailable)
+    try:
         from .binary_sensor import BINARY_SENSORS, _CONNECTIVITY, _UNIVERSAL_GATED
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        BINARY_SENSORS, _CONNECTIVITY, _UNIVERSAL_GATED = {}, None, ()
+        _note_missing_registry("binary_sensor", unavailable)
+    try:
         from .number import NUMBERS, _AP_TIMING_NUMBERS, _PROGRAM_OPTION_NUMBERS
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        NUMBERS, _AP_TIMING_NUMBERS, _PROGRAM_OPTION_NUMBERS = {}, (), ()
+        _note_missing_registry("number", unavailable)
+    try:
         from .program_options import STARTPROGRAM_COMMAND
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        STARTPROGRAM_COMMAND = ""
+        _note_missing_registry("program_options", unavailable)
+    try:
         from .select import _AC_DIRECTION_SELECTS, _PROGRAM_OPTION_SELECTS
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _AC_DIRECTION_SELECTS, _PROGRAM_OPTION_SELECTS = (), ()
+        _note_missing_registry("select", unavailable)
+    try:
         from .sensor import SENSORS
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        SENSORS = {}
+        _note_missing_registry("sensor", unavailable)
+    try:
         from .switch import (
             _AIR_PURIFIER_SWITCHES,
             _PROGRAM_OPTION_SWITCHES,
             _SETTINGS_SWITCHES,
         )
-    except Exception:  # pragma: no cover - diagnostics must never crash
-        _LOGGER.debug(
-            "Diagnostics debug: coverage registries unavailable", exc_info=True
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _AIR_PURIFIER_SWITCHES, _PROGRAM_OPTION_SWITCHES, _SETTINGS_SWITCHES = (
+            (),
+            (),
+            {},
         )
-        return mapped_attrs, mapped_params, None
+        _note_missing_registry("switch", unavailable)
 
     # ONE pass per table: the coverage sets get the DECLARED names (unchanged --
     # `mapped_attrs` is the attribute axis' numerator and moving it would silently
@@ -606,10 +687,14 @@ def _mapped_sets(
         sources[f"binary_sensor.{desc.key}"] = _source_row(
             read=_read_chain(desc.attr_key)
         )
-    mapped_attrs.add(_CONNECTIVITY.attr_key)
-    sources[f"binary_sensor.{_CONNECTIVITY.key}"] = _source_row(
-        read=_read_chain(_CONNECTIVITY.attr_key)
-    )
+    # The only row in this walk with no type gate and no table to be empty, so
+    # it is also the only one that needs a None check rather than an empty
+    # stand-in: `binary_sensor` failing leaves nothing to read `.attr_key` off.
+    if _CONNECTIVITY is not None:
+        mapped_attrs.add(_CONNECTIVITY.attr_key)
+        sources[f"binary_sensor.{_CONNECTIVITY.key}"] = _source_row(
+            read=_read_chain(_CONNECTIVITY.attr_key)
+        )
     for desc in _UNIVERSAL_GATED:
         mapped_attrs.add(desc.attr_key)
         sources[f"binary_sensor.{desc.key}"] = _source_row(
@@ -632,14 +717,47 @@ def _mapped_sets(
     # read chain has a second link nothing else in this walk has -- the option is
     # read bare first and then under `startProgram.<param>`, because unlike
     # `settings` the startProgram command is not mirrored into the device shadow
-    # (`program_options.HonProgramOptionEntity._current_raw`). These params are
-    # deliberately NOT added to `mapped_params`: they live on startProgram, which
-    # `_settings_param_names` never reads, so adding them would put names in the
-    # coverage numerator that its denominator can never contain.
+    # (`program_options.HonProgramOptionEntity._current_raw`). These params were
+    # once left out of both coverage numerators, on the argument that they live
+    # on startProgram, which `_settings_param_names` never reads. That argument
+    # is false and the loop below says where; the sentence is corrected here
+    # rather than deleted, because it is the belief a reader arrives with and
+    # the code makes no sense while they still hold it.
+    #
+    # `program_options` contributes exactly one thing to this walk: the command
+    # name those options are read under. Without it the second link cannot be
+    # spelled: with the stand-in `STARTPROGRAM_COMMAND = ""` the loop would emit
+    # `read: ['tumblingStatus', '.tumblingStatus']` -- a fabricated key name no
+    # device ever publishes, under a real entity tag -- which is worse than no
+    # row at all. Both
+    # halves of that were measured on the live TD: emitting the chain truncated
+    # makes `_coverage`'s `reachable` test find no published spelling for
+    # `tumblingStatus` and drop it into `attributes_expected_absent` -- telling
+    # the reader the dryer does not have a control it does have, since the TD
+    # publishes it only as `startProgram.tumblingStatus` -- WHILE `sources` two
+    # sections below still names the switch that reads and writes it. That is
+    # the contradiction shape this whole section exists to remove. Skipping the
+    # loop drops both halves back to what they said before this walk read the
+    # option tables: three names return to the unmapped lists -- so `coverage` is
+    # not silent, it still accuses `tumblingStatus`, exactly as it did at
+    # 5d12cb2 -- but `sources` no longer contradicts it, and
+    # `registries_unavailable` names the module that caused it. Nor does the
+    # skip cover every module that can produce this shape: with only `number`
+    # broken, the live WM gains `delayTime` in `attributes_expected_absent`
+    # while `sensor.delay_time` two sections below still reads it. That one is
+    # not fixed here; the list in `registries_unavailable` is what tells the
+    # reader to distrust that axis. Little is lost
+    # in practice either way: number.py, select.py and switch.py each import
+    # `program_options` themselves, so a real break in it empties all three
+    # tables anyway and this branch changes nothing.
     for prefix, table in (
-        ("number.opt_", _PROGRAM_OPTION_NUMBERS),
-        ("select.opt_", _PROGRAM_OPTION_SELECTS),
-        ("switch.opt_", _PROGRAM_OPTION_SWITCHES),
+        (
+            ("number.opt_", _PROGRAM_OPTION_NUMBERS),
+            ("select.opt_", _PROGRAM_OPTION_SELECTS),
+            ("switch.opt_", _PROGRAM_OPTION_SWITCHES),
+        )
+        if STARTPROGRAM_COMMAND
+        else ()
     ):
         for desc in table:
             if app_type not in (getattr(desc, "types", None) or ()):
@@ -699,6 +817,14 @@ def _mapped_sets(
                     read=_read_chain(desc.param), write=[desc.param]
                 )
 
+    # How many rows the PLATFORM tables produced, counted before the literal
+    # ones below join them. Nothing below this line can fail to import --
+    # `_CUSTOM_ENTITY_SOURCES` is written out three hundred lines above, in this
+    # file -- so the SIZE of the finished map cannot say whether this walk was
+    # able to look at anything. This count can, and a healthy walk always makes
+    # it non-zero: `_CONNECTIVITY` above is added with no type gate.
+    platform_rows = len(sources)
+
     # Last, the entities no registry knows about. Guarded field by field even
     # though the table three hundred lines above is a literal in this same file:
     # this loop is OUTSIDE the try above, and `_appliance_block` is called with no
@@ -720,7 +846,19 @@ def _mapped_sets(
             ],
             write=entry.get("write") or (),
         )
-    return mapped_attrs, mapped_params, sources
+    # No platform row at all is the TOTAL collapse, and the only thing the None
+    # third value is for: the reader gets ONE null instead of a null per entity,
+    # which would read as "every entity was looked up and none was found".
+    # Anything the walk DID read is returned as it stands, and the entities
+    # behind a lost table then take one explicit null each in `entities.sources`
+    # -- the narrower and truer statement, naming them one at a time instead of
+    # blanking a map that is mostly correct.
+    return (
+        mapped_attrs,
+        mapped_params,
+        sources if platform_rows else None,
+        unavailable,
+    )
 
 
 def _settings_param_names(appliance) -> set[str]:
@@ -824,7 +962,7 @@ def _coverage(
     publishes no ``tempZ4``. On the live REF dump this line prints thirteen
     names on the first download, and ``tempZ4`` is one of them.
     """
-    mapped_attrs, mapped_params, sources_index = (
+    mapped_attrs, mapped_params, sources_index, registries_unavailable = (
         mapped if mapped is not None else _mapped_sets(app_type)
     )
     settings_params = _settings_param_names(appliance)
@@ -920,17 +1058,25 @@ def _coverage(
         # `startProgram` is reported by neither.
         "attributes_expected_absent": sorted(mapped_attrs - reachable),
         "command_params_expected_absent": sorted(mapped_params - command_params),
-        # Emitted ONLY when the lazy import above failed, because every number
-        # in this dict is then measured against tables that could not be read:
-        # the two unmapped lists swell to the whole device and both
-        # expected_absent lists collapse to empty, which reads as "this
-        # integration maps nothing on your appliance". `entities.sources`
-        # carries the same null -- but that section is absent entirely whenever
-        # there is no registry inventory for this appliance (the device dump, or
-        # a registry that could not be read), and a reader cannot tell that null
-        # apart from "there was nothing to decorate". A coverage section that
-        # under-reports in silence is the one thing this dump may not do.
-        **({"registries_unavailable": True} if sources_index is None else {}),
+        # Emitted ONLY when a platform module would not import, and it NAMES
+        # the ones that did not, because every number in this dict is then
+        # measured against tables that are missing pieces: the unmapped lists
+        # swell by whatever those modules mapped and both expected_absent lists
+        # shrink by the same names. Naming them is what keeps the marker worth
+        # reading now that each import degrades on its own -- `sensor` missing
+        # invalidates `attributes_unmapped`, `air_purifier` missing invalidates
+        # nothing at all on a fridge, and a bare `true` cannot tell the two
+        # apart. `entities.sources` carries the matching per-entity nulls -- but
+        # that section is absent entirely whenever there is no registry
+        # inventory for this appliance (the device dump, or a registry that
+        # could not be read), and a reader cannot tell that absence apart from
+        # "there was nothing to decorate". A coverage section that under-reports
+        # in silence is the one thing this dump may not do.
+        **(
+            {"registries_unavailable": list(registries_unavailable)}
+            if registries_unavailable
+            else {}
+        ),
     }
 
 
@@ -2030,7 +2176,7 @@ def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | N
     by_domain = section.get("by_domain")
     if not isinstance(by_domain, Mapping):
         return section
-    _mapped_attrs, _mapped_params, index = (
+    _mapped_attrs, _mapped_params, index, _unavailable = (
         mapped if mapped is not None else _mapped_sets(app_type)
     )
     if index is None:
@@ -2038,7 +2184,10 @@ def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | N
         # read as "every entity was looked up and none of them is known", which is
         # a finding; "this dump could not look" is the absence of one, and the
         # sibling `_registry_entries` docstring spells out why the two must never
-        # be folded together.
+        # be folded together. Reached only when NO table could be read at all:
+        # a single broken platform module leaves the rest of the index intact,
+        # and its own entities fall through to the per-entity null below, which
+        # is that same distinction drawn one entity at a time.
         section["sources"] = None
         return section
     sources: dict[str, dict[str, list[str]] | None] = {}

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1443,17 +1443,50 @@ def _attribute_timestamps(
     and the OUTPUT is validated, because `isinstance(x, datetime)` admits
     subclasses and a subclass may return anything at all from `isoformat`.
 
-    The `parameters` sub-map is walked as a SECOND source, and the reason is not
-    the obvious one. `hon_client._get_attributes` merges `raw` -- which carries
-    that sub-map under its own key -- at :187, and only then flattens the
-    parameters over the top at :191, so on a healthy device the `HonAttribute`
-    IS already the bare value and the nested copy is pure duplication (all four
-    live dumps agree on every key, zero mismatches in 243 parameters). The
-    reachable failure is :192-196: when `parameters` is a Mapping that is not a
-    `dict`, the merge goes through `dict(params)`, whose argument is evaluated
-    in full before anything is merged, so a Mapping whose iteration or
-    `__getitem__` misbehaves leaves NOTHING flattened and the nested object as
-    the only surviving carrier of the instants.
+    The `parameters` sub-map is walked as a SECOND source, and the honest
+    statement about that walk is that it is INERT.
+    `hon_client._get_attributes` merges `raw` -- which carries that sub-map
+    under its own key -- at :187, and only then flattens the parameters over
+    the top at :191, so on a healthy device the `HonAttribute` IS already the
+    bare value and the nested copy is pure duplication (all four live dumps
+    agree on every key, zero mismatches in 243 parameters). Measured on the
+    real REF capture driven through the real engine, and on AC and WM rebuilt
+    from it: the nested source contributes ZERO rows the flattened top level
+    did not already carry.
+
+    An earlier version of this paragraph named `hon_client.py:192-196` -- the
+    `except` around `dict(params)` -- as the reachable failure this walk
+    rescues. That was WRONG, and it is corrected here rather than quietly
+    deleted, because the guards below read as evidence for it and the next
+    reader would otherwise re-derive the same belief from them. The producer
+    chain was traced end to end. Only three sites in this integration ever
+    write a `parameters` key, all in `client/engine/appliance.py`: :277 and
+    :385 mutate a VALUE inside the container, and :279 CREATES the container as
+    a literal `{}`. The one wholesale replacement is `self._attributes |=
+    attributes` at :280, whose right-hand side is the `/commands/v1/context`
+    payload straight out of `response.json()` (`client/transport/api.py:170`),
+    so it is a plain `dict`, a `list`, a `str`, a number, a bool or None --
+    never a Mapping SUBCLASS. The per-type layer at :330 returns the object it
+    was given and never touches the key, and the MQTT handler
+    (`client/transport/mqtt.py:434`) only calls `.update()` on values already
+    inside it. Both coordinator producers reach this module through the one
+    `hon_client._build_appliance_entry` (:975) -- the REST poll at :1104 and
+    `build_realtime_snapshot` at :1004 alike -- so the realtime push introduces
+    no fourth shape. And `dict(x)` cannot raise on a plain `dict`, nor on a
+    dict SUBCLASS: CPython takes the `PyDict_Merge` fast path and never calls
+    an overridden `keys()`. So :192-196 can only fire for a value that is NOT a
+    Mapping, and `test_diagnostics.py` pins that invariant on the real engine
+    so this paragraph cannot go stale in silence.
+
+    That is what ties the correction to the paragraph below rather than leaving
+    it as trivia: the only shapes `dict(params)` can actually choke on are
+    exactly the shapes this map refuses to read, so on every input a producer
+    can deliver there is nothing for the fallback to fall back to. The walk is
+    kept anyway -- it costs one `isinstance` and one `seen` lookup per
+    parameter, and it is the only thing that would keep the instants in the
+    document if the engine ever stopped building that container itself (a
+    `MappingProxyType`, a lazy view, a cache object). Keep it as insurance; do
+    not read it as a report that a half-broken Mapping arrives here today.
 
     Only a Mapping is followed there. A non-Mapping iterable under that key (a
     generator, a list) is deliberately NOT walked: this runs on the event loop,
@@ -1505,11 +1538,15 @@ def _attribute_timestamps(
         try:
             names = sorted(source, key=str)
         except Exception:  # pragma: no cover - a Mapping that cannot list keys
-            # Honest scope: for the NESTED map this is the reachable guard, and
-            # it is what keeps a half-broken Mapping from taking the document
-            # down. For `attributes` itself it is a formality -- `_coverage`
+            # Honest scope, corrected: NEITHER source can reach this today.
+            # For `attributes` it was always a formality -- `_coverage`
             # iterates the same object a few lines below with no guard at all,
             # so a mapping that cannot list its keys ends the dump regardless.
+            # For the NESTED map this was called the reachable guard, and the
+            # producer trace in the docstring above shows it is not: that key
+            # holds a plain `dict`, which lists its keys, or a non-Mapping,
+            # which is never appended to `sources`. Kept as the cheap half of
+            # "degrade, never raise", not as evidence of a live failure.
             _LOGGER.debug(
                 "Diagnostics debug: attribute names unreadable", exc_info=True
             )
@@ -1521,8 +1558,9 @@ def _attribute_timestamps(
             try:
                 value = source[name]
             except Exception:
-                # A key that enumerates and then refuses to resolve is exactly
-                # the object that made `dict(params)` raise upstream. Skip the
+                # A key that enumerates and then refuses to resolve is the
+                # object that WOULD have made `dict(params)` raise upstream; no
+                # producer builds one today (traced in the docstring). Skip the
                 # one key rather than the whole source, so a single bad entry
                 # costs one row and not the entire section.
                 continue
@@ -1678,11 +1716,23 @@ def _attribute_values(attributes: Mapping) -> Mapping:
     kept for the same conservatism: `all([])` is True, and "the shadow
     container was empty" is a different statement from "there is no shadow
     container". When even one nested key is missing from the top level the whole
-    sub-map is kept, because that is the signature of the degraded path at
-    `hon_client.py:192-196` -- a `parameters` Mapping whose `dict()` coercion
-    raised, leaving NOTHING flattened and this sub-map as the only carrier of
-    both the values and their instants. Deleting it there would delete the only
-    copy of the data.
+    sub-map is kept, on the plain principle that a map which cannot be SHOWN to
+    be a copy is not deleted: deleting it would delete data rather than
+    duplication.
+
+    The reason this branch used to give for itself is retracted. It cited "the
+    signature of the degraded path at `hon_client.py:192-196` -- a `parameters`
+    Mapping whose `dict()` coercion raised", and `_attribute_timestamps`'
+    docstring above now traces every producer of this key and shows it holds
+    either a plain `dict`, which `dict()` cannot refuse, or a value that is not
+    a Mapping at all, which the `isinstance` below returns on before this check
+    is reached. Measured over the real REF capture through the real engine,
+    over AC and WM rebuilt from it, and over every JSON shape a cloud payload
+    can put under the key: `redundant` is True for every NON-EMPTY sub-map that
+    gets this far, so that half of the branch has no reachable input. The EMPTY
+    half does have one -- a payload carrying its own top-level `parameters`
+    replaces the shadow container, and `{}` then fails `bool(nested)` -- and
+    the principle above is reason enough for both halves to stay.
     """
     try:
         nested = attributes.get("parameters")
@@ -1749,10 +1799,14 @@ def _appliance_block(
     # pass so that anything reporting freshness from it can never disagree with
     # the map the reader is looking at, even after the row cap has fired.
     stamps, stamps_truncated, newest_stamp = _attribute_timestamps(attributes)
-    # De-duplicated ONCE, above every consumer, and only after the instants have
-    # been read -- the sub-map is their fallback source on the degraded merge
-    # path, so dropping it first would throw away the very rows it exists to
-    # rescue. Skipped entirely when the row cap fired: the justification for
+    # De-duplicated ONCE, above every consumer, and only after the instants
+    # have been read. The ordering is kept for the reason it was written -- the
+    # sub-map is the instants' fallback source -- even though that fallback is
+    # inert on every input a producer can deliver, which
+    # `_attribute_timestamps`' docstring traces in full. Two helpers whose
+    # combined result depends on call order is a trap either way, and one that
+    # holds only while the fallback is dead is the worse of the two.
+    # Skipped entirely when the row cap fired: the justification for
     # deleting the sub-map is that `attributes_last_update` now carries the one
     # bit it held (which keys are shadow parameters), and a truncated map does
     # not carry it for the rows it dropped.

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Mapping
+from datetime import datetime, timezone
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -412,6 +413,66 @@ def _settings_param_names(appliance) -> set[str]:
     return names
 
 
+def _command_param_names(appliance) -> set[str]:
+    """Names of every parameter under ANY command, writable through it or not.
+
+    `_settings_param_names` above answers 'what can be written through the
+    settings command', which is the universe the `command_params_unmapped` axis
+    is measured against and must stay measured against. This helper answers a
+    different question -- 'does this device's schema know this parameter AT
+    ALL' -- and exists for `command_params_expected_absent`, where the
+    settings-only universe manufactures false positives: `program` and `prCode`
+    are mapped for every wash appliance and live under `startProgram`, and
+    `onOffStatus` is mapped for the air purifier and lives under
+    `startProgram`/`stopProgram`. Measured on the live 2026-06-22 dump,
+    subtracting only the settings params reported all three as missing from
+    devices whose `commands` section printed them a few lines further down.
+
+    Only KEYS are read. Iterating a parameter mapping's VALUES would reach
+    `HonParameterRange.values`, which materialises the entire grid (the trap
+    documented in `_param_schema`), so this walk stays proportional to the
+    number of parameters the device declares and never to their ranges.
+
+    Every read is guarded, and the guards are a BACKSTOP rather than the dump's
+    protection - be exact about that, because the tempting claim is the wrong
+    one. `_command_schema` already walks EVERY command and reads the same
+    `.parameters` surface, and `_appliance_block` calls it one line above
+    `_coverage`, so an appliance whose `startProgram.parameters` raises has
+    already taken the dump down before this helper is reached; measured,
+    building the block for such an appliance propagates RuntimeError out of
+    `_command_schema`. That exposure predates this change and is not fixed
+    here. What the guards below DO buy is that this helper cannot ADD a way to
+    fail. The loop setup is inside the guard as well as the loop body, and that
+    part is not theoretical: `_command_schema` iterates the commands mapping
+    with `.items()` and `_settings_param_names` with `.get(name)`, so a foreign
+    `commands` object whose `.values()` view alone raises survives both of them
+    and would die here, in new code, on the one axis this module treats as
+    inviolable.
+    """
+    commands = getattr(appliance, "commands", None)
+    if not isinstance(commands, Mapping):
+        return set()
+    names: set[str] = set()
+    try:
+        entries = list(commands.values())
+    except Exception:  # pragma: no cover - diagnostics must never crash
+        _LOGGER.debug(
+            "Diagnostics debug: command list unreadable", exc_info=True
+        )
+        return names
+    for cmd in entries:
+        try:
+            params = getattr(cmd, "parameters", None)
+            if isinstance(params, Mapping):
+                names.update(str(k) for k in params)
+        except Exception:  # pragma: no cover - diagnostics must never crash
+            _LOGGER.debug(
+                "Diagnostics debug: command parameters unreadable",
+                exc_info=True,
+            )
+    return names
+
+
 def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> dict:
     """What the device exposes with no addhon entity (the gold signal).
 
@@ -425,9 +486,24 @@ def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> 
                                              + scalar debug/protocol noise + program slots.
     The command-param axis is split the same way (``command_params_unmapped`` vs
     ``command_params_unmapped_meta``).
+
+    Both axes are then reported once more in MIRROR image.
+    ``attributes_expected_absent`` and ``command_params_expected_absent`` are
+    the keys this integration maps for the TYPE and this DEVICE does not have
+    at all. The unmapped lists answer 'what should we add'; the mirror answers
+    'why is the control I expected not in Home Assistant', which until now was
+    the one coverage question a dump could not answer. Issue #75 is the worked
+    example: its reporter established for himself, across two dumps four days
+    apart and a decompiler pass, that his fridge declares a vtRoom2 zone and
+    publishes no ``tempZ4``. On the live REF dump this line prints thirteen
+    names on the first download, and ``tempZ4`` is one of them.
     """
     mapped_attrs, mapped_params = _mapped_sets(app_type)
     settings_params = _settings_param_names(appliance)
+    # A SECOND, wider universe, used only by the expected-absent mirror below:
+    # every parameter of every command, not just the settings ones. The two are
+    # deliberately different sets; see the comment on the mirror keys.
+    command_params = _command_param_names(appliance)
 
     # The device shadow exposes writable params ALSO as bare attribute keys (e.g. a
     # fridge reports `tempSelZ1` both bare and as `settings.tempSelZ1`). Those belong
@@ -474,6 +550,37 @@ def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> 
         "command_params_total": len(settings_params) - len(params_meta),
         "command_params_unmapped": params_signal,
         "command_params_unmapped_meta": params_meta,
+        # The mirror of the two unmapped axes, and the only part of this block
+        # that reads the tables against the device rather than the device
+        # against the tables. Neither list needs a cap or a truncation flag:
+        # both are differences taken FROM the static per-type tables, so their
+        # length is bounded by what this repository ships and not by anything
+        # the cloud sends. Measured worst case per type today: 37 short names
+        # (WD and AC), 27 (REF), 5 (HO).
+        #
+        # The attribute side subtracts the BARE keys and nothing else, because
+        # that is how the entity actually reads: `base_entity._get_attr` looks
+        # its key up whole, then in statistics, and strips a `settings.` prefix
+        # only when the key ITSELF carries one. So a mapped bare name that the
+        # device publishes only as `startProgram.delayTime` genuinely is
+        # unreadable and belongs in this list -- the live WM is exactly that
+        # case, and treating the dotted spelling as coverage would hide it.
+        #
+        # The command side subtracts EVERY command's parameters, which is where
+        # it stops mirroring `command_params_total` above. Restricted to the
+        # settings params it reported `program` and `prCode` on every wash
+        # appliance and `onOffStatus` on the air purifier -- all of them
+        # present, under `startProgram`/`stopProgram`, in the same dump. An
+        # axis sold as pure signal cannot open with three names the reader can
+        # disprove by scrolling down. Say plainly what that costs, because the
+        # two command axes are now measured against DIFFERENT universes:
+        # `command_params_unmapped` asks whether the entity can WRITE the
+        # parameter through the settings command, this asks only whether the
+        # schema KNOWS the name at all, so a mapped param the entity writes
+        # through settings while the device declares it only under
+        # `startProgram` is reported by neither.
+        "attributes_expected_absent": sorted(mapped_attrs - bare),
+        "command_params_expected_absent": sorted(mapped_params - command_params),
     }
 
 
@@ -511,6 +618,178 @@ def _scalar_text(value) -> str | None:
         return str(int(plain))
     text = str(plain)
     return text or None
+
+
+def _bounded_text(value, limit: int) -> str | None:
+    """A cloud-controlled string, MASKED first and only then cut to `limit`.
+
+    The order is the whole safety property, not a style preference. Both masks
+    in this module run LATE: `_redact` walks the finished block at the end of
+    `_appliance_block`, and the only VALUE-shaped mask anywhere in the dump is
+    `_MAC_RE` inside `_jsonable`, which recognises a MAC address only when all
+    six octet groups are present. A helper that slices its input to a cap
+    BEFORE that mask therefore hands the mask a three-and-a-half octet fragment
+    that no longer matches the pattern, and the remains of the address travel
+    to a public GitHub issue in cleartext. Measured, with a MAC straddling the
+    boundary of an 80 character cap:
+
+        cut first, then mask  ->  'xxxxx3c:71:bf:b'   (3.5 octets, readable)
+        mask first, then cut  ->  'xxxxx***'
+
+    `_future_capabilities` already bounds its state values in this order
+    (`_scalar_text`, which masks, and only then the slice at the call site).
+    This helper exists so that the next section needing a bounded cloud string
+    does not have to rediscover why, and so that reviewing the order is a
+    matter of checking the call site uses it at all.
+
+    Containers are refused OUTRIGHT, and the guard has to run TWICE - once on
+    the object and once on what it wraps. `_scalar_text` cannot be relied upon
+    for this: it tests the value AFTER `_jsonable` has run, and `_jsonable`
+    turns a dict into its repr, so its isinstance guard never fires for a real
+    Mapping. `_jsonable` also unwraps a `.value` one level, and the merged
+    attributes mapping this module reads is made almost entirely of such
+    wrappers (HonAttribute from the shadow, HonParameter from
+    `appliance.settings`), so a wrapper holding a cloud dict is the ordinary
+    shape here rather than an exotic one. Measured, with only the outer guard a
+    wrapped lastConnEvent came through as "{'macAddress': '***', 'category':
+    'CONNECTED', 'mobileId': 'm-123'}": the MAC masked, `mobileId` in
+    cleartext, and the whole envelope collapsed into one string under whatever
+    key the caller chose, which is exactly where key-based redaction can no
+    longer reach it (see the `mobileId`/`transactionId` note on `_TO_REDACT`).
+    A caller holding a cloud CONTAINER must still type-guard the field it wants
+    before calling; this is the backstop for when it forgets, not a licence to
+    pass the container in.
+
+    What this helper does NOT do is make an arbitrary string safe. The only
+    value-shaped mask it applies is `_MAC_RE`; an email, a serial, a nickname
+    or a mobileId inside a cloud string passes through untouched, and `_redact`
+    cannot help because it matches on KEY names. Bounding is a size property,
+    not a privacy one. A caller is still responsible for the argument that its
+    field is either a closed vocabulary or emitted under a name `_TO_REDACT`
+    already knows.
+
+    Returns None for anything `_scalar_text` refuses too: a character bound
+    only means something for a scalar.
+    """
+    if isinstance(value, (Mapping, list, tuple, set, frozenset)):
+        return None
+    try:
+        inner = value.value if hasattr(value, "value") else value
+    except Exception:  # pragma: no cover - a raising wrapper must not kill it
+        return None
+    if isinstance(inner, (Mapping, list, tuple, set, frozenset)):
+        return None
+    text = _scalar_text(value)
+    return None if text is None else text[:limit]
+
+
+def _as_utc(value, assume_naive_utc: bool) -> datetime | None:
+    """A datetime as an AWARE UTC datetime, or None when it cannot be one.
+
+    Every age this dump prints is a subtraction, and Python raises TypeError
+    when the two operands disagree about awareness. `_appliance_block` is
+    called with no try/except around it from both entry points, so one naive
+    datetime reaching one subtraction does not produce a wrong age, it produces
+    no dump at all. This is the single place that settles awareness, so that no
+    caller has to reason about it twice.
+
+    What is guarded is `utcoffset()`, NOT `tzinfo`. A tzinfo object whose
+    `utcoffset()` returns None does not raise: CPython falls back to the HOST's
+    local zone, silently shifting the instant and then labelling it '+00:00' --
+    a wrong time wearing an authoritative offset, which is worse than no time.
+    Such a value is treated as naive here. A `utcoffset()` that raises (a
+    foreign tzinfo, a broken subclass) yields None rather than propagating, and
+    so does a subclass that raises from `astimezone` or `replace`: everything
+    that touches the value at all is inside the one guard, because the callers
+    downstream are fed cloud-supplied objects.
+
+    `assume_naive_utc` deliberately has NO default. A naive instant is a guess
+    whichever way it is read, and making every call site spell out its policy
+    keeps that guess on the record instead of hiding it in this signature.
+    """
+    if not isinstance(value, datetime):
+        return None
+    try:
+        if value.utcoffset() is not None:
+            return value.astimezone(timezone.utc)
+        if not assume_naive_utc:
+            return None
+        return value.replace(tzinfo=timezone.utc)
+    except Exception:  # pragma: no cover - a foreign tzinfo must not kill it
+        return None
+
+
+# What an emitted instant must look like, and how long it may be. These sit
+# here rather than in the bounds block near the top of the module because the
+# rule in this file is that a constant lives immediately above its single
+# consumer (see `_ZONE_SUFFIX_RE`): a reader meeting `_STAMP_MAX_CHARS` in
+# `_stamp_text` should not have to scroll 300 lines to learn what it bounds.
+# The separator is 'T' and nothing else: `_stamp_text` calls `isoformat()` with
+# no `sep` argument, so a genuine datetime can never produce a space, and every
+# shape this pattern accepts is a shape a datetime SUBCLASS could smuggle
+# through the output validation below. The narrower it is, the less it admits.
+_ISO_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:[+-]\d{2}:\d{2})?"
+)
+_STAMP_MAX_CHARS = 40
+
+
+def _stamp_text(value) -> str | None:
+    """The one datetime -> ISO text conversion in the whole dump.
+
+    An AWARE value is converted to UTC first, and that conversion is load
+    bearing for CORRECTNESS, not merely for comparability: `_MAC_RE` runs over
+    every string in the block and a sub-minute offset makes an ISO instant look
+    exactly like a MAC address. Measured, '2026-04-09T12:34:56-05:30:15'
+    survives `_jsonable` as '2026-04-09T***'. Normalising to UTC always yields
+    '+00:00', which cannot match, which is the only reason this field reaches
+    the reader intact. A future simplification that 'preserves the original
+    offset' would silently mangle the section.
+
+    A NAIVE value is emitted as it is, never shifted onto the host's zone: the
+    cloud does hand back stamps with no offset, and a reader can reason about
+    an instant with no zone, but not about one that has been quietly moved by
+    however many hours the reporter's machine happens to be from UTC.
+
+    Anything that is not a datetime yields None, on purpose and by contract. A
+    cloud STRING instant such as `lastConnEvent.instantTime` must NOT be routed
+    through here: this helper's promise is that its output was built by
+    `datetime.isoformat`, and echoing a cloud-chosen string would break that
+    promise while looking identical in the dump.
+
+    Finally the OUTPUT is validated, not just the input type. `isinstance`
+    admits SUBCLASSES, and a datetime subclass is free to override `isoformat`
+    and return any string at all; without the length and shape check, an
+    attacker-or-accident-supplied value would be copied verbatim into a
+    document the user is about to attach to a public issue.
+    """
+    if not isinstance(value, datetime):
+        return None
+    try:
+        if value.utcoffset() is not None:
+            value = value.astimezone(timezone.utc)
+        text = value.isoformat()
+    except Exception:  # pragma: no cover - foreign subclass or tzinfo
+        return None
+    if not isinstance(text, str) or len(text) > _STAMP_MAX_CHARS:
+        return None
+    return text if _ISO_RE.fullmatch(text) else None
+
+
+def _utcnow() -> datetime:
+    """Now, as an aware UTC datetime.
+
+    One line on purpose. `homeassistant.util.dt.now(tz)` is defined as
+    `datetime.now(tz or DEFAULT_TIME_ZONE)`, so asking it for UTC makes the
+    whole Home Assistant branch an identity function: a lazy import, a fallback
+    path and a comment, all to produce what the line below produces.
+
+    What this function is actually FOR is being a seam. Every test that asserts
+    an age patches `diagnostics._utcnow`, and a dump that read the clock inline
+    could only be tested against the wall clock, which is how age assertions
+    turn into tests that fail once a year on a slow machine.
+    """
+    return datetime.now(timezone.utc)
 
 
 def _enum_deltas(appliance, handled: Mapping[str, frozenset[str]]) -> tuple[dict, bool]:
@@ -577,13 +856,27 @@ def _future_capabilities(app_type, attributes: Mapping, appliance) -> dict:
 
 
 def _appliance_block(
-    appliance_id: str, data: Mapping, entities: Mapping | None = None
+    appliance_id: str,
+    data: Mapping,
+    entities: Mapping | None = None,
+    now: datetime | None = None,
 ) -> dict:
     """Build the (redacted) diagnostics block for a single appliance.
 
     `entities` is the registry-derived inventory for THIS appliance, already
     computed once for the whole dump. It defaults to None so the helper stays
     hass-less and pure, and so a caller with no registry still produces a block.
+
+    `now` is the instant the WHOLE dump was taken, threaded in from the entry
+    point instead of read here, so that the `generated_at` at the top of the
+    document and every age inside every appliance block describe one moment.
+    Reading the clock per block would let two ages in one document disagree by
+    however long the dump took to build -- a small inconsistency, and exactly
+    the kind that costs a maintainer an hour before it is recognised as noise.
+    It is TRAILING and defaults to None so that the existing callers passing
+    only the first arguments keep working and still get a dated block, and it
+    is normalised on the first line of the body: see the comment there for why
+    nothing downstream may be handed a naive datetime.
     """
     appliance = data.get("appliance")
     app_type = data.get("type")
@@ -591,6 +884,16 @@ def _appliance_block(
     attributes = attributes if isinstance(attributes, Mapping) else {}
     statistics = data.get("statistics")
     statistics = statistics if isinstance(statistics, Mapping) else {}
+    # Normalised HERE and nowhere else. A caller may pass nothing, a naive
+    # datetime, or something that is not a datetime at all; below this line
+    # `now` is always an aware UTC instant, so every age is a subtraction that
+    # cannot raise TypeError and take the entire dump down with it -- this
+    # function is called with no try/except around it from both entry points.
+    # `assume_naive_utc=True` is the honest reading AT THIS BOUNDARY: the only
+    # naive value that can arrive here comes from a caller that meant 'now', so
+    # trusting it is wrong by the host's offset at worst, where refusing it
+    # would be wrong by the whole age.
+    now = _as_utc(now, True) or _utcnow()
 
     commands = _command_schema(appliance)
     model_attributes = _model_attributes(appliance)
@@ -899,6 +1202,10 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry (all appliances)."""
+    # Read ONCE, before anything else is built. `generated_at` and every age in
+    # every appliance block below must all describe the same instant, or the
+    # document contains numbers that disagree for a reason no reader can see.
+    now = _utcnow()
     coordinator = _coordinator(hass, entry)
     _LOGGER.debug(
         "Diagnostics debug: diagnostics requested entry=%s title=%s coordinator_present=%s",
@@ -920,10 +1227,24 @@ async def async_get_config_entry_diagnostics(
     for appliance_id, data in coord_data.items():
         if isinstance(data, Mapping):
             appliances.append(
-                _appliance_block(appliance_id, data, inventory.get(appliance_id))
+                _appliance_block(
+                    appliance_id, data, inventory.get(appliance_id), now=now
+                )
             )
 
     return {
+        # The FIRST key of the document on purpose: 'when was this taken' is the
+        # first thing a maintainer needs and the last thing a reporter thinks to
+        # say, and an issue thread routinely carries two downloads days apart
+        # with nothing in the files to tell them apart. Aware UTC, so it always
+        # ends in '+00:00' and never has to be reconciled with the zone the
+        # reporter's machine happened to be in. Like `last_error` and
+        # `platforms` below, this key sits OUTSIDE `_redact` -- only
+        # `_appliance_block` redacts -- so it is leak-proof by construction
+        # instead: `_stamp_text` refuses every non-datetime and then validates
+        # its own output against `_ISO_RE` and a 40 character bound, so the
+        # only thing that can appear here is an instant.
+        "generated_at": _stamp_text(now),
         "entry": {
             "title": _redact_title(entry.title),
             "data": {
@@ -952,6 +1273,11 @@ async def async_get_device_diagnostics(
     registers ``{(DOMAIN, appliance_id)}``, so the appliance_id is recovered directly.
     The raw identifier (which may BE the serial) is never echoed into the output.
     """
+    # Read BEFORE the two early returns below, not after. A device dump that
+    # resolves no appliance is precisely the one that gets pasted into an issue
+    # as 'the download gave me nothing', and an undated empty object cannot
+    # even be placed in time relative to the entry dump beside it.
+    now = _utcnow()
     coordinator = _coordinator(hass, entry)
     coord_data = getattr(coordinator, "data", None)
 
@@ -963,11 +1289,18 @@ async def async_get_device_diagnostics(
         ),
         None,
     )
+    # Both degraded paths still return a DATED document rather than a bare {}.
+    # They are the two dumps most likely to be attached to an issue, because
+    # they are what a user gets when the thing they are reporting is that
+    # nothing works, and 'the file was empty' is a materially different report
+    # from 'the file said it was taken at 07:09 and had nothing in it'. Like
+    # the entry dump's own `generated_at`, these bypass `_redact` and are
+    # leak-proof by construction rather than by masking.
     if appliance_id is None or not isinstance(coord_data, Mapping):
-        return {}
+        return {"generated_at": _stamp_text(now)}
     data = coord_data.get(appliance_id)
     if not isinstance(data, Mapping):
-        return {}
+        return {"generated_at": _stamp_text(now)}
     # The inventory is built over EVERY appliance id, not just this one: attribution
     # is by unique_id prefix and those prefixes nest, so hiding the siblings would
     # let a longer id's rows fall into this block.
@@ -978,7 +1311,8 @@ async def async_get_device_diagnostics(
         _states_getter(hass),
     )
     return {
+        "generated_at": _stamp_text(now),
         "appliance": _appliance_block(
-            appliance_id, data, inventory.get(appliance_id)
-        )
+            appliance_id, data, inventory.get(appliance_id), now=now
+        ),
     }

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -210,10 +210,20 @@ _CUSTOM_ENTITY_SOURCES: tuple[dict, ...] = (
         "write": ("pause",),
     },
     {"tag": "button.start_program", "types": APPLIANCE_WASH_GROUP},
+    # The one row whose truth is per-APPLIANCE, not per-type. `button.py` hands
+    # the stop button `command_parameters={"onOffStatus": "0"}` and applies each
+    # only `if name in params`, so on a device whose `stopProgram` does not carry
+    # the name the button fixes nothing. The live washer's stopProgram carries
+    # `onOffStatus`; the live dryer's carries `returnStandby` and nothing else,
+    # so shipping this row for the whole wash group states a write that cannot
+    # happen on a real TD. `write_command` names the command the fixed parameters
+    # have to be declared under, and `_entity_section` drops the ones the device
+    # does not declare.
     {
         "tag": "button.stop_program",
         "types": APPLIANCE_WASH_GROUP,
         "write": ("onOffStatus",),
+        "write_command": "stopProgram",
     },
     {"tag": "select.program", "types": APPLIANCE_WASH_GROUP},
     {
@@ -859,6 +869,36 @@ def _mapped_sets(
         sources if platform_rows else None,
         unavailable,
     )
+
+
+# Custom rows whose `write` half is a set of FIXED parameters the entity only
+# gets to apply when the device declares them under a named command. Built from
+# the table above rather than repeated, so a row cannot grow the key and be
+# forgotten here.
+_FIXED_WRITE_COMMANDS: dict[str, str] = {
+    str(entry.get("tag") or ""): str(entry["write_command"])
+    for entry in _CUSTOM_ENTITY_SOURCES
+    if entry.get("write_command")
+}
+
+
+def _declared_command_params(appliance) -> dict[str, set[str]]:
+    """Parameter names the appliance declares, per command.
+
+    Distinct from `_settings_param_names` (writables, settings commands only)
+    and from `_command_param_names` (every command flattened into one set): the
+    question here is which command a name is declared UNDER, because a fixed
+    parameter applied by an entity is only applied when that command carries it.
+    """
+    commands = getattr(appliance, "commands", None)
+    if not isinstance(commands, Mapping):
+        return {}
+    out: dict[str, set[str]] = {}
+    for cmd_name, cmd in commands.items():
+        params = getattr(cmd, "parameters", None)
+        if isinstance(params, Mapping):
+            out[str(cmd_name)] = {str(name) for name in params}
+    return out
 
 
 def _settings_param_names(appliance) -> set[str]:
@@ -1843,7 +1883,9 @@ def _appliance_block(
     # the readings are.
     freshness = _freshness(appliance, attributes, newest_stamp, now)
     future = _future_capabilities(app_type, attributes, appliance)
-    entity_section = _entity_section(entities, app_type, mapped)
+    entity_section = _entity_section(
+        entities, app_type, mapped, _declared_command_params(appliance)
+    )
 
     _LOGGER.debug(
         "Diagnostics debug: appliance id=%s name=%s type=%s attrs=%d model_attrs=%d "
@@ -2191,7 +2233,38 @@ def _age_seconds(moment, now: datetime) -> int | None:
         return None
 
 
-def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | None:
+def _declared_write_only(row, tag: str, declared) -> dict | None:
+    """Drop fixed writes the DEVICE does not declare, from the rows that have them.
+
+    Only `_FIXED_WRITE_COMMANDS` rows are touched, and only when the caller could
+    read the appliance's command schema -- `declared=None` means "not looked", and
+    a row is never narrowed on the strength of a lookup that did not happen.
+
+    A row left with no half at all becomes an explicit `null`, which is the same
+    statement `select.program` already makes: the entity exists and this dump
+    cannot name a parameter for it. That is the honest reading for a dryer, whose
+    stop button really does apply nothing -- and it is more useful than the
+    alternative of printing a write the device cannot perform, because a reader
+    chasing `onOffStatus` there finds it published as a bare attribute and
+    concludes the button works.
+    """
+    if not isinstance(row, Mapping) or not isinstance(declared, Mapping):
+        return row
+    command = _FIXED_WRITE_COMMANDS.get(tag)
+    if command is None:
+        return row
+    keep = [
+        name for name in (row.get("write") or ()) if name in declared.get(command, ())
+    ]
+    narrowed = {half: value for half, value in row.items() if half != "write"}
+    if keep:
+        narrowed["write"] = keep
+    return narrowed or None
+
+
+def _entity_section(
+    entities: Mapping | None, app_type, mapped=None, declared=None
+) -> dict | None:
     """The registry inventory for one appliance, plus what each entity speaks to.
 
     `by_domain` and its siblings answer WHICH entities Home Assistant holds.
@@ -2255,7 +2328,7 @@ def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | N
             # `sources` disagree with `by_domain` about how many entities exist,
             # which is the one thing a join key must never do.
             tag = f"{domain}.{key}"
-            sources[tag] = index.get(tag)
+            sources[tag] = _declared_write_only(index.get(tag), tag, declared)
     section["sources"] = sources
     return section
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -62,7 +62,12 @@ from homeassistant.core import HomeAssistant
 from .const import (
     APPLIANCE_AC,
     APPLIANCE_AP,
+    APPLIANCE_FR,
+    APPLIANCE_FRE,
+    APPLIANCE_REF,
     APPLIANCE_WASH_GROUP,
+    APPLIANCE_WD,
+    APPLIANCE_WM,
     DOMAIN,
     PROGRAM_PARAM_NAMES,
 )
@@ -125,6 +130,125 @@ _CUSTOM_MAPPED_ATTRS: dict[str, frozenset[str]] = {
 # description table). AC only.
 _AC_CLIMATE_PARAMS = frozenset(
     {"onOffStatus", "machMode", "tempSel", "windSpeed", "windDirectionVertical"}
+)
+
+# The entities this integration builds with NO description table behind them.
+# `_mapped_sets` walks the per-type registries to learn which parameter each
+# entity speaks to; these classes are not in any registry, so without a row here
+# they would be the only entities in the inventory with nothing to say, and they
+# include the two most-asked-about controls on a washer (start and stop).
+#
+# THE RULE, and it is the same one the registry walk follows: a row names a
+# parameter only when a STATIC table in this repository names it. Where the code
+# discovers the name from the DEVICE's own schema at runtime, the row stays empty
+# and the section emits `null` -- which reads as "this entity exists and this dump
+# cannot say what it speaks to". That is an honest gap; a guess would be a finding
+# the reader can act on and be wrong about, which is worse than no finding.
+#
+# The two program selects are exactly that case. `HonProgramSelect` and
+# `HonRefProgramSelect` walk the appliance's OWN commands for whichever of
+# `PROGRAM_PARAM_NAMES` it happens to carry (select.py), so the answer is a
+# property of the device, not of this repository, and the same select is
+# `program` on one washer and `prCode` on the next. `button.start_program` is the
+# same shape seen from the other end: it sends a whole command and fixes no
+# parameter at all, so there is nothing to name. Its sibling `stop_program` DOES
+# fix one -- `command_parameters={"onOffStatus": "0"}` in button.py, applied to
+# the command's parameters before the send -- and that write appears in no other
+# section of the dump, which is precisely why it is worth a row.
+#
+# `climate.climate` is the row where the rule is least comfortable, and it is
+# followed anyway. All five writes are named because `_AC_CLIMATE_PARAMS` names
+# them; but an air conditioner whose `settings` command has no `onOffStatus`
+# drives power and mode through startProgram/stopProgram instead (see
+# `climate._is_program_based`), so on that model two of these five are written
+# somewhere other than where a reader would look first. Nothing is hidden to
+# paper over it: `commands` a few lines below says which command really carries
+# each parameter, and `coverage.command_params_expected_absent` says when the
+# device carries it nowhere. Going silent instead would cost every reader of
+# every other AC the remaining three names to spare one reader a second look.
+#
+# The write half is spelled out here as its own literal rather than reusing
+# `_AC_CLIMATE_PARAMS`, so that the drift test comparing the two compares two
+# independent statements instead of asserting a value against itself.
+_CUSTOM_ENTITY_SOURCES: tuple[dict, ...] = (
+    {
+        "tag": "climate.climate",
+        "types": (APPLIANCE_AC,),
+        "read": (
+            "settings.onOffStatus",
+            "settings.machMode",
+            "settings.tempSel",
+            "tempIndoor",
+            "settings.windSpeed",
+            "settings.windDirectionVertical",
+        ),
+        "write": (
+            "onOffStatus",
+            "machMode",
+            "tempSel",
+            "windSpeed",
+            "windDirectionVertical",
+        ),
+    },
+    # Derived from TWO attributes, which is why it can never be a description row
+    # (those read a single attr_key) and why it is the entity most likely to be
+    # reported as "stuck on unknown": it needs both, and a washer publishing only
+    # one of them produces exactly that.
+    {
+        "tag": "sensor.mean_water_consumption",
+        "types": (APPLIANCE_WM, APPLIANCE_WD),
+        "read": ("totalWaterUsed", "totalWashCycle"),
+    },
+    # Reads machMode (3 = paused) but writes the `pause` parameter of the
+    # pauseProgram/resumeProgram commands -- the one row in this table whose two
+    # halves name different parameters, and a reader who assumed they matched
+    # would go looking for a writable machMode that does not exist.
+    {
+        "tag": "switch.pause",
+        "types": APPLIANCE_WASH_GROUP,
+        "read": ("machMode",),
+        "write": ("pause",),
+    },
+    {"tag": "button.start_program", "types": APPLIANCE_WASH_GROUP},
+    {
+        "tag": "button.stop_program",
+        "types": APPLIANCE_WASH_GROUP,
+        "write": ("onOffStatus",),
+    },
+    {"tag": "select.program", "types": APPLIANCE_WASH_GROUP},
+    {
+        "tag": "select.ref_program",
+        "types": (APPLIANCE_REF, APPLIANCE_FR, APPLIANCE_FRE),
+    },
+    # The air purifier's three fixed-key entities. Their parameters are already in
+    # `AP_ENTITY_PARAMS` (which is why coverage sees them), but that frozenset says
+    # only THAT the integration uses them, never WHICH entity uses which.
+    #
+    # The fan READS `onOffStatus` (fan.py) and does not write it: power is a whole
+    # COMMAND action -- `ap_patch` returns startProgram with a machMode for
+    # turn_on and stopProgram with no values at all for turn_off -- and the
+    # dispatcher fills `onOffStatus` from the schema at its existing value. Naming
+    # it as a write would send a reader looking for a writable onOffStatus on the
+    # AP settings command that this integration never touches, which is the same
+    # misdirection `button.start_program` stays null to avoid.
+    {
+        "tag": "fan.purifier",
+        "types": (APPLIANCE_AP,),
+        "read": ("onOffStatus", "machMode"),
+        "write": ("machMode",),
+    },
+    {
+        "tag": "select.aroma",
+        "types": (APPLIANCE_AP,),
+        "read": ("aromaStatus",),
+        "write": ("aromaStatus",),
+    },
+    {
+        "tag": "select.panel_light",
+        "types": (APPLIANCE_AP,),
+        "read": ("lightStatus",),
+        "write": ("lightStatus",),
+    },
 )
 
 # Coverage noise: keys that are technically "unmapped" but are never mappable
@@ -350,43 +474,213 @@ def _command_schema(appliance) -> dict:
     return out
 
 
-def _mapped_sets(app_type) -> tuple[set[str], set[str]]:
-    """(mapped attribute keys, mapped writable command params) for a type.
+def _read_chain(key) -> list[str]:
+    """The attribute keys `base_entity._get_attr` really tries, in order.
+
+    A description names ONE key, and when that key carries the `settings.` prefix
+    the name is only the first thing the entity looks at: `_get_attr` tries the
+    key whole, then the statistics container, and then -- only for a key that
+    itself carries the prefix -- the BARE spelling underneath it. Emitting just
+    the dotted name would hide exactly the fallback chain this section exists to
+    reveal. A reader asking why the climate entity shows no temperature would
+    search the `attributes` map for `settings.tempSel`, find nothing, and never
+    learn that the entity would equally have accepted the bare `tempSel` printed
+    a few lines above it -- which is the same chain-hiding that made
+    `actualWeight` -> `weight` invisible until someone read sensor.py.
+
+    The statistics container is deliberately NOT listed as a third link.
+    `hon_client._get_attributes` merges it into `attributes` before this dump ever
+    sees either, so naming it would point the reader at a place that does not
+    appear in the document.
+    """
+    text = str(key)
+    prefix = "settings."
+    if text.startswith(prefix):
+        return [text, text[len(prefix):]]
+    return [text]
+
+
+def _source_row(read=(), write=()) -> dict[str, list[str]] | None:
+    """One `entities.sources` value: what an entity reads, what it writes.
+
+    An EMPTY half is omitted rather than emitted as `[]`, so a read-only sensor is
+    visibly read-only instead of carrying a `"write": []` the reader has to
+    interpret; and a row with NEITHER half is `null`, which is how this section
+    says "the entity exists and this dump cannot name its parameter" without
+    inventing one.
+
+    Order is preserved and duplicates dropped (`dict.fromkeys`, never `sorted`):
+    for a read chain the SEQUENCE is the information, because it is the order
+    `_get_attr` tries the keys in, and sorting it would turn a fallback chain into
+    an unordered set of equally-plausible names.
+    """
+    # A bare string is ONE name, not a sequence of characters. A row written
+    # `write="onOffStatus"` instead of `write=("onOffStatus",)` -- the missing
+    # trailing comma -- would otherwise be emitted as nine invented one-character
+    # parameter names under a real entity tag.
+    if isinstance(read, (str, bytes)):
+        read = (read,)
+    if isinstance(write, (str, bytes)):
+        write = (write,)
+    row: dict[str, list[str]] = {}
+    reads = [str(name) for name in read if name]
+    if reads:
+        row["read"] = list(dict.fromkeys(reads))
+    writes = [str(name) for name in write if name]
+    if writes:
+        row["write"] = list(dict.fromkeys(writes))
+    return row or None
+
+
+def _mapped_sets(
+    app_type,
+) -> tuple[set[str], set[str], dict[str, dict[str, list[str]] | None] | None]:
+    """(mapped attribute keys, mapped writable command params, entity sources).
 
     Registries are imported lazily so diagnostics.py keeps a tiny top-level import
     surface and cannot be caught in an import cycle; on any import hiccup it degrades
     to the documented custom set rather than crashing the dump.
+
+    The THIRD value is the static per-type index behind `entities.sources`: which
+    raw parameter each entity of this type reads and writes, keyed by the same
+    ``<domain>.<unique_id suffix>`` tag that ``by_domain``, ``disabled``,
+    ``hidden`` and ``not_created`` already speak, so the five views join on one
+    key. It is built HERE, in the same traversal that produces the two coverage
+    sets, rather than in a helper of its own, and that is a correctness
+    requirement rather than a tidiness one: a second lazy-import block with
+    DIFFERENT membership means a single broken platform module makes one dump
+    contradict itself. With `select` imported only by the sources half, a
+    `select.py` that fails to import would produce a dump whose `coverage`
+    confidently reports `tempSelZ3` as mapped while `entities.sources` is a lone
+    null claiming nothing could be looked at. One walk, one degradation decision,
+    and the two sections can never disagree about whether the tables were read.
+
+    The price of that is stated plainly: this block now imports `select` and
+    `program_options` as well, so a break in either degrades the COVERAGE axes
+    too, where before it could not. That is the intended trade -- a dump that
+    under-reports both axes is diagnosable, a dump whose two halves disagree is
+    not -- and it is why `_coverage` prints `registries_unavailable` on that
+    path: the sources half announces the degradation with a null, but there is
+    no sources half at all in a device dump or on an appliance with no registry
+    inventory, and a coverage section that under-reports in silence would be
+    read as fact.
+
+    A None third value (never an empty dict) is what the degraded path returns, so
+    that one unreadable registry costs the reader ONE null instead of a null per
+    entity, which would read as "every entity was looked up and none was found".
     """
     mapped_attrs: set[str] = set(_CUSTOM_MAPPED_ATTRS.get(app_type, ()))
     mapped_params: set[str] = set()
+    sources: dict[str, dict[str, list[str]] | None] = {}
     try:
         from .air_purifier import AP_ENTITY_PARAMS
         from .binary_sensor import BINARY_SENSORS, _CONNECTIVITY, _UNIVERSAL_GATED
-        from .number import NUMBERS
+        from .number import NUMBERS, _AP_TIMING_NUMBERS, _PROGRAM_OPTION_NUMBERS
+        from .program_options import STARTPROGRAM_COMMAND
+        from .select import _AC_DIRECTION_SELECTS, _PROGRAM_OPTION_SELECTS
         from .sensor import SENSORS
-        from .switch import _SETTINGS_SWITCHES
+        from .switch import (
+            _AIR_PURIFIER_SWITCHES,
+            _PROGRAM_OPTION_SWITCHES,
+            _SETTINGS_SWITCHES,
+        )
     except Exception:  # pragma: no cover - diagnostics must never crash
         _LOGGER.debug(
             "Diagnostics debug: coverage registries unavailable", exc_info=True
         )
-        return mapped_attrs, mapped_params
+        return mapped_attrs, mapped_params, None
 
+    # ONE pass per table: the coverage sets get the DECLARED names (unchanged --
+    # `mapped_attrs` is the attribute axis' numerator and moving it would silently
+    # restate every published coverage figure), while the source rows get the
+    # declared name EXPANDED through `_read_chain`, which is the reader-facing
+    # question and a different one.
     for desc in SENSORS.get(app_type, ()):
-        mapped_attrs.add(desc.attr_key)
-        mapped_attrs.update(getattr(desc, "attr_fallbacks", ()) or ())
+        declared = [desc.attr_key, *(getattr(desc, "attr_fallbacks", ()) or ())]
+        mapped_attrs.update(declared)
+        sources[f"sensor.{desc.key}"] = _source_row(
+            read=[key for name in declared for key in _read_chain(name)]
+        )
     for desc in BINARY_SENSORS.get(app_type, ()):
         mapped_attrs.add(desc.attr_key)
+        sources[f"binary_sensor.{desc.key}"] = _source_row(
+            read=_read_chain(desc.attr_key)
+        )
     mapped_attrs.add(_CONNECTIVITY.attr_key)
+    sources[f"binary_sensor.{_CONNECTIVITY.key}"] = _source_row(
+        read=_read_chain(_CONNECTIVITY.attr_key)
+    )
     for desc in _UNIVERSAL_GATED:
         mapped_attrs.add(desc.attr_key)
+        sources[f"binary_sensor.{desc.key}"] = _source_row(
+            read=_read_chain(desc.attr_key)
+        )
 
     for desc in NUMBERS.get(app_type, ()):
         mapped_params.add(desc.param)
+        sources[f"number.{desc.key}"] = _source_row(
+            read=_read_chain(desc.param), write=[desc.param]
+        )
     # Settings-command switches (AC toggles + wine-cooler light) map their write param.
     for desc in _SETTINGS_SWITCHES.get(app_type, ()):
         mapped_params.add(desc.param)
+        sources[f"switch.{desc.key}"] = _source_row(
+            read=_read_chain(desc.param), write=[desc.param]
+        )
+    # A program option is BUFFERED, not sent: it is written to the pending store
+    # and applied to `startProgram` when the start button fires. That is why its
+    # read chain has a second link nothing else in this walk has -- the option is
+    # read bare first and then under `startProgram.<param>`, because unlike
+    # `settings` the startProgram command is not mirrored into the device shadow
+    # (`program_options.HonProgramOptionEntity._current_raw`). These params are
+    # deliberately NOT added to `mapped_params`: they live on startProgram, which
+    # `_settings_param_names` never reads, so adding them would put names in the
+    # coverage numerator that its denominator can never contain.
+    for prefix, table in (
+        ("number.opt_", _PROGRAM_OPTION_NUMBERS),
+        ("select.opt_", _PROGRAM_OPTION_SELECTS),
+        ("switch.opt_", _PROGRAM_OPTION_SWITCHES),
+    ):
+        for desc in table:
+            if app_type not in (getattr(desc, "types", None) or ()):
+                continue
+            # BOTH numerators, not just `sources`. The stated reason for leaving
+            # them out -- "they live on startProgram, which `_settings_param_names`
+            # never reads" -- is false on the live TD, whose `settings` command
+            # carries `tumblingStatus`, and does not apply at all on the attribute
+            # axis, where the option IS a bare shadow key (live TD:
+            # `antiCreaseTime`, `sterilizationStatus`). Leaving them out ships one
+            # block whose `coverage` calls a name unmapped while `entities.sources`
+            # twenty lines below names the switch that reads and writes it -- the
+            # exact failure the `_AC_DIRECTION_SELECTS` correction exists to avoid.
+            mapped_attrs.add(desc.param)
+            mapped_params.add(desc.param)
+            sources[f"{prefix}{desc.key}"] = _source_row(
+                read=[desc.param, f"{STARTPROGRAM_COMMAND}.{desc.param}"],
+                write=[desc.param],
+            )
     if app_type == APPLIANCE_AC:
         mapped_params |= _AC_CLIMATE_PARAMS
+        # The manual louver selects. `desc.attr` is the DOTTED read path and
+        # `desc.param` the settings parameter written, and they differ, which is
+        # the whole reason this section is worth its bytes.
+        #
+        # `mapped_params.add` is here and not only in `sources`, and it is a
+        # deliberate correction rather than an oversight repeated. Before this
+        # section existed, `windDirectionHorizontal` sat in
+        # `command_params_unmapped` -- "the device has it and no addhon entity
+        # maps it" -- and nothing in the dump disproved it. `sources` now names
+        # `select.fan_direction_horizontal` as its writer ten lines below, so
+        # leaving the coverage line alone would ship one block making two
+        # statements the reader can see contradict each other, on the list this
+        # module calls the gold signal. Nothing published moves:
+        # `command_params_total` is `len(settings_params) - len(params_meta)`,
+        # which never reads `mapped_params`, and this name is not a meta param.
+        for desc in _AC_DIRECTION_SELECTS:
+            mapped_params.add(desc.param)
+            sources[f"select.{desc.key}"] = _source_row(
+                read=_read_chain(desc.attr), write=[desc.param]
+            )
     if app_type in APPLIANCE_WASH_GROUP:
         mapped_params.update(PROGRAM_PARAM_NAMES)
     if app_type == APPLIANCE_AP:
@@ -396,7 +690,37 @@ def _mapped_sets(app_type) -> tuple[set[str], set[str]]:
         # written as a command field, hence both axes.
         mapped_attrs |= AP_ENTITY_PARAMS
         mapped_params |= AP_ENTITY_PARAMS
-    return mapped_attrs, mapped_params
+        for prefix, table in (
+            ("number.", _AP_TIMING_NUMBERS),
+            ("switch.", _AIR_PURIFIER_SWITCHES),
+        ):
+            for desc in table:
+                sources[f"{prefix}{desc.key}"] = _source_row(
+                    read=_read_chain(desc.param), write=[desc.param]
+                )
+
+    # Last, the entities no registry knows about. Guarded field by field even
+    # though the table three hundred lines above is a literal in this same file:
+    # this loop is OUTSIDE the try above, and `_appliance_block` is called with no
+    # try/except around it from either entry point, so one malformed row added
+    # later -- a missing `types`, a tag with no dot -- would not cost a section, it
+    # would cost the reporter the entire dump.
+    for entry in _CUSTOM_ENTITY_SOURCES:
+        tag = str(entry.get("tag") or "")
+        domain, _dot, suffix = tag.partition(".")
+        if not domain or not suffix:
+            continue
+        if app_type not in (entry.get("types") or ()):
+            continue
+        sources[tag] = _source_row(
+            read=[
+                key
+                for name in (entry.get("read") or ())
+                for key in _read_chain(name)
+            ],
+            write=entry.get("write") or (),
+        )
+    return mapped_attrs, mapped_params, sources
 
 
 def _settings_param_names(appliance) -> set[str]:
@@ -473,7 +797,9 @@ def _command_param_names(appliance) -> set[str]:
     return names
 
 
-def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> dict:
+def _coverage(
+    app_type, attributes: Mapping, statistics: Mapping, appliance, mapped=None
+) -> dict:
     """What the device exposes with no addhon entity (the gold signal).
 
     Attribute axis: only BARE keys (no dot) are considered; dotted ``settings.*``
@@ -498,7 +824,9 @@ def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> 
     publishes no ``tempZ4``. On the live REF dump this line prints thirteen
     names on the first download, and ``tempZ4`` is one of them.
     """
-    mapped_attrs, mapped_params = _mapped_sets(app_type)
+    mapped_attrs, mapped_params, sources_index = (
+        mapped if mapped is not None else _mapped_sets(app_type)
+    )
     settings_params = _settings_param_names(appliance)
     # A SECOND, wider universe, used only by the expected-absent mirror below:
     # every parameter of every command, not just the settings ones. The two are
@@ -510,10 +838,21 @@ def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> 
     # to the command-param axis, not the attribute axis, so subtract every writable
     # settings-param name as well - otherwise controlled setpoints (number/climate/AC
     # switch) would be falsely listed as unmapped read-only attributes.
-    bare = {k for k in attributes if isinstance(k, str) and "." not in k}
+    published = {k for k in attributes if isinstance(k, str)}
+    bare = {k for k in published if "." not in k}
     # Read-only telemetry is the attribute axis: writable param mirrors live on the
     # command-param axis, so exclude them from BOTH the unmapped list and the total
     # (otherwise `total` overstates this axis' denominator).
+    # A mapped name is ABSENT only when no spelling its OWN read chain reaches is
+    # published. A buffered program option is read bare and then under
+    # `startProgram.<name>`, and the live TD publishes `tumblingStatus` only
+    # there; a single-link chain (`sensor.delay_time` -> `delayTime`) keeps the
+    # strict bare test, because that entity really cannot see a dotted spelling.
+    reachable = set(bare)
+    for _row in (sources_index or {}).values():
+        _chain = (_row or {}).get("read") or ()
+        if len(_chain) > 1 and any(link in published for link in _chain[1:]):
+            reachable.add(_chain[0])
     read_only_bare = bare - settings_params
     unmapped = read_only_bare - mapped_attrs
     stats_keys = set(statistics) if isinstance(statistics, Mapping) else set()
@@ -579,8 +918,19 @@ def _coverage(app_type, attributes: Mapping, statistics: Mapping, appliance) -> 
         # schema KNOWS the name at all, so a mapped param the entity writes
         # through settings while the device declares it only under
         # `startProgram` is reported by neither.
-        "attributes_expected_absent": sorted(mapped_attrs - bare),
+        "attributes_expected_absent": sorted(mapped_attrs - reachable),
         "command_params_expected_absent": sorted(mapped_params - command_params),
+        # Emitted ONLY when the lazy import above failed, because every number
+        # in this dict is then measured against tables that could not be read:
+        # the two unmapped lists swell to the whole device and both
+        # expected_absent lists collapse to empty, which reads as "this
+        # integration maps nothing on your appliance". `entities.sources`
+        # carries the same null -- but that section is absent entirely whenever
+        # there is no registry inventory for this appliance (the device dump, or
+        # a registry that could not be read), and a reader cannot tell that null
+        # apart from "there was nothing to decorate". A coverage section that
+        # under-reports in silence is the one thing this dump may not do.
+        **({"registries_unavailable": True} if sources_index is None else {}),
     }
 
 
@@ -897,8 +1247,14 @@ def _appliance_block(
 
     commands = _command_schema(appliance)
     model_attributes = _model_attributes(appliance)
-    coverage = _coverage(app_type, attributes, statistics, appliance)
+    # ONE walk of the per-type tables, ONE lazy-import decision, shared by both
+    # consumers -- which is what the `_mapped_sets` docstring claims and what
+    # makes `coverage.registries_unavailable` and `entities.sources` structurally
+    # incapable of disagreeing.
+    mapped = _mapped_sets(app_type)
+    coverage = _coverage(app_type, attributes, statistics, appliance, mapped)
     future = _future_capabilities(app_type, attributes, appliance)
+    entity_section = _entity_section(entities, app_type, mapped)
 
     _LOGGER.debug(
         "Diagnostics debug: appliance id=%s name=%s type=%s attrs=%d model_attrs=%d "
@@ -928,10 +1284,76 @@ def _appliance_block(
         # Next to coverage on purpose: one says what the code could map for this
         # type, the other what Home Assistant actually holds. Reading them together
         # is the whole point, and a disagreement between them IS the finding.
-        "entities": dict(entities) if isinstance(entities, Mapping) else None,
+        "entities": entity_section,
         "future_capabilities": future,
     }
     return _redact(block)
+
+
+def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | None:
+    """The registry inventory for one appliance, plus what each entity speaks to.
+
+    `by_domain` and its siblings answer WHICH entities Home Assistant holds.
+    `sources` answers the question that used to need the source tree: which raw
+    parameter each of them reads, and which one it writes. On issue #75 those are
+    two adjacent rows -- `sensor.temp_zone3` reads `tempZ3` while
+    `number.target_temp_zone4` writes `tempSelZ4` -- and reading them together is
+    what removes the round trip that otherwise costs the reporter another dump.
+
+    Appended LAST so that every key a reader already knows keeps its position; a
+    section that reshuffles between releases is a section people stop skimming.
+
+    THE PRIVACY ARGUMENT, stated precisely because the obvious version of it is
+    wrong. Registry rows ARE an input here: every key of `sources` is a tag built
+    in `_entity_inventory` from `_entity_row(row.unique_id, appliance_id)`, so
+    cloud-derived text reaches this map's KEYS. What makes that safe is not that
+    the registry is untouched, it is `_entity_row`'s prefix slice (the appliance
+    id is removed by construction, having already been proven a prefix) plus the
+    closed vocabulary of unique_id suffixes, every one of which is a constant
+    written in this repository. The VALUES are safe for a stronger reason: they
+    are copied out of the static per-type tables and never out of the device, so
+    no cloud string can reach them at all. Both halves are pinned by tests, and
+    the first is the one to re-check whenever a new entity class lands -- a class
+    that built its unique_id out of a device-supplied name would break it.
+
+    A non-Mapping inventory yields None, which is today's behaviour for "there was
+    nothing to decorate", unchanged. A section with no `by_domain` is returned as
+    a plain copy: that shape is the degraded `{"status": "unavailable"}` marker,
+    whose whole meaning is that the registry could not be read, and hanging a
+    `sources` key off it would claim a lookup that never happened. The test that
+    guards it asserts EXACT dict equality, on purpose.
+    """
+    if not isinstance(entities, Mapping):
+        return None
+    section = dict(entities)
+    by_domain = section.get("by_domain")
+    if not isinstance(by_domain, Mapping):
+        return section
+    _mapped_attrs, _mapped_params, index = (
+        mapped if mapped is not None else _mapped_sets(app_type)
+    )
+    if index is None:
+        # ONE null for the whole section, not one per entity. A map of nulls would
+        # read as "every entity was looked up and none of them is known", which is
+        # a finding; "this dump could not look" is the absence of one, and the
+        # sibling `_registry_entries` docstring spells out why the two must never
+        # be folded together.
+        section["sources"] = None
+        return section
+    sources: dict[str, dict[str, list[str]] | None] = {}
+    for domain, keys in by_domain.items():
+        if not isinstance(keys, (list, tuple)):
+            continue
+        for key in keys:
+            # `index.get` and not `index[...]`: a registry row left over from an
+            # older release names a suffix no current table knows, and that row
+            # must still appear here as an explicit null. Dropping it would make
+            # `sources` disagree with `by_domain` about how many entities exist,
+            # which is the one thing a join key must never do.
+            tag = f"{domain}.{key}"
+            sources[tag] = index.get(tag)
+    section["sources"] = sources
+    return section
 
 
 def _registry_entries(hass: HomeAssistant, entry: ConfigEntry) -> list | None:

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -112,19 +112,6 @@ _TO_REDACT = frozenset(
     }
 )
 
-# Bare attributes consumed by CUSTOM entity classes that have NO description table,
-# so a coverage calc based only on the description registries would wrongly report
-# them as unmapped. Kept small and documented; a unit test guards against drift.
-#   HonMeanWaterConsumption (sensor.py): totalWashCycle + totalWaterUsed
-#   HonWashingMachinePauseSwitch (switch.py): machMode
-#   HaierClimateEntity (climate.py): tempIndoor (current temp; its other reads are
-#       dotted settings.* keys, already excluded from the attribute axis)
-_CUSTOM_MAPPED_ATTRS: dict[str, frozenset[str]] = {
-    "WM": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
-    "WD": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
-    "TD": frozenset({"machMode"}),
-    "AC": frozenset({"tempIndoor"}),
-}
 
 # Settings-command params written by HaierClimateEntity (climate.py has no
 # description table). AC only.
@@ -628,7 +615,15 @@ def _mapped_sets(
     `entities.sources`: that is the narrower and truer statement, and it names
     them one by one instead of blanking the whole map.
     """
-    mapped_attrs: set[str] = set(_CUSTOM_MAPPED_ATTRS.get(app_type, ()))
+    # Custom entity classes have no description table, so their bare attributes
+    # used to be listed in a `_CUSTOM_MAPPED_ATTRS` constant and seeded here.
+    # Measured on every type the constant covered: the registry walk below
+    # already supplies all eight names, so the seed contributed nothing and is
+    # gone. The guarantee it existed for -- a custom class's attribute never
+    # reported unmapped -- is pinned behaviourally in the tests, which is the
+    # loud failure a narrowed description table should produce rather than the
+    # silent correction a standing seed would apply.
+    mapped_attrs: set[str] = set()
     mapped_params: set[str] = set()
     sources: dict[str, dict[str, list[str]] | None] = {}
     unavailable: list[str] = []

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1438,6 +1438,82 @@ def _attribute_timestamps(
     return dict(sorted(rows.items())), truncated, newest
 
 
+def _attribute_values(attributes: Mapping) -> Mapping:
+    """The attribute mapping the block uses, minus the sub-map that repeats it.
+
+    `attributes["parameters"]` is the device shadow's own container, and
+    `hon_client._get_attributes` flattens it over the top level one line after
+    merging it (`hon_client.py:187-191`), so every one of its keys is normally
+    ALSO a bare key pointing at the very same object. Measured on
+    diagnostics/live-2026-06-22/, across all four appliances and all 243
+    parameters (REF 16, AC 74, TD 41, WM 112): zero mismatches. The nested map
+    is a verbatim second copy, and it costs 7624 bytes and 251 lines of the
+    entry dump at the indent=2 Home Assistant serves.
+
+    The one thing it carried that the bare keys did not is WHICH keys are shadow
+    parameters -- and `attributes_last_update` beside it now carries exactly
+    that set, with the instant as well. Dropping it is therefore not a loss of
+    information, which is the only reason it is dropped at all.
+
+    The result replaces `attributes` for the WHOLE block, not just for the
+    emitted echo, and that is not a convenience. `_coverage` classifies
+    `parameters` as an envelope blob and lists it in
+    ``attributes_unmapped_meta`` -- it does so on all four live appliances --
+    so deduplicating only the copy the reader sees would ship a document whose
+    coverage section names a key the section beside it no longer prints. Two
+    parts of one dump contradicting each other is the failure this dump exists
+    to expose, not to commit.
+
+    It is dropped ONLY when it is provably redundant, and never merely because
+    it is present. The check is identity (`is`), not equality, for two reasons:
+    equality on a cloud object calls an `__eq__` this module does not control
+    and cannot afford to have raise, and identity is what the merge above
+    actually establishes. The lookup uses the module sentinel rather than
+    `.get(name)`, because `.get` answers None both for "absent" and for
+    "present and None", and a nested value of None would otherwise read as
+    redundant against a bare key that is not there at all. An EMPTY sub-map is
+    kept for the same conservatism: `all([])` is True, and "the shadow
+    container was empty" is a different statement from "there is no shadow
+    container". When even one nested key is missing from the top level the whole
+    sub-map is kept, because that is the signature of the degraded path at
+    `hon_client.py:192-196` -- a `parameters` Mapping whose `dict()` coercion
+    raised, leaving NOTHING flattened and this sub-map as the only carrier of
+    both the values and their instants. Deleting it there would delete the only
+    copy of the data.
+    """
+    try:
+        nested = attributes.get("parameters")
+    except Exception:  # pragma: no cover - a Mapping that refuses one key
+        return attributes
+    if not isinstance(nested, Mapping):
+        return attributes
+    try:
+        redundant = bool(nested) and all(
+            attributes.get(name, _NO_LAST_UPDATE) is value
+            for name, value in nested.items()
+        )
+    except Exception:  # pragma: no cover - a Mapping that cannot be walked
+        # The same object that made `dict(params)` raise upstream. If it cannot
+        # be compared it cannot be shown to be redundant, so it stays.
+        _LOGGER.debug(
+            "Diagnostics debug: nested parameters not comparable", exc_info=True
+        )
+        return attributes
+    if not redundant:
+        return attributes
+    try:
+        return {
+            name: value for name, value in attributes.items() if name != "parameters"
+        }
+    except Exception:  # pragma: no cover - a Mapping that cannot be copied
+        # The last unguarded read of `attributes` in this helper. Losing the
+        # dedupe costs bytes; raising here costs the reporter the whole file.
+        _LOGGER.debug(
+            "Diagnostics debug: attributes not copyable", exc_info=True
+        )
+        return attributes
+
+
 def _appliance_block(
     appliance_id: str,
     data: Mapping,
@@ -1470,6 +1546,15 @@ def _appliance_block(
     # pass so that anything reporting freshness from it can never disagree with
     # the map the reader is looking at, even after the row cap has fired.
     stamps, stamps_truncated, newest_stamp = _attribute_timestamps(attributes)
+    # De-duplicated ONCE, above every consumer, and only after the instants have
+    # been read -- the sub-map is their fallback source on the degraded merge
+    # path, so dropping it first would throw away the very rows it exists to
+    # rescue. Skipped entirely when the row cap fired: the justification for
+    # deleting the sub-map is that `attributes_last_update` now carries the one
+    # bit it held (which keys are shadow parameters), and a truncated map does
+    # not carry it for the rows it dropped.
+    if not stamps_truncated:
+        attributes = _attribute_values(attributes)
     statistics = data.get("statistics")
     statistics = statistics if isinstance(statistics, Mapping) else {}
     # Normalised HERE and nowhere else. A caller may pass nothing, a naive

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1079,7 +1079,8 @@ def _as_utc(value, assume_naive_utc: bool) -> datetime | None:
 # shape this pattern accepts is a shape a datetime SUBCLASS could smuggle
 # through the output validation below. The narrower it is, the less it admits.
 _ISO_RE = re.compile(
-    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:[+-]\d{2}:\d{2})?"
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]{1,6})?(?:[+-][0-9]{2}:[0-9]{2})?"
 )
 _STAMP_MAX_CHARS = 40
 
@@ -1205,6 +1206,238 @@ def _future_capabilities(app_type, attributes: Mapping, appliance) -> dict:
     return section
 
 
+# Bound on the ROWS of the instant map below, one row per shadow parameter. The
+# largest real device this repository holds a dump from is a washing machine
+# with 112 of them (counted in diagnostics/live-2026-06-22/: REF 16, TD 41,
+# AC 74, WM 112), so at 200 this is a runaway guard against a firmware that
+# starts publishing thousands of parameters, not a filter -- exactly the framing
+# _ENTITY_MAX_PER_DOMAIN carries above, and on every appliance seen so far it
+# does not fire. It exists at all because `attributes` beside it is emitted
+# UNCAPPED: if a shadow ever did explode, this map would be the second copy of
+# the explosion in one document and the reader would pay for it twice.
+_STAMP_MAX_ROWS = 200
+
+# "This value exposes no `last_update` surface at all", which has to stay
+# distinguishable from "it exposes one and the answer is None". The first is not
+# a shadow parameter and gets NO row; the second is one and gets a `null` row,
+# and those are two different findings. It is the same distinction
+# `_registry_entries` draws between None and [], and it is why the plain
+# `getattr(value, "last_update", None)` is not good enough here.
+_NO_LAST_UPDATE = object()
+
+# The cloud's "this parameter has never been stamped" sentinel. Every one of the
+# 66 `lastUpdate` values in the only real REF capture this repository holds
+# (tests/fixtures/ref_10136, apk/dump/ref_10136) is exactly this instant, while
+# the AC capture beside it carries real 2023 dates. It is not an instant, and it
+# must never become the newest one: printed as an age it reads as a 56-year-old
+# shadow on a fridge that is connected and reporting.
+_NEVER_STAMPED = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _attribute_timestamps(
+    attributes: Mapping,
+) -> tuple[dict[str, str | None], bool, datetime | None]:
+    """The cloud instant behind each shadow value: the map, the cap flag, the newest.
+
+    The device shadow arrives as `{parNewVal, lastUpdate}` per parameter and the
+    engine keeps both on a `HonAttribute` (`client/engine/attributes.py`), but
+    `_jsonable` unwraps only `.value`, so every instant the cloud sent has until
+    now been discarded at the last step before the dump. The difference that
+    makes is the difference between "the appliance reports tempZ3 = -43" and
+    "the appliance last moved tempZ3 four days ago and has been repeating it
+    since", and answering the second used to require a SECOND dump days later --
+    which is precisely the round trip issue #75 paid for. The hOn app's own
+    mocked shadow shows how much signal sits in the field: of its 74 parameters
+    38 carry one identical instant from 2020 and the remainder spread over 21
+    distinct ones (`apk/decomp.txt:1836416-1836566`).
+
+    Three values are returned, deliberately out of ONE pass:
+
+      [0] `{parameter name: ISO text or None}`, one row for each value that
+          exposes a `last_update` surface. That set is also the only honest
+          answer to "which of these keys are shadow parameters", a bit the dump
+          carries today only by duplicating the whole `attributes["parameters"]`
+          sub-map.
+      [1] True when the ROW CAP dropped rows, and for nothing else. In this
+          module a flag named `truncated` means dropped ROWS -- see
+          `_future_capabilities`, `_entity_inventory` and the platform summary,
+          which all use it that way -- and a character cap would need a
+          different name. There is no character cap here.
+      [2] the newest instant, as an AWARE UTC datetime, computed over ALL
+          parameters INCLUDING any the row cap dropped, and never emitted from
+          here. It is handed back rather than left for the caller to recompute
+          so that anything reporting freshness from it and the map above it are
+          physically incapable of disagreeing: a second pass over an already
+          truncated map would quietly report the newest SURVIVING instant as
+          the newest instant, which is the worst kind of wrong -- plausible.
+
+    `None` in [0] is OVERLOADED and a reader has to be told all three ways it is
+    reached. It means "no parseable instant has ever arrived for this
+    parameter"; it means "reading the instant raised"; and it means "a datetime
+    did arrive and `_stamp_text` refused its output", which happens when a
+    datetime SUBCLASS returns something from `isoformat` that is too long or is
+    not an ISO instant. It does NOT mean "the cloud stopped stamping this
+    parameter": `attributes.py:73` is a walrus guard (`if last_update :=
+    data.get("lastUpdate"):`), so an update carrying no `lastUpdate` leaves the
+    previous instant standing, and only a present-but-unparseable value resets
+    it (`attributes.py:75-77`). The consequence is worth stating plainly,
+    because it will otherwise be read as a bug: a stamp here can legitimately be
+    OLDER than the value printed beside it in `attributes`, on the plain REST
+    path, with nothing wrong anywhere.
+
+    Formatting is delegated to `_stamp_text` and NOT reimplemented here. That
+    helper owns the three properties this section would otherwise have to
+    rediscover: an aware instant is normalised to UTC because `_MAC_RE` eats a
+    sub-minute offset ('2026-04-09T12:34:56-05:30:15' survives `_jsonable` as
+    '2026-04-09T***'); awareness is decided on `utcoffset()` and not on
+    `tzinfo`, because a tzinfo whose `utcoffset()` returns None makes CPython
+    silently re-read the instant in the HOST's zone and then label it '+00:00';
+    and the OUTPUT is validated, because `isinstance(x, datetime)` admits
+    subclasses and a subclass may return anything at all from `isoformat`.
+
+    The `parameters` sub-map is walked as a SECOND source, and the reason is not
+    the obvious one. `hon_client._get_attributes` merges `raw` -- which carries
+    that sub-map under its own key -- at :187, and only then flattens the
+    parameters over the top at :191, so on a healthy device the `HonAttribute`
+    IS already the bare value and the nested copy is pure duplication (all four
+    live dumps agree on every key, zero mismatches in 243 parameters). The
+    reachable failure is :192-196: when `parameters` is a Mapping that is not a
+    `dict`, the merge goes through `dict(params)`, whose argument is evaluated
+    in full before anything is merged, so a Mapping whose iteration or
+    `__getitem__` misbehaves leaves NOTHING flattened and the nested object as
+    the only surviving carrier of the instants.
+
+    Only a Mapping is followed there. A non-Mapping iterable under that key (a
+    generator, a list) is deliberately NOT walked: this runs on the event loop,
+    `len()` is the only bound available before iterating, and a section that
+    would hang the loop to rescue a degraded corner is worse than the corner.
+
+    Two shapes were weighed and rejected, on the record.
+
+    Re-using `attributes["parameters"]` by replacing its values with the
+    instants is measurably cheaper than a sibling map (one key, one nesting
+    level, and the duplication is paid for already). It is refused because it
+    silently redefines a key four live dumps already carry: a maintainer
+    comparing a June dump against an August one would read instants where the
+    older file has values, with nothing in either file to announce the change.
+    It would also mean special-casing one key inside the `dict(attributes)`
+    copy, and that copy's whole contract is to be a faithful echo of what the
+    device said. The honest treatment of that duplication is to DELETE the
+    nested map, which is a separate decision from this one and is taken (or
+    not) at the point where `attributes` is normalised.
+
+    Emitting relative AGES (`{"tempZ3": 345}`) instead of absolute instants is
+    the privacy-cheaper shape: an age carries no wall clock and no zone. It is
+    refused because an age is only meaningful against the moment the dump was
+    taken, which `generated_at` now supplies at the top of the document, so the
+    absolute form gives that up for nothing; because two dumps taken days apart
+    can be aligned on absolute instants and cannot be aligned on ages; and
+    because an age is computed from the REPORTER's clock, which adds a
+    dependency on that clock being right, where the instants are cloud-authored
+    and arrive already agreed.
+    """
+    rows: dict[str, str | None] = {}
+    newest: datetime | None = None
+    truncated = False
+    seen: set[str] = set()
+
+    sources: list[Mapping] = [attributes]
+    try:
+        nested = attributes.get("parameters")
+    except Exception:  # pragma: no cover - a Mapping that refuses one key
+        # Guarded even though `.get` looks total: `Mapping.get` only swallows
+        # KeyError, and this is the FIRST read of `attributes` in the block, so
+        # an unguarded call here would take the dump down before `_coverage`
+        # ever gets its own chance to fail on the same object.
+        nested = None
+    if isinstance(nested, Mapping):
+        sources.append(nested)
+
+    for source in sources:
+        try:
+            names = sorted(source, key=str)
+        except Exception:  # pragma: no cover - a Mapping that cannot list keys
+            # Honest scope: for the NESTED map this is the reachable guard, and
+            # it is what keeps a half-broken Mapping from taking the document
+            # down. For `attributes` itself it is a formality -- `_coverage`
+            # iterates the same object a few lines below with no guard at all,
+            # so a mapping that cannot list its keys ends the dump regardless.
+            _LOGGER.debug(
+                "Diagnostics debug: attribute names unreadable", exc_info=True
+            )
+            continue
+        for name in names:
+            key = str(name)
+            if key in seen:
+                continue
+            try:
+                value = source[name]
+            except Exception:
+                # A key that enumerates and then refuses to resolve is exactly
+                # the object that made `dict(params)` raise upstream. Skip the
+                # one key rather than the whole source, so a single bad entry
+                # costs one row and not the entire section.
+                continue
+            try:
+                raw = getattr(value, "last_update", _NO_LAST_UPDATE)
+            except Exception:
+                # A `last_update` PROPERTY that raises. This must land as a
+                # `null` row, never as a missing one: dropping it here would
+                # merge "this parameter has never carried a parseable instant"
+                # into "this key is not a shadow parameter at all", and telling
+                # those two apart is most of what the section is for.
+                raw = None
+            if raw is _NO_LAST_UPDATE:
+                continue
+            seen.add(key)
+            # Two conversions of one value, on purpose, because the two answers
+            # follow different policies. `_stamp_text` keeps a naive instant
+            # naive, so the dump never claims a zone the cloud did not send;
+            # `_as_utc(..., True)` reads that same naive instant AS UTC, because
+            # an age has to be computed under some assumption and stating it is
+            # better than dropping the row. The newest is tracked for EVERY
+            # parameter, including the ones the cap below refuses to print.
+            try:
+                instant = _as_utc(raw, True)
+                if instant is not None:
+                    # Rebuilt from the integer fields, INSIDE the guard, and
+                    # both halves of that matter. `isinstance(x, datetime)`
+                    # admits SUBCLASSES: the door `_stamp_text` closes on
+                    # `isoformat` is wide open on the `__gt__` below and on the
+                    # `__sub__` that whoever consumes this value will perform,
+                    # and a subclass raising in either does not produce a wrong
+                    # age, it produces NO DUMP AT ALL. Rebuilding also means the
+                    # instant handed on is a plain `datetime`, so no later
+                    # consumer inherits the risk.
+                    instant = datetime(
+                        instant.year,
+                        instant.month,
+                        instant.day,
+                        instant.hour,
+                        instant.minute,
+                        instant.second,
+                        instant.microsecond,
+                        tzinfo=timezone.utc,
+                    )
+                    if instant > _NEVER_STAMPED and (
+                        newest is None or instant > newest
+                    ):
+                        newest = instant
+            except Exception:  # pragma: no cover - a hostile datetime subclass
+                _LOGGER.debug(
+                    "Diagnostics debug: instant not comparable", exc_info=True
+                )
+            if len(rows) >= _STAMP_MAX_ROWS:
+                truncated = True
+                continue
+            rows[key] = _stamp_text(raw)
+    # Sorted ONCE, at the end, and not per source: the two sources are each
+    # walked in sorted order but a bare key and a nested one can both be
+    # productive, and a map whose second half restarts the alphabet reads as a
+    # rendering bug.
+    return dict(sorted(rows.items())), truncated, newest
+
+
 def _appliance_block(
     appliance_id: str,
     data: Mapping,
@@ -1232,6 +1465,11 @@ def _appliance_block(
     app_type = data.get("type")
     attributes = data.get("attributes")
     attributes = attributes if isinstance(attributes, Mapping) else {}
+    # Read the instants HERE, off the same mapping the block echoes below, and
+    # once. The third value is the newest of them: it is computed in the same
+    # pass so that anything reporting freshness from it can never disagree with
+    # the map the reader is looking at, even after the row cap has fired.
+    stamps, stamps_truncated, newest_stamp = _attribute_timestamps(attributes)
     statistics = data.get("statistics")
     statistics = statistics if isinstance(statistics, Mapping) else {}
     # Normalised HERE and nowhere else. A caller may pass nothing, a naive
@@ -1279,6 +1517,24 @@ def _appliance_block(
         # Before `attributes` on purpose: what the model IS, then what it is doing.
         "model_attributes": model_attributes,
         "attributes": dict(attributes),
+        # BESIDE the values, never inside them. `attributes` above has one
+        # contract -- a flat name -> value echo of what the device said -- and a
+        # section that turned its leaves into {value, last_update} objects would
+        # break every reader, every jq filter and the value-type partition
+        # `_coverage` runs over exactly those leaves.
+        #
+        # The truncation flag is a SIBLING key rather than a `truncated` entry
+        # inside the map, and that is a deliberate deviation from the three
+        # precedents in this module (`_future_capabilities`, `_entity_inventory`
+        # and the platform summary all put it inside). The reason is specific to
+        # this map and does not generalise: every key in it is a cloud-CHOSEN
+        # parameter name, so a reserved key named `truncated` would be
+        # indistinguishable from a device that publishes a parameter called
+        # `truncated` -- the section would be unable to say whether it had
+        # dropped rows or merely found one oddly named. It is emitted only when
+        # true and immediately after the map, so it still reads as part of it.
+        "attributes_last_update": stamps,
+        **({"attributes_last_update_truncated": True} if stamps_truncated else {}),
         "commands": commands,
         "coverage": coverage,
         # Next to coverage on purpose: one says what the code could map for this

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -877,17 +877,27 @@ _FIXED_WRITE_COMMANDS: dict[str, str] = {
 }
 
 
-def _declared_command_params(appliance) -> dict[str, set[str]]:
-    """Parameter names the appliance declares, per command.
+def _declared_command_params(appliance) -> dict[str, set[str]] | None:
+    """Parameter names the appliance declares, per command, or None if unread.
 
     Distinct from `_settings_param_names` (writables, settings commands only)
     and from `_command_param_names` (every command flattened into one set): the
     question here is which command a name is declared UNDER, because a fixed
     parameter applied by an entity is only applied when that command carries it.
+
+    None and `{}` are DIFFERENT answers and must never be folded together, for
+    the same reason `_registry_entries` keeps them apart. `{}` is an appliance
+    whose command schema was read and declares nothing -- the live dryer -- and
+    `_declared_write_only` narrows on it, which is correct. None is a schema
+    this dump could not read at all, and narrowing there would print "not
+    looked" as "the device does not declare it". Returning `{}` for both made
+    that substitution on every unreadable appliance: it is a Mapping, so the
+    guard downstream let it through and `button.stop_program` shipped as null,
+    indistinguishable from the dryer that really applies nothing.
     """
     commands = getattr(appliance, "commands", None)
     if not isinstance(commands, Mapping):
-        return {}
+        return None
     out: dict[str, set[str]] = {}
     for cmd_name, cmd in commands.items():
         params = getattr(cmd, "parameters", None)

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -1491,6 +1491,15 @@ def _appliance_block(
     # incapable of disagreeing.
     mapped = _mapped_sets(app_type)
     coverage = _coverage(app_type, attributes, statistics, appliance, mapped)
+    # Built from `newest_stamp`, the third value of the SAME `_attribute_timestamps`
+    # pass that produced the printed `attributes_last_update` map below, never from a
+    # second walk of `attributes`. Two passes over one mapping is two chances to
+    # disagree, and they WOULD disagree on the dump where it matters most: once the
+    # row cap has dropped the newest parameter from the printed map, a second pass
+    # over the printed rows would report a shadow that is older than the appliance's
+    # real newest reading, in the very document a reader opened to find out how stale
+    # the readings are.
+    freshness = _freshness(appliance, attributes, newest_stamp, now)
     future = _future_capabilities(app_type, attributes, appliance)
     entity_section = _entity_section(entities, app_type, mapped)
 
@@ -1514,7 +1523,20 @@ def _appliance_block(
         "model": data.get("model"),
         "serial": _REDACTED,
         "mac": _REDACTED,
-        # Before `attributes` on purpose: what the model IS, then what it is doing.
+        # Directly under the identity keys, and above everything it qualifies: a
+        # reader who does not know whether the appliance was online cannot safely
+        # interpret a single value below this line, so the answer must arrive before
+        # the values do rather than being hunted for among sixty attribute keys.
+        "freshness": freshness,
+        # The pinned order from here on, which sections are APPENDED into rather than
+        # sorted: what the model IS, then a reserved slot for the per-zone map, then
+        # what it is DOING and when the cloud last moved it, then what can be
+        # COMMANDED, then the analysis sections -- `coverage`, `entities`,
+        # `future_capabilities` -- which are read together and are the reason the
+        # dump exists at all. The reserved slot is real and load bearing: `zone_map`
+        # goes BETWEEN `model_attributes` and `attributes`, and naming it here is
+        # what stops the next section from being dropped wherever its patch happened
+        # to apply cleanly.
         "model_attributes": model_attributes,
         "attributes": dict(attributes),
         # BESIDE the values, never inside them. `attributes` above has one
@@ -1544,6 +1566,287 @@ def _appliance_block(
         "future_capabilities": future,
     }
     return _redact(block)
+
+
+# The bound on the ONE cloud-controlled string this section prints. The vocabulary
+# behind it is closed: the engine decides connectivity by comparing `category`
+# against the single literal "DISCONNECTED" (client/engine/appliance.py,
+# load_attributes), and every live dump captured so far carries either that word or
+# "CONNECTED". Forty characters is therefore already several times more than a real
+# value needs, and no truncation flag is warranted here -- a `category` long enough
+# to be cut is not a category, it is a payload, and the cap exists to stop it from
+# becoming one rather than to summarise it. Placed immediately above its single
+# consumer for the same reason `_STAMP_MAX_CHARS` is, and not in the bounds block
+# near the top of the module.
+_CONN_CATEGORY_MAX_CHARS = 40
+
+
+def _freshness(
+    appliance,
+    attributes: Mapping,
+    newest_stamp: datetime | None,
+    now: datetime,
+) -> dict:
+    """How OLD everything below this key is, stated before the values arrive.
+
+    The misreading this section exists to prevent is the expensive one: a reporter
+    downloads a dump, the maintainer reads `machMode`, `tempZ3` and a wash program
+    out of it as the appliance's CURRENT state, and neither of them notices for two
+    round trips that the cloud stopped updating that shadow days ago and every value
+    in the file is a fossil. `generated_at` at the top of the document says when the
+    dump was taken; this says how far behind the dump the DEVICE was.
+
+    Be exact about what it is not. `available` is ALREADY a top-level scalar under
+    `attributes` today -- the live 2026-06-22 capture carries it as `false` on the
+    fridge, the tumble dryer and the washer, next to a `lastConnEvent.category` of
+    "DISCONNECTED" -- so nothing here is a new FACT about the appliance. What the
+    section buys is PROMINENCE (three lines above the values instead of two keys
+    lost among sixty in cloud-chosen order) and an AGE, which is the part no
+    existing key carries: `lastConnEvent` prints an instant, and turning an instant
+    into "six minutes" or "eleven days" needs a second instant that this document
+    did not contain at all until `generated_at` landed.
+
+    THREE FIELDS WERE DESIGNED FOR THIS BLOCK AND ARE DELIBERATELY ABSENT.
+    `decided_by`, `realtime` and `realtime_ttl_s` must not come back without an
+    engine change, for three independent reasons, each of which makes them print a
+    claim this same dump disproves a line later:
+      * the engine keys connectivity on `"category" in lce` and then on
+        `lce["category"] != "DISCONNECTED"`, so a category that is PRESENT and null
+        makes it declare the appliance CONNECTED, while any mirror written from the
+        same values reads a null as "unknown". The block would contradict the
+        connectivity it printed one line above, on precisely the malformed payload
+        it was added to explain.
+      * `mark_realtime_disconnected` sets connection False and CLEARS both realtime
+        marks, while leaving the cached `lastConnEvent` at its last REST value. The
+        block would then print `connected: false` beside a "CONNECTED" category and
+        two empty realtime marks: every printed input saying online, the engine
+        saying offline, and the evidence that reconciles them already erased from
+        the object. "Derived only from the values printed above it, so a reader can
+        check it by hand" is false exactly there, and no amount of patching makes it
+        true from inside this module.
+      * whether an MQTT delta advances a parameter's `lastUpdate` is genuinely
+        unresolved, so "the shadow has not moved, therefore nothing under
+        `attributes` is live" is an inference this code is not entitled to draw.
+    A field that is right most of the time and confidently wrong on the one failure
+    it was built for is worse than no field at all.
+
+    `poll` is absent for a plainer reason: there is no honest source for it here.
+    Every input reachable from this function was checked. The coordinator entry
+    (`hon_client._build_appliance_entry`) carries appliance, type, name, model,
+    serial, mac, attributes, statistics and settings, and no fetch instant. The
+    coordinator itself is not passed to `_appliance_block` and must not be, since
+    nothing here may grow a fifth parameter. And the only poll-ish datetime the
+    engine holds, `HonAppliance._last_update`, is disqualified three times over: it
+    is private; it is `datetime.now()`, hence NAIVE and in the HOST's zone, so read
+    as UTC it prints a NEGATIVE age for every reporter east of Greenwich and read as
+    local it needs a third naive policy that `_as_utc` deliberately refuses to have;
+    and it only advances on the HTTP path, so on a realtime MQTT snapshot it would
+    report the freshest data in the whole dump as the stalest. An `age_s` nobody can
+    trust is the mistake above in a smaller font. If a fetch instant is wanted here,
+    the honest fix is for the coordinator to record one and for
+    `_build_appliance_entry` to carry it; until then the key stays out rather than
+    being sourced from the nearest datetime that happens to be in scope.
+
+    `newest_stamp` is handed in, not recomputed: see the comment at the call site.
+    `now` arrives already normalised to an aware UTC instant by `_appliance_block`,
+    so every subtraction below is aware-against-aware and cannot raise the
+    `TypeError` that would take the entire dump down -- this function is reached
+    with no try/except around it from either entry point.
+
+    A section that could not be established is ABSENT, never present-and-null.
+    `last_conn_event` missing means the appliance carries no such envelope at all;
+    `last_conn_event` present with a null `category` means it carries one and the
+    field inside it was not USABLE text -- not a string at all, or the empty
+    string, which `_bounded_text` refuses along with every other empty scalar. Note
+    what that second case costs, because it is the same ambiguity that sank
+    `decided_by`: the engine compares `lce.get("category", "") != "DISCONNECTED"`
+    and therefore reads an EMPTY category as CONNECTED, so on that one payload this
+    row prints a null where the engine saw a decision. It is reported as null anyway
+    rather than as "", because a bare empty string in a dump reads as a rendering
+    bug and the finding a reader needs is already carried by `connected` on the line
+    above. Folding the two shapes together altogether would report "this device has
+    never reported a connection event" and "this payload is malformed" as the same
+    finding, which is the None-versus-[] collapse `_registry_entries` documents a
+    few functions below.
+    """
+    # A raising property is not hypothetical here: `connection` IS a property on
+    # HonAppliance, and a foreign or half-constructed appliance object is exactly
+    # what this dump is most often built from when something has gone wrong.
+    try:
+        connected = getattr(appliance, "connection", None)
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug(
+            "Diagnostics debug: appliance connection unreadable", exc_info=True
+        )
+        connected = None
+    # One try around BOTH attribute reads, for the same reason `_conn_event_row`
+    # guards its own: `attributes` arrives as whatever the coordinator entry
+    # carried, and a Mapping whose `.get` raises would abort the ENTIRE dump from
+    # inside a section that is only ever a convenience. There is nothing upstream
+    # to have failed first on every appliance: `_coverage` reaches `.get` only
+    # while it still has unmapped bare keys left to classify, and
+    # `_future_capabilities` only for the air purifier.
+    try:
+        available = attributes.get("available")
+        event = attributes.get("lastConnEvent")
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: attributes unreadable", exc_info=True)
+        available = event = None
+    # Both are booleans or they are nothing. The engine writes real `bool`s into
+    # both surfaces, so a string "true" or a 1 arriving here means something
+    # upstream is no longer what this section thinks it is, and printing it anyway
+    # would launder that into a fact the reader cannot question.
+    section: dict = {
+        "connected": connected if isinstance(connected, bool) else None,
+        "available": available if isinstance(available, bool) else None,
+    }
+
+    if isinstance(event, Mapping):
+        section["last_conn_event"] = _conn_event_row(event, now)
+
+    # Normalised here even though the only supported producer of `newest_stamp`
+    # already returns an aware UTC datetime. `_conn_event_row` decides awareness
+    # for its own instant rather than trusting another module to keep a promise it
+    # could quietly stop keeping, and this half must do the same: a naive value
+    # reaching `_stamp_text` alone would print an `at` with no offset next to a
+    # null `age_s`, which is exactly the "an age with no `at`, an `at` with no age"
+    # shape this section refuses everywhere else. `_stamp_text` still refuses
+    # anything that is not a datetime, so junk simply produces no shadow.
+    moment = _as_utc(newest_stamp, True)
+    text = _stamp_text(moment)
+    if text is not None:
+        section["shadow"] = {"at": text, "age_s": _age_seconds(moment, now)}
+    return section
+
+
+def _conn_event_row(event: Mapping, now: datetime) -> dict:
+    """What the CLOUD last said about this appliance's link, and how long ago.
+
+    `category` is type-guarded as `str` before anything else touches it, and that
+    guard carries the whole privacy weight of this section. The live capture shows
+    the envelope as `{macAddress, category, instantTime, timestampEvent}`: applying
+    `str(...)` or `_scalar_text(...)` to the ENVELOPE instead of to the field
+    flattens the entire dict into one string filed under the key `category`, and
+    `_redact` matches by exact key NAME, so the `macAddress` sitting inside that
+    string is permanently out of its reach. The value that survives the guard then
+    goes through `_bounded_text`, which masks before it cuts, so an address
+    straddling the cap cannot leave a readable fragment behind either. Be honest
+    about what the cap is and is not: it is a SIZE bound. `_MAC_RE` is the only
+    value-shaped mask in the dump, so up to forty characters of arbitrary cloud
+    text would still reach the reader here; what makes the field safe is the closed
+    CONNECTED/DISCONNECTED vocabulary behind it, and a firmware that started
+    putting free text in this slot would need this decision revisited, not just
+    this number.
+
+    The instant is read from `timestampEvent` FIRST and only then from
+    `instantTime`, which is not a coin toss: it is the same order, on the same two
+    keys, that `HonAppliance.load_attributes` uses when it decides whether a REST
+    disconnect is newer than the last realtime traffic. Printing the instant the
+    ENGINE ordered on is the point -- a dump that quietly preferred the other key
+    would, on a payload where the two disagree, explain a decision the engine did
+    not make. `timestampEvent` is epoch milliseconds, so its rendering can carry a
+    sub-second tail; that is the real precision of the field and it is not rounded
+    away.
+
+    Neither raw value is ever echoed. `instantTime` is a cloud-chosen STRING, and
+    the only way it reaches the dump is by being parsed into a datetime and then
+    re-rendered by `_stamp_text` from that datetime's own fields, so a `category`-
+    shaped payload smuggled into an instant slot yields no `at` key at all rather
+    than a verbatim copy.
+
+    `at` and `age_s` appear together or not at all. An `at` with no age would make
+    the reader do the arithmetic this section exists to have already done, and an
+    age with no `at` would be a number with nothing to check it against.
+    """
+    # Read in TWO guards rather than one, so that a `.get` which raises on the
+    # instant keys does not throw away a category this function has already read.
+    # `event` is a cloud-supplied Mapping and a foreign implementation of `.get`
+    # is free to raise, which from here would abort the entire dump.
+    try:
+        category = event.get("category")
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: lastConnEvent unreadable", exc_info=True)
+        category = None
+    row: dict = {
+        "category": (
+            _bounded_text(category, _CONN_CATEGORY_MAX_CHARS)
+            if isinstance(category, str)
+            else None
+        )
+    }
+    try:
+        candidates = (event.get("timestampEvent"), event.get("instantTime"))
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug(
+            "Diagnostics debug: lastConnEvent instant unreadable", exc_info=True
+        )
+        return row
+    for raw in candidates:
+        # `assume_naive_utc=True` mirrors the parser's own documented assumption
+        # ("the cloud stamps UTC, hence the trailing Z"). It is belt and braces
+        # today, since `parse_cloud_timestamp` already returns aware UTC; it is here
+        # so this section keeps deciding awareness for itself instead of trusting
+        # another module to keep a promise it could quietly stop keeping.
+        moment = _as_utc(_parse_cloud_moment(raw), True)
+        text = _stamp_text(moment)
+        if text is not None:
+            row["at"] = text
+            row["age_s"] = _age_seconds(moment, now)
+            break
+    return row
+
+
+def _parse_cloud_moment(value) -> datetime | None:
+    """A cloud-stamped instant (epoch milliseconds OR ISO text) as a datetime.
+
+    Delegates to the client's `parse_cloud_timestamp` rather than reimplementing
+    it, and the reason is correctness rather than economy: that function is what
+    the engine itself orders `lastConnEvent` with, it is already total (it returns
+    None for None, for a bool, for garbage, for an arbitrary-precision int that
+    overflows `float()`, and for an out-of-range epoch), and it handles the two
+    cloud spellings this dump meets -- a trailing "Z" that Python 3.10's
+    `fromisoformat` rejects, and a VARIABLE number of fractional digits. A local
+    reimplementation would have to rediscover all of that, and would then be free
+    to drift away from the engine it is supposed to be reporting on.
+
+    The import is function-local, mirroring `_mapped_sets` and `_registry_entries`:
+    diagnostics.py keeps a tiny top-level import surface so it cannot be caught in
+    an import cycle, and this parser is only ever needed while a dump is being
+    built. It costs one `sys.modules` lookup per call after the first, and it is
+    called at most twice per appliance.
+    """
+    try:
+        from .client.helpers import parse_cloud_timestamp
+
+        return parse_cloud_timestamp(value)
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: cloud timestamp unreadable", exc_info=True)
+        return None
+
+
+def _age_seconds(moment, now: datetime) -> int | None:
+    """Whole seconds from `moment` to `now`. NEGATIVE when `moment` is ahead.
+
+    The negative is deliberate and must not be clamped to zero. Both instants a
+    reader sees here are stamped by the CLOUD while `now` is stamped by the
+    reporter's host, so a negative age is not nonsense: it is the dump saying the
+    two clocks disagree, which is itself a finding, and one that explains
+    connectivity decisions the engine makes by ordering those very timestamps
+    against each other. Clamping would erase the evidence and leave behind a
+    plausible-looking `0` that reads as "just now".
+
+    Truncated toward zero rather than rounded, so the number never claims a second
+    that has not fully elapsed. `moment` is deliberately UNANNOTATED: both callers
+    hand it an aware UTC datetime, but the try/except exists precisely for the
+    thing that is not one -- a foreign datetime subclass with an opinion about
+    subtraction, which would otherwise take down the whole dump from inside a
+    field that is only ever a convenience.
+    """
+    try:
+        return int((now - moment).total_seconds())
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: age not computable", exc_info=True)
+        return None
 
 
 def _entity_section(entities: Mapping | None, app_type, mapped=None) -> dict | None:

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.12.0"
+  "version": "5.13.0"
 }

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Local guard: refuse a commit whose message credits an AI assistant.
+#
+# Catches the trailer BEFORE the object exists, which is the whole point --
+# once a commit is written the only cures are amend (if it is still the tip) or
+# a history rewrite, and unreachable copies survive in the reflog for 90 days
+# regardless. Five such commits already exist in this repository's reflog; the
+# rule was written down in docs/ and relied on the committer remembering it.
+#
+# INSTALL (once per clone):
+#     git config core.hooksPath scripts/hooks
+#
+# `core.hooksPath` rather than a copy into .git/hooks so the hook is versioned
+# and every clone gets fixes to it. .git/hooks is untracked, so a copy there
+# would silently rot.
+#
+# Bypassable with `git commit --no-verify`, like every client-side hook. That is
+# why the same check also runs in CI, where it cannot be skipped.
+
+set -eu
+
+exec "$(git rev-parse --show-toplevel)/scripts/no-assistant-trailer.sh" < "$1"

--- a/scripts/no-assistant-trailer.sh
+++ b/scripts/no-assistant-trailer.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Reject AI-assistant authorship trailers in commit messages.
+#
+# Reads one or more commit messages on stdin and exits non-zero if any of them
+# carries a trailer crediting an assistant. Shared by the local `commit-msg`
+# hook (scripts/hooks/commit-msg) and by CI (.github/workflows/ci.yml) so the
+# two can never disagree about what is forbidden.
+#
+# WHY ANCHORED AT LINE START: the pattern matches only a line that BEGINS with
+# the trailer key, never the words appearing inside prose. This repository's own
+# docs quote the rule verbatim ("No `Co-Authored-By: Claude` trailer" in
+# docs/superpowers/plans/), and a substring match would flag the document that
+# states the prohibition as a violation of it. A trailer is a line; match a line.
+#
+# The list is deliberately short and literal rather than a clever catch-all: a
+# guard that is easy to read is a guard a contributor can trust. Add a case here
+# when a new tool starts signing commits.
+
+set -eu
+
+messages=$(cat)
+
+# 1. `Co-Authored-By:` naming an assistant or its noreply address.
+# 2. The `Generated with [Claude Code]` line some tools append to PR bodies and
+#    commit messages.
+# 3. A bare `Author:`/`Co-Authored-By:` pointing at anthropic.com.
+if printf '%s\n' "$messages" | grep -qiE \
+    '^[[:space:]]*(co-)?authored-by:[[:space:]]*.*(claude|anthropic)|^[[:space:]]*(co-)?authored-by:.*@anthropic\.com|^[[:space:]]*.?.?[[:space:]]*Generated with \[Claude Code\]'
+then
+    cat >&2 <<'EOF'
+Commit rejected: AI-assistant authorship trailer.
+
+This repository does not credit assistants in commit metadata. Remove the
+offending line and commit again. The offending lines were:
+
+EOF
+    printf '%s\n' "$messages" | grep -inE \
+        '^[[:space:]]*(co-)?authored-by:[[:space:]]*.*(claude|anthropic)|^[[:space:]]*(co-)?authored-by:.*@anthropic\.com|^[[:space:]]*.?.?[[:space:]]*Generated with \[Claude Code\]' >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/test_commit_trailer_guard.py
+++ b/tests/test_commit_trailer_guard.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The guard that keeps AI-assistant authorship out of commit metadata.
+
+`scripts/no-assistant-trailer.sh` is shared by the local `commit-msg` hook and
+by the CI job, so a silent regression in it disarms BOTH halves at once with a
+green suite. These tests are what makes that impossible.
+
+Two failure directions matter and they are not symmetric:
+
+  * a MISS lets the trailer through, and the cure is a history rewrite plus 90
+    days of reflog copies nobody can reach;
+  * a FALSE POSITIVE blocks an honest commit, and the most likely victim is a
+    commit that quotes the rule. This repository already contains prose that
+    does exactly that (`docs/superpowers/plans/2026-07-14-...md` states "No
+    `Co-Authored-By: Claude` trailer"), and a substring match would flag the
+    document defining the prohibition as a violation of it. Hence the matcher
+    anchors at line start, and `test_prose_quoting_the_rule_is_not_a_trailer`
+    pins that decision against a future "simplification".
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GUARD = REPO / "scripts" / "no-assistant-trailer.sh"
+HOOK = REPO / "scripts" / "hooks" / "commit-msg"
+
+
+def _check(message: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["sh", str(GUARD)],
+        input=message,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class GuardRejectsTest(unittest.TestCase):
+    """Messages that must NOT be committable."""
+
+    def test_the_exact_trailer_this_repo_has_seen(self) -> None:
+        # Verbatim from the five unreachable commits found in the reflog.
+        result = _check(
+            "fix: something\n\n"
+            "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n"
+        )
+        self.assertEqual(1, result.returncode)
+        self.assertIn("Co-Authored-By", result.stderr)
+
+    def test_lowercase_spelling(self) -> None:
+        self.assertEqual(
+            1, _check("fix: x\n\nco-authored-by: claude <a@b.c>\n").returncode
+        )
+
+    def test_authored_by_without_the_co(self) -> None:
+        self.assertEqual(
+            1, _check("fix: x\n\nAuthored-by: Claude <a@b.c>\n").returncode
+        )
+
+    def test_the_anthropic_address_under_any_name(self) -> None:
+        # The name can be anything; the address is the tell.
+        self.assertEqual(
+            1,
+            _check("fix: x\n\nCo-Authored-By: Somebody <bot@anthropic.com>\n").returncode,
+        )
+
+    def test_the_generated_with_line(self) -> None:
+        self.assertEqual(
+            1,
+            _check("fix: x\n\n\U0001F916 Generated with [Claude Code](https://x)\n").returncode,
+        )
+
+    def test_leading_whitespace_does_not_hide_it(self) -> None:
+        self.assertEqual(
+            1, _check("fix: x\n\n   Co-Authored-By: Claude <a@b.c>\n").returncode
+        )
+
+    def test_the_offending_line_is_reported_back(self) -> None:
+        # A guard that says "rejected" without saying WHICH line sends the
+        # committer hunting through a long message.
+        result = _check(
+            "feat: a long message\n\nline two\nline three\n"
+            "Co-Authored-By: Claude <a@b.c>\n"
+        )
+        self.assertIn("Claude", result.stderr)
+        self.assertIn("5:", result.stderr)  # line number, not just the text
+
+
+class GuardAcceptsTest(unittest.TestCase):
+    """Messages that MUST stay committable."""
+
+    def test_an_ordinary_message(self) -> None:
+        result = _check("feat(diagnostics): date the dump\n\nBody paragraph.\n")
+        self.assertEqual(0, result.returncode)
+
+    def test_a_human_co_author(self) -> None:
+        # The trailer itself is legitimate; only assistant credit is not.
+        self.assertEqual(
+            0,
+            _check("fix: x\n\nCo-authored-by: telard-pixel <telard@gmail.com>\n").returncode,
+        )
+
+    def test_the_github_actions_bot(self) -> None:
+        self.assertEqual(
+            0,
+            _check(
+                "Release v5.12.0\n\nCo-authored-by: github-actions[bot] "
+                "<41898282+github-actions[bot]@users.noreply.github.com>\n"
+            ).returncode,
+        )
+
+    def test_prose_quoting_the_rule_is_not_a_trailer(self) -> None:
+        # The regression this repository is most likely to hit: a commit whose
+        # body explains the prohibition. Anchoring at line start is the whole
+        # defence -- a substring match fails here.
+        self.assertEqual(
+            0,
+            _check(
+                "docs: write down the commit conventions\n\n"
+                "Conventional-commit messages. No `Co-Authored-By: Claude` trailer.\n"
+            ).returncode,
+        )
+
+    def test_a_body_mentioning_the_assistant_in_passing(self) -> None:
+        self.assertEqual(
+            0,
+            _check("chore: update CLAUDE.md with the anthropic model ids\n").returncode,
+        )
+
+
+class GuardWiringTest(unittest.TestCase):
+    """The two consumers really point at this script."""
+
+    def test_both_files_are_executable(self) -> None:
+        for path in (GUARD, HOOK):
+            self.assertTrue(path.exists(), f"{path} missing")
+            self.assertTrue(path.stat().st_mode & 0o111, f"{path} not executable")
+
+    def test_the_hook_delegates_to_the_shared_matcher(self) -> None:
+        # If the hook ever grows its own copy of the pattern, the two halves of
+        # the guard can drift and only one of them will be tested here.
+        self.assertIn("no-assistant-trailer.sh", HOOK.read_text(encoding="utf-8"))
+
+    def test_ci_runs_the_shared_matcher(self) -> None:
+        workflow = (REPO / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("no-assistant-trailer.sh", workflow)
+        # Full history, or `base..head` has no ends to walk.
+        self.assertIn("fetch-depth: 0", workflow)
+
+    def test_ci_passes_the_shas_through_env_not_interpolation(self) -> None:
+        # Workflow-injection hygiene: a `${{ }}` expansion inside `run:` is
+        # substituted into the shell source before it executes.
+        workflow = (REPO / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn('git log --format=\'%B\' "$BASE..$HEAD"', workflow)
+
+
+class GuardAgainstHistoryTest(unittest.TestCase):
+    """Run the matcher over the real history it exists to police."""
+
+    def _messages(self, ref: str) -> list[str]:
+        result = subprocess.run(
+            ["git", "log", "--format=%H", ref],
+            cwd=REPO, capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            self.skipTest(f"git unavailable or {ref} missing")
+        out = []
+        for sha in result.stdout.split():
+            body = subprocess.run(
+                ["git", "log", "-1", "--format=%B", sha],
+                cwd=REPO, capture_output=True, text=True, check=False,
+            )
+            out.append(body.stdout)
+        return out
+
+    def test_the_shipped_history_is_clean(self) -> None:
+        # Doubles as the answer to "is the published history already tainted".
+        offenders = [m for m in self._messages("HEAD") if _check(m).returncode != 0]
+        self.assertEqual([], offenders, f"{len(offenders)} commits carry the trailer")
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -253,7 +253,7 @@ class IdentityKeysBehaviouralTest(unittest.TestCase):
     a canary credential appear in the output -- not syncing a bookkeeping literal.
     """
 
-    _SECRET = "CANARY-CREDENTIAL-VALUE"
+    _CANARY_VALUE = "CANARY-CREDENTIAL-VALUE"
 
     # NAMED on purpose, NOT `for key in _IDENTITY_KEYS`. A loop over the constant
     # proves every SURVIVING member still works but goes quiet the moment a member is
@@ -274,14 +274,20 @@ class IdentityKeysBehaviouralTest(unittest.TestCase):
             # match is documented as case-insensitive, so the spelling must not matter.
             for spelling in (key, key.upper(), key.title()):
                 with self.subTest(key=spelling):
-                    flat = debug_utils.redact_identity({spelling: self._SECRET})
+                    flat = debug_utils.redact_identity({spelling: self._CANARY_VALUE})
                     self.assertEqual("***", flat[spelling])
                     # ...and at the depth the sinks actually log: api.py:92 passes the
                     # whole appliance-list body, mqtt.py:515 the whole broker payload.
                     nested = debug_utils.redact_identity(
-                        {"payload": [{"attributes": {spelling: self._SECRET}}]}
+                        {"payload": [{"attributes": {spelling: self._CANARY_VALUE}}]}
                     )
-                    self.assertNotIn(self._SECRET, repr(nested))
+                    # The VALUE, not the absence of the canary: `assertNotIn` on
+                    # the repr would also pass if the redactor deleted the field
+                    # instead of masking it, and a dropped key is a different
+                    # bug that this test would then certify as the fix.
+                    self.assertEqual(
+                        "***", nested["payload"][0]["attributes"][spelling]
+                    )
 
     def test_every_identity_key_has_a_behavioural_assertion(self) -> None:
         # The replacement for the old pin. This is still a set equality, but the

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -232,24 +232,69 @@ class RedactTopicTest(unittest.TestCase):
         self.assertIn("redact_topic", debug_utils.__all__)
 
 
-class IdentityKeysPinTest(unittest.TestCase):
-    """Pin the EXACT _IDENTITY_KEYS set: iterating the set in a test would silently
-    stop checking a removed key, so dropping one (e.g. the snake-case transaction_id
-    not covered by the diagnostics drift-guard) must fail here."""
+class IdentityKeysBehaviouralTest(unittest.TestCase):
+    """Every name in _IDENTITY_KEYS must actually MASK A VALUE on the log path.
 
-    _EXPECTED = frozenset(
-        {
-            "serial", "serialnumber", "serial_number",
-            "mac", "macaddress", "mac_address",
-            "code", "nickname", "nick_name", "email",
-            "password", "token", "access_token", "refresh_token",
-            "authorization", "secret",
-            "transactionid", "transaction_id", "mobileid", "mobile_id",
-        }
+    This replaces a set-equality pin that compared _IDENTITY_KEYS to a hand-copied
+    `_EXPECTED` frozenset. That pin held the CONSTANT, not the guarantee, and it was
+    measured to be worth nothing against either realistic regression:
+
+      * Narrow only the MATCHING (leave both constants byte-identical, stop nine names
+        from being looked up) and the pin PASSES -- measured, whole suite green at
+        rc=0 with authorization/nickname/refresh_token and six more emitting cleartext.
+      * Delete a name from the constant AND from the transcription -- which is exactly
+        what the pin's own failure message instructs a developer to do -- and the pin
+        is neutralised by construction. Nine such edits were run; the pin appeared in
+        none of the failure lists, and four of them (mac_address, mobile_id,
+        serial_number, transaction_id) left the WHOLE suite green.
+
+    So the assertions below drive redact_identity itself. Making a retired key green
+    again now requires DELETING a line that says that key must be masked, and watching
+    a canary credential appear in the output -- not syncing a bookkeeping literal.
+    """
+
+    _SECRET = "CANARY-CREDENTIAL-VALUE"
+
+    # NAMED on purpose, NOT `for key in _IDENTITY_KEYS`. A loop over the constant
+    # proves every SURVIVING member still works but goes quiet the moment a member is
+    # removed -- its iteration simply stops visiting the retired key. Measured: with a
+    # derived loop in place, dropping mac_address from the constant still ran green.
+    _MUST_MASK = (
+        "serial", "serialnumber", "serial_number",
+        "mac", "macaddress", "mac_address",
+        "code", "nickname", "nick_name", "email",
+        "password", "token", "access_token", "refresh_token",
+        "authorization", "secret",
+        "transactionid", "transaction_id", "mobileid", "mobile_id",
     )
 
-    def test_identity_keys_exact(self) -> None:
-        self.assertEqual(set(debug_utils._IDENTITY_KEYS), set(self._EXPECTED))
+    def test_named_identity_keys_mask_their_value_on_the_log_path(self) -> None:
+        for key in self._MUST_MASK:
+            # Case variants: the cloud sends camelCase (nickName, macAddress) and the
+            # match is documented as case-insensitive, so the spelling must not matter.
+            for spelling in (key, key.upper(), key.title()):
+                with self.subTest(key=spelling):
+                    flat = debug_utils.redact_identity({spelling: self._SECRET})
+                    self.assertEqual("***", flat[spelling])
+                    # ...and at the depth the sinks actually log: api.py:92 passes the
+                    # whole appliance-list body, mqtt.py:515 the whole broker payload.
+                    nested = debug_utils.redact_identity(
+                        {"payload": [{"attributes": {spelling: self._SECRET}}]}
+                    )
+                    self.assertNotIn(self._SECRET, repr(nested))
+
+    def test_every_identity_key_has_a_behavioural_assertion(self) -> None:
+        # The replacement for the old pin. This is still a set equality, but the
+        # right-hand side is no longer a copy kept only for comparison: _MUST_MASK is
+        # the list that DRIVES the redactor above. So this asserts a real property --
+        # "every member of the constant is behaviourally covered" -- and a key ADDED to
+        # _IDENTITY_KEYS fails here until it is given a real assertion.
+        self.assertEqual(set(self._MUST_MASK), set(debug_utils._IDENTITY_KEYS))
+
+    def test_non_identity_key_value_survives(self) -> None:
+        # Positive control: the assertions above are not passing vacuously because
+        # redact_identity masks everything it is handed.
+        self.assertEqual({"label": "ok"}, debug_utils.redact_identity({"label": "ok"}))
 
 
 redact_store = debug_utils.redact_store

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -755,20 +755,28 @@ class DiagnosticsDeviceTest(unittest.TestCase):
         self.assertEqual({"generated_at": FROZEN_TEXT}, result)
 
 
-class DiagnosticsDriftGuardTest(unittest.TestCase):
-    def test_custom_mapped_attrs_pinned(self):
-        # Adding a custom entity class that consumes a new bare attribute must come
-        # with an update here, otherwise the attribute would be reported as unmapped.
-        self.assertEqual(
-            diagnostics._CUSTOM_MAPPED_ATTRS,
-            {
-                "WM": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
-                "WD": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
-                "TD": frozenset({"machMode"}),
-                "AC": frozenset({"tempIndoor"}),
-            },
-        )
+# The bare attributes CUSTOM entity classes consume. They have no description
+# table, so no walk can derive them: `HonMeanWaterConsumption` needs both
+# `totalWaterUsed` and `totalWashCycle`, `HonWashingMachinePauseSwitch` reads
+# `machMode`, `HaierClimateEntity` reads `tempIndoor`.
+#
+# This used to be a constant in diagnostics.py seeded into `mapped_attrs`, plus a
+# literal-vs-literal test pinning it. Both are gone: measured on every type it
+# covered, the registry walk already supplies all eight names, so the seed
+# corrected nothing and the pin fired only when someone edited the constant --
+# exactly when they had already remembered it. What remains is the GUARANTEE,
+# checked below against behaviour: if a description table is ever narrowed so one
+# of these stops being derivable, the dump would start calling it unmapped, and
+# this list is what makes that fail loudly instead of being silently patched.
+_CUSTOM_ENTITY_ATTRS: dict[str, frozenset[str]] = {
+    "WM": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+    "WD": frozenset({"totalWashCycle", "totalWaterUsed", "machMode"}),
+    "TD": frozenset({"machMode"}),
+    "AC": frozenset({"tempIndoor"}),
+}
 
+
+class DiagnosticsDriftGuardTest(unittest.TestCase):
     def test_custom_mapped_attrs_are_not_reported_unmapped(self):
         """The behavioural half of the pin above: the EFFECT the comment there claims,
         stated independently of which mechanism delivers it.
@@ -783,7 +791,7 @@ class DiagnosticsDriftGuardTest(unittest.TestCase):
         pins the guarantee it exists to provide, and so keeps holding whether the net
         is load-bearing or redundant.
         """
-        for app_type, attrs in diagnostics._CUSTOM_MAPPED_ATTRS.items():
+        for app_type, attrs in _CUSTOM_ENTITY_ATTRS.items():
             cov = diagnostics._coverage(
                 app_type,
                 {attr: "1" for attr in attrs},
@@ -827,6 +835,30 @@ class DiagnosticsDriftGuardTest(unittest.TestCase):
 
 
 class DiagnosticsCoverageMetaTest(unittest.TestCase):
+    def test_a_container_valued_statistics_key_goes_to_statistics_not_meta(self):
+        """Order matters between the two carve-outs, and only a container proves it.
+
+        `_coverage` partitions unmapped keys statistics-first, then meta (a Mapping
+        or list value, or a denylisted name), then signal. A key that is BOTH a
+        statistics key and container-valued satisfies both rules, so which list it
+        lands in is decided purely by which carve-out runs first -- and nothing
+        asserted that until now. It is not hypothetical: the live fridge publishes
+        `mostUsedPrograms` as an empty list AND as a statistics key
+        (diagnostics/live-2026-06-22/device-REF.json), so on real hardware this is
+        the only shape that exercises the precedence.
+        """
+        cov = diagnostics._coverage(
+            "REF",
+            {"mostUsedPrograms": [], "someBlob": {"a": 1}},
+            {"mostUsedPrograms": []},
+            FakeAppliance(commands={}),
+        )
+        self.assertIn("mostUsedPrograms", cov["attributes_unmapped_statistics"])
+        # ... and NOT double-counted into the meta list, which the sibling
+        # container lands in to prove the meta rule is live in the same call.
+        self.assertNotIn("mostUsedPrograms", cov["attributes_unmapped_meta"])
+        self.assertIn("someBlob", cov["attributes_unmapped_meta"])
+
     """Coverage noise partition: value-type envelope + scalar denylist + program slots
     move to *_meta; genuine signal stays in *_unmapped; nothing is dropped."""
 
@@ -1520,6 +1552,26 @@ AP_ROWS = (
 
 
 class EntityInventoryTest(unittest.TestCase):
+    def test_a_registry_flag_is_read_through_its_enum_value(self):
+        """`_enum_text` unwraps `.value` before stringifying, and nothing pinned it.
+
+        Redundant on current Home Assistant, whose `RegistryEntryDisabler` is a
+        `StrEnum` -- `str()` already yields the token. It stops being redundant the
+        moment the flag is a plain Enum or a mixin enum, which is what the helper
+        was written for: `str()` on those yields `ClassName.MEMBER`, and the dump
+        would report a disabled entity as disabled by `RegistryEntryDisabler.USER`.
+        Every fixture in this file passes a bare string, so the unwrap could be
+        deleted with the suite green. This is the test that stops that.
+        """
+        import enum
+
+        class _PlainDisabler(enum.Enum):
+            USER = "user"
+
+        self.assertEqual("user", diagnostics._enum_text(_PlainDisabler.USER))
+        self.assertEqual("user", diagnostics._enum_text("user"))
+        self.assertIsNone(diagnostics._enum_text(None))
+
     def tearDown(self) -> None:
         _restore_registry()
 
@@ -2784,7 +2836,7 @@ def _static_parameter_names() -> set[str]:
     # the harvest in place, planting an identity-shaped literal into a custom row
     # left the whole suite green.
     names |= set(diagnostics._AC_CLIMATE_PARAMS)
-    for mapped in diagnostics._CUSTOM_MAPPED_ATTRS.values():
+    for mapped in _CUSTOM_ENTITY_ATTRS.values():
         names |= set(mapped)
     # `pause` is the single custom-row name no other table in the repository
     # carries (switch.pause writes the `pause` parameter of pauseProgram /
@@ -3287,9 +3339,8 @@ class RegistryDegradationTest(unittest.TestCase):
             attrs, params, index, missing = diagnostics._mapped_sets("REF")
         self.assertIsNone(index)
         self.assertEqual(list(_PLATFORM_MODULES), missing)
-        self.assertEqual(
-            set(diagnostics._CUSTOM_MAPPED_ATTRS.get("REF", ())), attrs
-        )
+        # No seed survives a total collapse: every mapped name comes from a walk.
+        self.assertEqual(set(), attrs)
         self.assertEqual(set(), params)
 
     def test_a_lost_table_gives_its_entities_one_null_each(self) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4122,5 +4122,117 @@ class FreshnessDegradationTest(unittest.TestCase):
         self.assertEqual({"category": "DISCONNECTED"}, row)
 
 
+# --- step 3b (optional): dropping the duplicated `parameters` sub-map --------
+
+
+class AttributeValuesDedupTest(unittest.TestCase):
+    """The nested `parameters` sub-map goes only when it is provably a copy."""
+
+    def test_a_redundant_nested_map_is_dropped(self):
+        shadow = FakeShadowAttribute("4", AC_STAMP_OLD)
+        block = _stamp_block({"tempZ1": shadow, "parameters": {"tempZ1": shadow}})
+        self.assertNotIn("parameters", block["attributes"])
+        self.assertEqual("4", block["attributes"]["tempZ1"])
+        # The one bit the sub-map carried -- which keys are shadow parameters --
+        # is still in the document, now with the instant as well.
+        self.assertEqual(
+            {"tempZ1": "2026-04-09T05:31:02+00:00"},
+            block["attributes_last_update"],
+        )
+
+    def test_coverage_and_the_echo_describe_the_same_mapping(self):
+        # The dedupe runs above EVERY consumer, so `attributes_unmapped_meta`
+        # cannot name a key the `attributes` section no longer prints. On all
+        # four live appliances that key is exactly `parameters`.
+        shadow = FakeShadowAttribute("4", AC_STAMP_OLD)
+        block = _stamp_block({"tempZ1": shadow, "parameters": {"tempZ1": shadow}})
+        self.assertNotIn(
+            "parameters", block["coverage"]["attributes_unmapped_meta"]
+        )
+        for name in block["coverage"]["attributes_unmapped_meta"]:
+            self.assertIn(name, block["attributes"])
+
+    def test_a_nested_map_that_is_the_only_copy_is_kept(self):
+        # The `hon_client.py:192-196` path: `dict(params)` raised, so NOTHING was
+        # flattened and this sub-map holds the only copy of the values. Dropping
+        # it here would delete data, not duplication.
+        block = _stamp_block(
+            {"parameters": {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)}}
+        )
+        self.assertEqual({"tempZ1": "4"}, block["attributes"]["parameters"])
+
+    def test_a_none_valued_nested_row_is_not_mistaken_for_a_flattened_one(self):
+        # `dict.get` answers None for "absent" and for "present and None" alike,
+        # so the lookup uses the module sentinel instead. Nothing here was
+        # flattened: the sub-map is the only copy and both names would otherwise
+        # have vanished from the document entirely.
+        block = _stamp_block({"parameters": {"tempZ1": None, "tempZ3": None}})
+        self.assertIn("parameters", block["attributes"])
+
+    def test_an_empty_nested_map_is_kept(self):
+        # `all([])` is True. "The shadow container was empty" and "there is no
+        # shadow container" are different statements and stay different.
+        block = _stamp_block({"x": 1, "parameters": {}})
+        self.assertEqual({}, block["attributes"]["parameters"])
+
+    def test_a_partially_flattened_map_is_kept_whole(self):
+        # One missing bare key is enough: the section never guesses which half
+        # of a half-merged shadow is the real one.
+        shadow = FakeShadowAttribute("4", AC_STAMP_OLD)
+        other = FakeShadowAttribute("5", AC_STAMP_NEW)
+        block = _stamp_block(
+            {"tempZ1": shadow, "parameters": {"tempZ1": shadow, "tempZ3": other}}
+        )
+        self.assertIn("parameters", block["attributes"])
+
+    def test_a_bare_key_rebound_to_another_object_keeps_the_map(self):
+        # Identity, not equality: a bare key that no longer IS the nested object
+        # means the merge this optimisation relies on did not happen the way it
+        # is documented, so the copy stays. Equality would also mean calling an
+        # `__eq__` this module does not control.
+        block = _stamp_block(
+            {
+                "tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD),
+                "parameters": {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)},
+            }
+        )
+        self.assertIn("parameters", block["attributes"])
+
+    def test_a_non_mapping_parameters_value_is_left_alone(self):
+        block = _stamp_block({"parameters": "not-a-map", "x": 1})
+        self.assertEqual("not-a-map", block["attributes"]["parameters"])
+
+    def test_a_truncated_instant_map_keeps_the_sub_map(self):
+        # The justification for deleting the copy is that
+        # `attributes_last_update` now carries the shadow-parameter set. Once
+        # the row cap has fired it does not carry it for the dropped rows, so
+        # the copy stays and the dump keeps saying which keys were shadow.
+        shadows = {
+            "p%03d" % i: FakeShadowAttribute(str(i), AC_STAMP_OLD)
+            for i in range(250)
+        }
+        attributes = dict(shadows)
+        attributes["parameters"] = shadows
+        block = _stamp_block(attributes)
+        self.assertTrue(block["attributes_last_update_truncated"])
+        self.assertIn("parameters", block["attributes"])
+
+    def test_an_uncomparable_nested_map_is_kept(self):
+        # On the helper rather than on a whole block, and for a reason worth
+        # recording: verified on HEAD, a Mapping whose `__getitem__` raises
+        # already takes the entire dump down at `_redact(block)`, which walks it
+        # with `.items()` and has no guard. This change neither creates that
+        # exposure nor fixes it -- it only guarantees that a sub-map which
+        # cannot be shown redundant is never deleted.
+        nested = _BrokenNested({"a": FakeShadowAttribute("1", AC_STAMP_OLD)}, broken="a")
+        kept = diagnostics._attribute_values({"parameters": nested})
+        self.assertIs(nested, kept["parameters"])
+
+    def test_an_appliance_with_no_nested_map_is_untouched(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(6, blocks["AC"]["coverage"]["attributes_total"])
+        self.assertEqual(22.5, blocks["AC"]["attributes"]["tempIndoor"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3156,20 +3156,68 @@ class AttributeTimestampTest(unittest.TestCase):
         _, blocks = _entry_diag()
         self.assertEqual({}, blocks["WD"]["attributes_last_update"])
 
-    def test_the_rows_are_sorted_across_both_sources(self):
-        # Sorted ONCE at the end and not per source: the nested `parameters` map
-        # is walked second, so a per-source sort would emit a map whose second
-        # half restarts the alphabet.
+    def test_the_rows_follow_the_map_they_are_read_beside(self):
+        # The map is never read alone: "when did tempZ3 last move" is asked with
+        # `attributes` already open at tempZ3. Sorting this one alphabetically
+        # while the sibling keeps the cloud's merge order put the same name at
+        # two unrelated ranks -- a mean 42.4 rows apart on the live WM, worst
+        # case 100, with 66 backward jumps (diagnostics/live-2026-06-22).
         _, blocks = _entry_diag()
-        rows = list(blocks["AC"]["attributes_last_update"])
-        self.assertEqual(sorted(rows), rows)
+        block = blocks["AC"]
+        rows = list(block["attributes_last_update"])
+        self.assertEqual([k for k in block["attributes"] if k in set(rows)], rows)
+        self.assertNotEqual(
+            sorted(rows), rows, "an already-sorted fixture would make this vacuous"
+        )
+
+    def test_a_row_the_sibling_cannot_rank_falls_back_to_sorted(self):
+        # `sorted` is still what orders the rows `attributes` does not enumerate:
+        # the nested-only keys of the degraded merge path. Ordered ONCE and not
+        # per source, so they land together AFTER everything the sibling ranks --
+        # a map whose second half restarts the alphabet reads as a rendering bug,
+        # and so would one that interleaved unrankable names at rank zero.
         mixed, _, _ = diagnostics._attribute_timestamps(
             {
                 "zzz": FakeShadowAttribute("1", AC_STAMP_OLD),
-                "parameters": {"aaa": FakeShadowAttribute("1", AC_STAMP_NEW)},
+                "mmm": FakeShadowAttribute("1", AC_STAMP_OLD),
+                "parameters": {
+                    "bbb": FakeShadowAttribute("1", AC_STAMP_NEW),
+                    "aaa": FakeShadowAttribute("1", AC_STAMP_NEW),
+                },
             }
         )
-        self.assertEqual(["aaa", "zzz"], list(mixed))
+        self.assertEqual(["zzz", "mmm", "aaa", "bbb"], list(mixed))
+
+    def test_a_sibling_that_cannot_be_ranked_costs_the_order_not_the_dump(self):
+        # The `order` build is a SECOND enumeration of `attributes`, and the walk
+        # above has already proved that a mapping which refuses to list its keys
+        # is survivable -- its rows can come entirely from the nested sub-map. An
+        # unguarded enumeration here would turn that survivable input into a dump
+        # that never reaches the reporter.
+        class _Unlistable(dict):
+            def __iter__(self):
+                raise RuntimeError("keys refused")
+
+        source = _Unlistable()
+        old = FakeShadowAttribute("1", AC_STAMP_OLD)
+        new = FakeShadowAttribute("1", AC_STAMP_NEW)
+        # The bare keys too, pointing at the SAME objects. That is the input the
+        # guard is load-bearing on: `_attribute_values` proves the sub-map
+        # redundant over `.items()`, which never calls `__iter__`, and hands
+        # `_coverage` a plain dict, so the block really does reach the reporter.
+        # Without them the fixture is killed by `_coverage`'s own unguarded
+        # enumeration on HEAD too, and would prove the guard exists rather than
+        # that it is worth anything.
+        source["zzz"] = old
+        source["aaa"] = new
+        source["parameters"] = {"zzz": old, "aaa": new}
+        rows, truncated, newest = diagnostics._attribute_timestamps(source)
+        block = _stamp_block(source)
+        self.assertEqual(["aaa", "zzz"], list(block["attributes_last_update"]))
+        # Unranked, so the alphabetical fallback is what is emitted.
+        self.assertEqual(["aaa", "zzz"], list(rows))
+        self.assertFalse(truncated)
+        self.assertEqual(AC_STAMP_NEW, newest)
 
     def test_every_stamp_is_aware_utc_iso_text(self):
         # The shape guard. `read`/`write`-style free text is not in `_TO_REDACT`

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -620,6 +620,16 @@ class DiagnosticsCoverageTest(unittest.TestCase):
         # (tempSel, machMode) and 1 meta (commandHistory, dict-valued) -> 6.
         self.assertEqual(cov["attributes_total"], 6)
         self.assertLessEqual(len(cov["attributes_unmapped"]), cov["attributes_total"])
+        # The AC fixture is built with `statistics: {}`, so the `- len(statistics)`
+        # term in the formula is identically 0 here and dropping it leaves the whole
+        # suite green. WD is the only block carrying a statistics key, and every real
+        # washer, dryer and fridge has them (the live REF has four).
+        wd = blocks["WD"]["coverage"]
+        # WD bare keys: available, weirdNewSensor, serialNumber, programsCounter,
+        # deviceInfo (5); minus 1 statistics (programsCounter) and 1 meta
+        # (deviceInfo, dict-valued) -> 3.
+        self.assertEqual(wd["attributes_total"], 3)
+        self.assertEqual(["programsCounter"], wd["attributes_unmapped_statistics"])
 
 
 class DiagnosticsSerializationTest(unittest.TestCase):
@@ -644,14 +654,42 @@ class DiagnosticsRedactionTest(unittest.TestCase):
             self.assertEqual(block["id"], "***")
             self.assertEqual(block["serial"], "***")
             self.assertEqual(block["mac"], "***")
+        # The fixture MAC is canonical, so `_MAC_RE` alone masks it and the clause
+        # above cannot see the key-name path die. Pin the key-name path on shapes
+        # the six-octet regex CANNOT match -- unseparated, and the placeholder the
+        # engine itself substitutes (tests/fixtures/ref_10136/attributes.json).
+        self.assertEqual("***", diagnostics._redact({"mac": "AABBCCDDEEFF"})["mac"])
+        self.assertEqual(
+            "***", diagnostics._redact({"macAddress": "xx-xx-xx-xx-xx-xx"})["macAddress"]
+        )
 
     def test_identity_keys_redacted_recursively(self):
         _, blocks = _entry_diag()
         self.assertEqual(blocks["AC"]["attributes"]["macAddress"], "***")
+        # As above: isolate the key-name path from `_MAC_RE` so this clause measures
+        # the mapping it is named for rather than the value regex.
+        self.assertEqual(
+            "***", diagnostics._redact({"MacAddress": "AABBCCDDEEFF"})["MacAddress"]
+        )
         self.assertEqual(blocks["WD"]["attributes"]["serialNumber"], "***")
         # nested dict: `code` (serial fallback) redacted, sibling preserved
         self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["code"], "***")
         self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["label"], "ok")
+
+    def test_credential_key_names_are_redacted_anywhere_they_appear(self):
+        """The entry envelope redacts with explicit literals, so the CREDENTIAL half
+        of `_TO_REDACT` is reachable only through this generic path: a credential
+        arriving under one of these names inside an appliance's attributes or a
+        nested cloud payload. Deleting all nine names left the full suite green.
+        """
+        for key in ("password", "token", "access_token", "refresh_token",
+                    "authorization", "secret", "email", "nickname", "nick_name"):
+            self.assertEqual(
+                "***", diagnostics._redact({key: "s3cret"})[key], key
+            )
+            # and one level down, where a cloud payload actually carries them
+            nested = diagnostics._redact({"attributes": {key: "s3cret"}})
+            self.assertEqual("***", nested["attributes"][key], key)
 
     def test_command_history_value_borne_identity_redacted(self):
         _, blocks = _entry_diag()
@@ -705,10 +743,16 @@ class DiagnosticsDeviceTest(unittest.TestCase):
         coord = _build_coordinator()
         hass = FakeHass(coord)
         device = FakeDevice(identifiers={("some_other_domain", WD_ID)})
-        result = _run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device))
-        # A foreign integration's identifier resolves nothing here, and the
-        # degraded dump is still dated (see the test above).
-        self.assertEqual(["generated_at"], list(result))
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+            )
+        # A foreign integration's identifier resolves nothing here, and the degraded
+        # dump is still dated. Exact-dict on the VALUE, not `list(result)`: this is
+        # the only test reaching the FIRST early return (appliance_id is None), so
+        # the stamp there has no other guard -- DumpTimestampTest's two degraded
+        # cases both resolve a DOMAIN identifier and land on the SECOND return.
+        self.assertEqual({"generated_at": FROZEN_TEXT}, result)
 
 
 class DiagnosticsDriftGuardTest(unittest.TestCase):
@@ -724,6 +768,32 @@ class DiagnosticsDriftGuardTest(unittest.TestCase):
                 "AC": frozenset({"tempIndoor"}),
             },
         )
+
+    def test_custom_mapped_attrs_are_not_reported_unmapped(self):
+        """The behavioural half of the pin above: the EFFECT the comment there claims,
+        stated independently of which mechanism delivers it.
+
+        The pin is a literal-vs-literal comparison, so it fires only when someone
+        edits the constant -- exactly when they already remembered it -- and says
+        nothing about whether the constant still does anything. Measured: it does
+        not. Every one of the eight entries is already supplied by the registry walk
+        on all four types, so `_CUSTOM_MAPPED_ATTRS` currently contributes NOTHING
+        and emptying its only consumer (diagnostics.py:631) leaves the whole suite
+        green. It is a safety net for a table change that has not happened; this test
+        pins the guarantee it exists to provide, and so keeps holding whether the net
+        is load-bearing or redundant.
+        """
+        for app_type, attrs in diagnostics._CUSTOM_MAPPED_ATTRS.items():
+            cov = diagnostics._coverage(
+                app_type,
+                {attr: "1" for attr in attrs},
+                {},
+                FakeAppliance(commands={}),
+            )
+            for attr in attrs:
+                self.assertNotIn(
+                    attr, cov["attributes_unmapped"], f"{app_type}.{attr}"
+                )
 
     def test_ac_climate_params_pinned(self):
         self.assertEqual(
@@ -764,6 +834,12 @@ class DiagnosticsCoverageMetaTest(unittest.TestCase):
         app = FakeAppliance(commands={"settings": FakeCommand({
             # genuine writable control (no entity) -> command-param signal
             "humiditySel": FakeParam(value="50", typology="range", rng=(30, 70, 5)),
+            # a MAPPED control (climate owns tempSel): counted into the denominator
+            # but never into the signal. Without one, `total` and `len(signal)`
+            # collapse to the same number and the denominator's mapped half is
+            # unfalsifiable -- redefining it as the signal count alone, so every dump
+            # reads 100% covered, leaves the class green.
+            "tempSel": FakeParam(value="22", typology="range", rng=(16, 30, 1)),
             # command plumbing -> command-param meta
             "category": FakeParam(value="setParameters", typology="enum", values=["setConfig", "setParameters"]),
             "httpEndpoint": FakeParam(value="x", typology="fixed"),
@@ -824,6 +900,22 @@ class DiagnosticsCoverageMetaTest(unittest.TestCase):
         self.assertEqual(signal & meta, set())
         self.assertEqual(signal & stats, set())
         self.assertEqual(meta & stats, set())
+        # LOSSLESS, the half the name promises and the body never checked: every bare
+        # key of the fixture lands in exactly one of the three lists. A key that falls
+        # out of all three is a device capability the maintainer never learns exists,
+        # which is silent and permanent -- whereas a double count is visible noise.
+        # Dropping a row from the meta list without re-homing it leaves the three
+        # disjointness assertions above green.
+        self.assertEqual(
+            {
+                "errors", "programName", "weirdSensor", "programsCounter",
+                "programClass", "commandHistory", "lastConnEvent",
+                "mostUsedPrograms", "debugEnabled", "transMode", "resultCode",
+                "highTransRate", "programStats", "cloudProgId", "forceDelete",
+                "program7", "program19",
+            },
+            signal | meta | stats,
+        )
 
     def test_command_param_meta_split(self):
         cov = self._coverage_ac()
@@ -834,11 +926,16 @@ class DiagnosticsCoverageMetaTest(unittest.TestCase):
 
     def test_command_param_total_excludes_meta(self):
         # Symmetric with attributes_total: denominator = mapped controls + signal, not
-        # inflated by meta params. settings has 4 params (humiditySel + 3 meta), none
-        # mapped -> total 4 - 3 meta = 1, equal to the signal count.
+        # inflated by meta params. settings has 5 params (humiditySel + tempSel + 3
+        # meta) -> total 5 - 3 meta = 2: one mapped control (tempSel) plus one signal
+        # (humiditySel). The two summands are deliberately different numbers so the
+        # denominator cannot be satisfied by the signal count alone.
         cov = self._coverage_ac()
-        self.assertEqual(cov["command_params_total"], 1)
-        self.assertEqual(len(cov["command_params_unmapped"]), cov["command_params_total"])
+        self.assertEqual(cov["command_params_total"], 2)
+        self.assertEqual(["humiditySel"], cov["command_params_unmapped"])
+        self.assertLess(
+            len(cov["command_params_unmapped"]), cov["command_params_total"]
+        )
 
 
 class WcSettingsSwitchCoverageTest(unittest.TestCase):
@@ -960,7 +1057,18 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
         class _Client:
             last_error_code = ec.MFA_REQUIRED
             last_error_phase = "mfa_challenge"
-            last_mfa_summary = {"challenge_kind": "email", "can_resend": True}
+            # A summary carrying MORE than the two published keys, so the assertion
+            # below measures the WHITELIST PROJECTION rather than restating the
+            # fixture. `_last_error` bypasses `_redact` by design, so this projection
+            # is the only filter on the path; MfaContext (client/transport/oauth.py)
+            # holds the JS-Remoting csrf and a signed authorization in exactly these
+            # shapes, and masks them in its own __repr__ to keep them out of LOGS.
+            last_mfa_summary = {
+                "challenge_kind": "email",
+                "can_resend": True,
+                "host": "eu-login.haier.example",
+                "verify": {"csrf": "c-123", "authorization": "signed-blob"},
+            }
             _refresh_token = "rt"
 
         hass = FakeHass(_build_coordinator())
@@ -971,6 +1079,30 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
         self.assertTrue(le["requires_reauth"])
         self.assertTrue(le["had_refresh_token"])
         self.assertEqual({"challenge_kind": "email", "can_resend": True}, le["mfa"])
+        blob = json.dumps(result)
+        for secret in ("csrf", "c-123", "authorization", "signed-blob",
+                       "eu-login.haier.example"):
+            self.assertNotIn(secret, blob, secret)
+
+    def test_last_error_suppresses_a_stale_mfa_summary_outside_the_band(self) -> None:
+        """hon_client's submit/resend except-branches (hon_client.py:748, :775) set a
+        NON-MFA code without clearing `last_mfa_summary` -- the clears at :753-755 are
+        on the success path. The 160-169 band gate is the only thing stopping a 2FA
+        challenge summary from being attached to a network fault, which would send a
+        triager down the 2FA path for a timeout.
+        """
+        from custom_components.addhon import error_codes as ec
+
+        class _Client:
+            last_error_code = ec.NETWORK_TIMEOUT       # 400, outside the band
+            last_error_phase = "mfa_send"
+            last_mfa_summary = {"challenge_kind": "email", "can_resend": True}
+            _refresh_token = ""
+
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"]["client"] = _Client()
+        result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        self.assertNotIn("mfa", result["last_error"])
 
 
 # --- Task 10: air purifier coverage and passive future-capability capture -----
@@ -1104,8 +1236,17 @@ class AirPurifierCoverageTest(unittest.TestCase):
 
         declared = {d.param for d in switch._AIR_PURIFIER_SWITCHES}
         declared |= {d.param for d in number._AP_TIMING_NUMBERS}
+        # The four AP controls that are hardcoded entity classes with no description
+        # table, so they contribute nothing to the walk above: a fifth one -- the
+        # SHAPE these already use -- would otherwise land with no guard at all.
+        declared |= {"machMode", "onOffStatus"}      # fan.HonAirPurifierFan
+        declared |= {"aromaStatus", "lightStatus"}   # select.HonAirPurifier{Aroma,PanelLight}Select
         self.assertTrue(declared)
-        self.assertTrue(declared <= AP_ENTITY_PARAMS, declared - AP_ENTITY_PARAMS)
+        # assertEqual, not a subset: coverage SUBTRACTS this set from both axes, so a
+        # name left here after its entity is removed silently deletes that parameter
+        # from the gold signal and the dump reports full coverage of a control the
+        # integration does not have. Adding a bogus name left the whole suite green.
+        self.assertEqual(declared, set(AP_ENTITY_PARAMS))
 
 
 class FutureCapabilityCaptureTest(unittest.TestCase):
@@ -1128,6 +1269,21 @@ class FutureCapabilityCaptureTest(unittest.TestCase):
     def test_future_capability_reports_an_unhandled_live_state(self) -> None:
         future = _ap_block()["future_capabilities"]
         self.assertEqual({"machMode": "3"}, future["state_values_unhandled"])
+
+    def test_a_stopped_purifier_is_not_a_future_capability(self) -> None:
+        """The ordinary case, which the exact-dict test above was positioned never to
+        see: machMode=0 is the documented off-state sentinel (air_purifier.py's own
+        comment, and fan.py: "never a preset"), so an idle purifier must not be
+        reported as running a mode nobody handles.
+
+        `AP_HANDLED_VALUES[machMode]` reused AP_WRITABLE_MODES {1,2,4}, and writable
+        is not the same as handled -- so every dump from a switched-off purifier
+        announced a phantom firmware capability. The real AP capture
+        (tests/fixtures/ap/schema.json) declares only ["1","2","4"], which makes 0 the
+        ONLY value that ever reaches this branch on the hardware this repo has seen.
+        """
+        future = _ap_block({"machMode": "0"})["future_capabilities"]
+        self.assertEqual({}, future["state_values_unhandled"])
 
     def test_an_unhandled_state_value_is_length_capped(self) -> None:
         """The section is passive EVIDENCE, not a report: a firmware answering with a
@@ -1169,12 +1325,25 @@ class FutureCapabilityCaptureTest(unittest.TestCase):
         self.assertEqual({"machMode": exact}, future["state_values_unhandled"])
 
     def test_future_capability_carries_no_identity(self) -> None:
+        """Identity must be masked BEFORE the value is cut to _FUTURE_MAX_VALUE_CHARS.
+
+        The fixture's mac/serial/model live under keys this section never reads, so
+        searching the default block for them asserts that a section containing no
+        identity contains no identity. Put the identity where the section actually
+        looks -- a live state value -- and put one ACROSS the cap, because a MAC
+        sliced through the middle no longer matches `_MAC_RE` and a mask applied
+        after the slice publishes the OUI verbatim.
+        """
         import json
 
-        future = _ap_block()["future_capabilities"]
+        mac = "AA:BB:CC:DD:EE:FF"
+        straddling = "x" * (diagnostics._FUTURE_MAX_VALUE_CHARS - 10) + mac
+        future = _ap_block({"machMode": straddling})["future_capabilities"]
         encoded = json.dumps(future)
-        for identity in ("AA:BB:CC:DD:EE:FF", "AP-PLAINTEXT-SERIAL", "SYNTHETIC-AP",
-                         "ap-unique"):
+        self.assertNotIn(mac, encoded, encoded)
+        # a MAC cut by the cap is still a MAC: the OUI alone identifies the vendor
+        self.assertNotIn("AA:BB:CC", encoded, encoded)
+        for identity in ("AP-PLAINTEXT-SERIAL", "SYNTHETIC-AP", "ap-unique"):
             self.assertNotIn(identity, encoded, identity)
 
     def test_future_capability_is_absent_for_a_type_with_no_registry(self) -> None:
@@ -1193,6 +1362,43 @@ class FutureCapabilityCaptureTest(unittest.TestCase):
         future = result["appliances"][0]["future_capabilities"]
         delta = future["enum_deltas"]["settings.aromaStatus"]
         self.assertEqual(diagnostics._FUTURE_MAX_VALUES, len(delta))
+        self.assertTrue(future["truncated"])
+
+    def test_future_capability_row_count_is_bounded(self) -> None:
+        """The OTHER bound. `_enum_deltas` caps VALUES per parameter
+        (_FUTURE_MAX_VALUES) and ROWS overall (_FUTURE_MAX_ENTRIES); the test above
+        drives only the first. The row cap is the one that matters for a device with
+        many PARAMETERS rather than many values on one -- the AC in
+        diagnostics/live-2026-06-22/ carries 74 shadow parameters, so a type whose
+        registry listed them all would cross 40 rows on real hardware while never
+        approaching 20 values on any single parameter. Deleting the row cap left the
+        entire suite green.
+        """
+        from custom_components.addhon import air_purifier
+
+        coord = _build_ap_coordinator()
+        params = coord.data[AP_ID]["appliance"].commands["settings"].parameters
+        overflow = diagnostics._FUTURE_MAX_ENTRIES + 10
+        for n in range(overflow):
+            params[f"futureParam{n}"] = FakeParam(
+                value="0", typology="enum", values=["0", "9"]
+            )
+        patched = dict(air_purifier.AP_HANDLED_VALUES)
+        patched.update({f"futureParam{n}": frozenset({"0"}) for n in range(overflow)})
+        original = air_purifier.AP_HANDLED_VALUES
+        air_purifier.AP_HANDLED_VALUES = patched
+        try:
+            result = _run(
+                diagnostics.async_get_config_entry_diagnostics(
+                    FakeHass(coord), FakeEntry()
+                )
+            )
+        finally:
+            air_purifier.AP_HANDLED_VALUES = original
+        future = result["appliances"][0]["future_capabilities"]
+        self.assertLessEqual(
+            len(future["enum_deltas"]), diagnostics._FUTURE_MAX_ENTRIES
+        )
         self.assertTrue(future["truncated"])
 
     def test_future_capability_does_not_enumerate_a_range_parameter(self) -> None:
@@ -1357,10 +1563,15 @@ class EntityInventoryTest(unittest.TestCase):
     def test_a_disabled_entity_is_reported_as_disabled_not_as_missing(self) -> None:
         """Home Assistant writes no state for a disabled entity, so a naive live
         check would report every user-disabled control as a platform crash."""
-        rows = self._rows(AP_ROWS[:1], disabled_by="user") + self._rows(AP_ROWS[1:])
+        # A disabler that is NOT "user": the distinction this section exists to make
+        # is a deliberate user choice (harmless) versus the integration disabling its
+        # own entity (a bug). Echoing the fixture's "user" back cannot see the value
+        # path die -- hardcoding the literal survives the whole suite -- and "user" is
+        # the only disabler any fixture in the repo has ever fed.
+        rows = self._rows(AP_ROWS[:1], disabled_by="integration") + self._rows(AP_ROWS[1:])
         live = FakeStates(live=[eid for _uid, eid in AP_ROWS[1:]])
         _result, entities = self._dump(rows, states=live)
-        self.assertEqual({"switch.child_lock": "user"}, entities["disabled"])
+        self.assertEqual({"switch.child_lock": "integration"}, entities["disabled"])
         self.assertNotIn("not_created", entities)
         self.assertIn("child_lock", entities["by_domain"]["switch"])
 
@@ -1421,6 +1632,13 @@ class EntityInventoryTest(unittest.TestCase):
         self.assertEqual({}, result["platforms"]["account"])
         self.assertNotIn("switch", entities["by_domain"])
         self.assertNotIn("switch", result["platforms"]["appliance_totals"])
+        # Positively pin the totals the contrast depends on. The three assertions
+        # above are all absence checks over a fixture built by DELETING exactly what
+        # they assert absent, so a build where appliance_totals is permanently empty
+        # -- or double-counts -- satisfies them unchanged.
+        self.assertEqual(
+            {"fan": 1, "select": 1}, result["platforms"]["appliance_totals"]
+        )
 
     def test_a_leftover_account_row_does_not_clear_a_dead_platform(self) -> None:
         """The harder half of the same case: the platform ran on an EARLIER install,
@@ -1626,6 +1844,27 @@ class EntityInventoryScopeTest(unittest.TestCase):
         self.assertEqual(
             {"switch": 1, "fan": 1}, result["platforms"]["appliance_totals"]
         )
+
+    def test_a_shorter_appliance_id_does_not_swallow_a_longer_one(self) -> None:
+        """The `_` separator is MANDATORY in prefix attribution, and longest-first
+        ordering does not stand in for it when the longer id is absent from the poll.
+
+        Realistic, not theoretical: when the cloud reports the placeholder MAC, the
+        engine builds the id as f"{type}_{applianceModelId}"
+        (client/engine/appliance.py:100-104), so two appliances of one type with
+        model ids 123 and 1234 get `wm_123` and `wm_1234` -- a bare prefix with no
+        separator between them. Without the mandatory `_`, the absent appliance's
+        surviving registry rows are attributed to its shorter-id sibling and emitted
+        under the mangled key `switch._child_lock`.
+        """
+        inventory, platforms = diagnostics._entity_inventory(
+            [FakeRegistryEntry("wm_1234_child_lock", "switch.b_child_lock")],
+            ["wm_123"],
+            "e1",
+            None,
+        )
+        self.assertEqual({}, inventory["wm_123"]["by_domain"])
+        self.assertEqual(1, platforms["unattributed"])
 
     def test_the_device_dump_carries_only_its_own_appliance(self) -> None:
         """The device hook builds the inventory over EVERY id on purpose; this pins

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -557,7 +557,9 @@ class DiagnosticsCoverageTest(unittest.TestCase):
     def test_unmapped_writable_params(self):
         _, blocks = _entry_diag()
         self.assertIn("mysteryParam", blocks["AC"]["coverage"]["command_params_unmapped"])
-        self.assertIn("spinSpeed", blocks["WD"]["coverage"]["command_params_unmapped"])
+        # `spinSpeed` is NOT unmapped: `select.opt_spin_speed` writes it, and
+        # `entities.sources` names it. Pinning it here pinned the contradiction.
+        self.assertNotIn("spinSpeed", blocks["WD"]["coverage"]["command_params_unmapped"])
 
     def test_mapped_writable_params_not_reported(self):
         _, blocks = _entry_diag()
@@ -822,7 +824,7 @@ class WcSettingsSwitchCoverageTest(unittest.TestCase):
         })})
 
     def test_lightstatus_in_mapped_params(self):
-        _, mapped_params = diagnostics._mapped_sets("WC")
+        _, mapped_params, _sources = diagnostics._mapped_sets("WC")
         self.assertIn("lightStatus", mapped_params)
 
     def test_lightstatus_not_reported_unmapped(self):
@@ -2125,7 +2127,12 @@ class CoverageExpectedAbsentTest(unittest.TestCase):
             },
         )
         absent = block["coverage"]["command_params_expected_absent"]
-        self.assertEqual([], absent)
+        # The three names this test exists for. The list is no longer empty:
+        # the program options this WD maps and this fake appliance does not
+        # declare are genuinely absent, which is what the axis is for.
+        self.assertNotIn("program", absent)
+        self.assertNotIn("prCode", absent)
+        self.assertNotIn("spinSpeed", absent)
 
     def test_a_device_that_publishes_everything_it_maps_reports_nothing(self):
         # The empty case, derived rather than hand-listed so it cannot rot when a
@@ -2223,6 +2230,637 @@ class CoverageExpectedAbsentTest(unittest.TestCase):
             self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
             for name in json.loads(encoded)["attributes_expected_absent"]:
                 self.assertRegex(name, r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+# --- step 2: the entity source map (issue #75) ------------------------------
+
+
+REF_ID = "ref-unique"
+
+# One registry row per entity the fridge fixture below produces, in the same
+# (unique_id, entity_id) shape as AP_ROWS so the existing `_rows()` idiom works
+# unchanged. The entity_ids carry a NICKNAME-derived object_id on purpose: the
+# identity test at the end of this section proves it never reaches the dump.
+REF_ROWS = (
+    (f"{REF_ID}_temp_zone3", "sensor.mario_fridge_temp_zone3"),
+    (f"{REF_ID}_target_temp_zone3", "number.mario_fridge_target_temp_zone3"),
+    (f"{REF_ID}_target_temp_zone4", "number.mario_fridge_target_temp_zone4"),
+    (f"{REF_ID}_ref_program", "select.mario_fridge_ref_program"),
+    (f"{REF_ID}_door_zone1", "binary_sensor.mario_fridge_door_zone1"),
+    (f"{REF_ID}_connectivity", "binary_sensor.mario_fridge_connectivity"),
+)
+
+
+def _build_ref_coordinator() -> FakeCoordinator:
+    """The issue-75 fridge: four zone setpoints declared, three zones reported.
+
+    Its `settings` command carries tempSelZ1/Z2/Z3/Z4 while the shadow publishes
+    tempZ1/Z2/Z3 only, which is the exact asymmetry the reporter spent two dumps
+    and a decompiler pass establishing by hand.
+
+    DO NOT REDEFINE THIS FUNCTION LOWER IN THE FILE. A second `def` of the same
+    name silently shadows this one at import time -- no error, no warning -- and
+    every assertion above it starts testing the other fixture. The deferred
+    zone-map work needs a variant whose tempSelZ3 is not writable; it must add a
+    KEYWORD-ONLY parameter here (`def _build_ref_coordinator(*, writable_z3: bool
+    = True)`) and branch inside, so there stays exactly one definition.
+    """
+    ref = FakeAppliance(
+        commands={
+            "settings": FakeCommand({
+                "tempSelZ1": FakeParam(value="4", typology="range", rng=(2, 8, 1)),
+                "tempSelZ2": FakeParam(
+                    value="-18", typology="enum", values=["-24", "-18"]
+                ),
+                "tempSelZ3": FakeParam(
+                    value="5", typology="enum", values=["0", "2", "5"]
+                ),
+                "tempSelZ4": FakeParam(
+                    value="5", typology="enum", values=["0", "2", "5"]
+                ),
+            }),
+            # A fridge program select resolves its parameter off THIS command at
+            # runtime, which is why `select.ref_program` has to read as null.
+            "startProgram": FakeCommand({
+                "program": FakeParam(value="1", typology="enum", values=["1", "2"]),
+            }),
+            "stopProgram": FakeCommand({
+                "onOffStatus": FakeParam(value="0", typology="fixed"),
+            }),
+        },
+        model_attributes={"zones": "fridge|freezer|vtRoom2", "doorNumber": 3},
+    )
+    return FakeCoordinator({
+        REF_ID: {
+            "appliance": ref,
+            "type": "REF",
+            "name": "Mario Fridge",
+            "model": "HTF-540",
+            "serial": "REF-PLAINTEXT-SERIAL",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "attributes": {
+                "tempZ1": 4,
+                "tempZ2": -18,
+                "tempZ3": 5,
+                "doorStatusZ1": "0",
+                "available": True,
+                "tempSelZ1": "4",
+                "tempSelZ2": "-18",
+                "tempSelZ3": "5",
+            },
+            "statistics": {},
+        },
+    })
+
+
+_ABSENT = object()
+
+
+class _BrokenModules:
+    """Make `from .<name> import ...` fail the way a broken platform module does.
+
+    `sys.modules[name] = None` is what CPython itself leaves behind for a module
+    whose import failed, and it makes the next import raise rather than silently
+    re-running the module body. Restoring is done against a sentinel, not against
+    `sys.modules[name]`: a module the suite has never imported is ABSENT rather
+    than None, and putting a None back for it would break every later test.
+    """
+
+    def __init__(self, *names):
+        self._names = [f"custom_components.addhon.{name}" for name in names]
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for name in self._names:
+            self._saved[name] = sys.modules.get(name, _ABSENT)
+            sys.modules[name] = None
+        return self
+
+    def __exit__(self, *exc_info):
+        for name, saved in self._saved.items():
+            if saved is _ABSENT:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+        return False
+
+
+def _ref_dump(rows=REF_ROWS, states=None, raises=False, entries=None):
+    """The fridge's `entities` section, built through the real registry path."""
+    if entries is None:
+        entries = [FakeRegistryEntry(uid, eid) for uid, eid in rows]
+    if states is None:
+        states = FakeStates(live=[row.entity_id for row in entries])
+    hass = RegistryHass(_build_ref_coordinator(), rows=entries, states=states)
+    _install_registry(hass, raises=raises)
+    result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+    return result, result["appliances"][0]["entities"]
+
+
+def _static_parameter_names() -> set[str]:
+    """Every parameter name the platform tables declare, harvested independently.
+
+    Built here by walking the tables directly instead of asking `_mapped_sets`,
+    so the drift assertions compare the emitted section against the tables and
+    not against the very walk that produced it.
+    """
+    from custom_components.addhon.air_purifier import AP_ENTITY_PARAMS
+    from custom_components.addhon.binary_sensor import (
+        BINARY_SENSORS,
+        _CONNECTIVITY,
+        _UNIVERSAL_GATED,
+    )
+    from custom_components.addhon.const import PROGRAM_PARAM_NAMES
+    from custom_components.addhon.number import (
+        NUMBERS,
+        _AP_TIMING_NUMBERS,
+        _PROGRAM_OPTION_NUMBERS,
+    )
+    from custom_components.addhon.select import (
+        _AC_DIRECTION_SELECTS,
+        _PROGRAM_OPTION_SELECTS,
+    )
+    from custom_components.addhon.sensor import SENSORS
+    from custom_components.addhon.switch import (
+        _AIR_PURIFIER_SWITCHES,
+        _PROGRAM_OPTION_SWITCHES,
+        _SETTINGS_SWITCHES,
+    )
+
+    names: set[str] = set(AP_ENTITY_PARAMS) | set(PROGRAM_PARAM_NAMES)
+    for registry in (SENSORS, BINARY_SENSORS):
+        for descriptions in registry.values():
+            for desc in descriptions:
+                names.add(desc.attr_key)
+                names.update(getattr(desc, "attr_fallbacks", ()) or ())
+    names.add(_CONNECTIVITY.attr_key)
+    for desc in _UNIVERSAL_GATED:
+        names.add(desc.attr_key)
+    for registry in (NUMBERS, _SETTINGS_SWITCHES):
+        for descriptions in registry.values():
+            for desc in descriptions:
+                names.add(desc.param)
+    for table in (
+        _AP_TIMING_NUMBERS,
+        _AIR_PURIFIER_SWITCHES,
+        _PROGRAM_OPTION_NUMBERS,
+        _PROGRAM_OPTION_SELECTS,
+        _PROGRAM_OPTION_SWITCHES,
+        _AC_DIRECTION_SELECTS,
+    ):
+        for desc in table:
+            names.add(desc.param)
+            attr = getattr(desc, "attr", None)
+            if attr:
+                names.add(attr)
+    # The two other STATIC tables in diagnostics.py that name parameters. They
+    # are harvested, and `_CUSTOM_ENTITY_SOURCES` deliberately is NOT: harvesting
+    # the hand-written table into the set that is supposed to police it makes the
+    # guard pass for anything anyone ever types into a custom row, which is the
+    # one half of this section a platform table cannot vouch for. Measured: with
+    # the harvest in place, planting an identity-shaped literal into a custom row
+    # left the whole suite green.
+    names |= set(diagnostics._AC_CLIMATE_PARAMS)
+    for mapped in diagnostics._CUSTOM_MAPPED_ATTRS.values():
+        names |= set(mapped)
+    # `pause` is the single custom-row name no other table in the repository
+    # carries (switch.pause writes the `pause` parameter of pauseProgram /
+    # resumeProgram, and no description table describes those commands). It is
+    # spelled out here so that adding a SECOND such name is a deliberate act
+    # recorded in this test rather than something the harvest absorbs silently.
+    names.add("pause")
+    return names
+
+
+class EntitySourceTest(unittest.TestCase):
+    """`entities.sources`: which raw parameter each registered entity speaks to."""
+
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def test_a_number_names_the_parameter_it_reads_and_writes(self) -> None:
+        _result, entities = _ref_dump()
+        self.assertEqual(
+            {"read": ["tempSelZ3"], "write": ["tempSelZ3"]},
+            entities["sources"]["number.target_temp_zone3"],
+        )
+
+    def test_a_sensor_is_visibly_read_only(self) -> None:
+        # The empty half is OMITTED, not emitted as []: a reader must be able to
+        # tell "this control cannot be written" from "this dump did not look".
+        _result, entities = _ref_dump()
+        row = entities["sources"]["sensor.temp_zone3"]
+        self.assertEqual({"read": ["tempZ3"]}, row)
+        self.assertNotIn("write", row)
+
+    def test_the_two_rows_that_answer_issue_75_sit_side_by_side(self) -> None:
+        # THE point of the whole section. Establishing that `sensor.temp_zone3`
+        # reads `tempZ3` while `number.target_temp_zone4` writes `tempSelZ4` cost
+        # the original reporter a round trip through sensor.py and number.py.
+        _result, entities = _ref_dump()
+        sources = entities["sources"]
+        self.assertEqual(["tempZ3"], sources["sensor.temp_zone3"]["read"])
+        self.assertEqual(
+            ["tempSelZ4"], sources["number.target_temp_zone4"]["write"]
+        )
+
+    def test_a_runtime_resolved_parameter_is_null_and_not_guessed(self) -> None:
+        # The fridge program select picks whichever of PROGRAM_PARAM_NAMES the
+        # DEVICE happens to carry, so no static table can name it. The key is
+        # present and the value is null: "this entity exists, and this dump
+        # cannot say what it writes" -- which is a different claim from silence.
+        _result, entities = _ref_dump()
+        self.assertIn("select.ref_program", entities["sources"])
+        self.assertIsNone(entities["sources"]["select.ref_program"])
+
+    def test_every_registered_entity_gets_exactly_one_row(self) -> None:
+        # The join contract: `sources` and `by_domain` describe the same set of
+        # entities, or the tag stops being usable as a key between the two.
+        _result, entities = _ref_dump()
+        tagged = {
+            f"{domain}.{key}"
+            for domain, keys in entities["by_domain"].items()
+            for key in keys
+        }
+        self.assertEqual(tagged, set(entities["sources"]))
+        self.assertEqual(len(REF_ROWS), len(entities["sources"]))
+
+    def test_sources_is_appended_after_the_existing_views(self) -> None:
+        # Position is a contract of its own: a section that reshuffles its keys
+        # between releases is one people stop skimming.
+        _result, entities = _ref_dump()
+        self.assertEqual("sources", list(entities)[-1])
+        self.assertEqual("status", list(entities)[0])
+
+    def test_a_disabled_entity_still_names_its_parameter(self) -> None:
+        # A disabled entity is the single most common reason a control is
+        # missing, and it is exactly the case where the reader wants to know
+        # which parameter they would get back by re-enabling it.
+        entries = [FakeRegistryEntry(uid, eid) for uid, eid in REF_ROWS]
+        entries[1].disabled_by = "user"
+        _result, entities = _ref_dump(entries=entries)
+        self.assertEqual(
+            {"number.target_temp_zone3": "user"}, entities["disabled"]
+        )
+        self.assertEqual(
+            {"read": ["tempSelZ3"], "write": ["tempSelZ3"]},
+            entities["sources"]["number.target_temp_zone3"],
+        )
+
+    def test_a_row_from_an_older_release_reads_as_null_not_as_absent(self) -> None:
+        # A registry row whose suffix no current table knows must still appear.
+        # Dropping it would make `sources` and `by_domain` disagree about how
+        # many entities exist, which is the one thing a join key may not do.
+        rows = REF_ROWS + ((f"{REF_ID}_retired_thing", "sensor.mario_fridge_x"),)
+        _result, entities = _ref_dump(rows=rows)
+        self.assertIn("sensor.retired_thing", entities["sources"])
+        self.assertIsNone(entities["sources"]["sensor.retired_thing"])
+
+    def test_the_index_is_per_type_and_never_offers_another_type_s_row(self) -> None:
+        # Asserted against the INDEX, not against a fridge dump: `sources` is a
+        # projection of `by_domain`, so a dump with no climate row could not show
+        # `climate.climate` however broken the index was, and the assertion would
+        # pass for the wrong reason.
+        ref_index = diagnostics._mapped_sets("REF")[2]
+        self.assertNotIn("climate.climate", ref_index)
+        self.assertNotIn("switch.pause", ref_index)
+        self.assertIn("climate.climate", diagnostics._mapped_sets("AC")[2])
+        self.assertIn("switch.pause", diagnostics._mapped_sets("WD")[2])
+
+    def test_a_stop_button_names_the_parameter_it_writes(self) -> None:
+        # `button.stop_program` fixes onOffStatus="0" on the command it sends,
+        # and that write appears in NO other section of the dump. Its sibling
+        # fixes nothing, so it stays null rather than being given the same row.
+        index = diagnostics._mapped_sets("WD")[2]
+        self.assertEqual({"write": ["onOffStatus"]}, index["button.stop_program"])
+        self.assertIsNone(index["button.start_program"])
+
+    def test_the_purifier_fan_reads_power_without_claiming_to_write_it(self) -> None:
+        # Power is a whole-COMMAND action on the AP (startProgram / stopProgram,
+        # the latter with no values at all), so the fan chooses a value for
+        # machMode and never for onOffStatus. Naming it as a write would send a
+        # reader looking for a writable onOffStatus this integration never sets.
+        index = diagnostics._mapped_sets("AP")[2]
+        self.assertEqual(
+            {"read": ["onOffStatus", "machMode"], "write": ["machMode"]},
+            index["fan.purifier"],
+        )
+
+    def test_a_dotted_read_names_its_bare_fallback(self) -> None:
+        # `_get_attr` tries the dotted key and then the bare one, so emitting
+        # only the dotted spelling would hide the chain and send a reader looking
+        # for a key that is not in `attributes` while the bare one is.
+        index = diagnostics._mapped_sets("AC")[2]
+        self.assertEqual(
+            ["settings.windDirectionVertical", "windDirectionVertical"],
+            index["select.fan_direction_vertical"]["read"],
+        )
+        self.assertEqual(
+            ["windDirectionVertical"],
+            index["select.fan_direction_vertical"]["write"],
+        )
+        climate_reads = index["climate.climate"]["read"]
+        for dotted in ("settings.tempSel", "settings.machMode"):
+            bare = dotted.removeprefix("settings.")
+            self.assertIn(dotted, climate_reads)
+            self.assertEqual(
+                climate_reads.index(dotted) + 1, climate_reads.index(bare)
+            )
+
+    def test_a_louver_select_is_also_counted_as_mapped_coverage(self) -> None:
+        # The two sections must not contradict each other. Before this section
+        # existed `windDirectionHorizontal` sat in `command_params_unmapped`
+        # while nothing disproved it; now `sources` names its writer, so the
+        # coverage numerator has to agree.
+        mapped_attrs, mapped_params, index = diagnostics._mapped_sets("AC")
+        self.assertIn("windDirectionHorizontal", mapped_params)
+        self.assertEqual(
+            ["windDirectionHorizontal"],
+            index["select.fan_direction_horizontal"]["write"],
+        )
+
+    def test_a_sensor_fallback_chain_keeps_its_order(self) -> None:
+        # `actualWeight` then `weight`: the ORDER is the information, because it
+        # is the order the entity tries them in. Sorting it would turn a chain
+        # into an unordered set of equally-plausible names.
+        index = diagnostics._mapped_sets("WD")[2]
+        self.assertEqual(
+            ["actualWeight", "weight"], index["sensor.estimated_weight"]["read"]
+        )
+
+    def test_a_program_option_names_both_places_it_is_read_from(self) -> None:
+        # A buffered option is read bare and then under startProgram, because
+        # that command is not mirrored into the shadow the way `settings` is.
+        index = diagnostics._mapped_sets("WD")[2]
+        self.assertEqual(
+            {
+                "read": ["prewash", "startProgram.prewash"],
+                "write": ["prewash"],
+            },
+            index["switch.opt_prewash"],
+        )
+
+    def test_a_derived_sensor_names_both_attributes_it_needs(self) -> None:
+        # The entity most likely to be reported as stuck on unknown: it needs two
+        # keys, and a washer publishing one of them produces exactly that.
+        index = diagnostics._mapped_sets("WD")[2]
+        self.assertEqual(
+            {"read": ["totalWaterUsed", "totalWashCycle"]},
+            index["sensor.mean_water_consumption"],
+        )
+
+    def test_the_pause_switch_reads_and_writes_different_names(self) -> None:
+        # The one row whose halves disagree: it reads machMode but writes the
+        # `pause` parameter of pauseProgram/resumeProgram. A reader assuming the
+        # halves match would go looking for a writable machMode that is not there.
+        index = diagnostics._mapped_sets("WD")[2]
+        self.assertEqual(
+            {"read": ["machMode"], "write": ["pause"]}, index["switch.pause"]
+        )
+
+    def test_the_degraded_section_gains_nothing(self) -> None:
+        # An unreadable registry yields the marker and NOTHING else. Hanging a
+        # `sources` key off it would claim a lookup that never happened.
+        result, degraded = _ref_dump(raises=True)
+        self.assertEqual({"status": "unavailable"}, degraded)
+        self.assertEqual({"status": "unavailable"}, result["platforms"])
+
+    def test_unreadable_registries_give_ONE_null_not_a_null_per_entity(self) -> None:
+        # The lazy import is what fails here, not the entity registry: the
+        # section knows WHICH entities exist and cannot say what any of them
+        # speaks to. A map of nulls would read as "all six were looked up and
+        # none is known", which is a finding; one null is the absence of one.
+        with _BrokenModules("select"):
+            _result, entities = _ref_dump()
+        self.assertIsNone(entities["sources"])
+        self.assertEqual(6, sum(len(v) for v in entities["by_domain"].values()))
+
+    def test_the_two_sections_share_one_degradation_decision(self) -> None:
+        # Correction 6 made real. With the walk folded into `_mapped_sets`, a
+        # broken platform module degrades coverage AND sources together; two
+        # independent import blocks would let one dump report `tempSelZ3` as
+        # confidently mapped while the other half claimed nothing was readable.
+        with _BrokenModules("select"):
+            result, entities = _ref_dump()
+            mapped_attrs, mapped_params, index = diagnostics._mapped_sets("REF")
+        self.assertIsNone(index)
+        self.assertEqual(set(), mapped_params)
+        self.assertEqual(set(), mapped_attrs)
+        # ... and the dump SAYS SO in both halves, which is the actual claim.
+        self.assertIsNone(entities["sources"])
+        coverage = result["appliances"][0]["coverage"]
+        self.assertTrue(coverage["registries_unavailable"])
+        # Positive control: the same calls with the module intact are populated
+        # and carry no marker, so the assertions above cannot pass for the wrong
+        # reason.
+        mapped_attrs, mapped_params, index = diagnostics._mapped_sets("REF")
+        self.assertIsNotNone(index)
+        self.assertIn("tempSelZ3", mapped_params)
+        _result, healthy = _ref_dump()
+        self.assertNotIn(
+            "registries_unavailable", _result["appliances"][0]["coverage"]
+        )
+        self.assertIsNotNone(healthy["sources"])
+
+    def test_a_device_dump_says_when_the_registries_were_unreadable(self) -> None:
+        # The case `entities.sources` structurally cannot cover: there is no
+        # inventory to decorate, so the coverage marker is the only thing in the
+        # document that stops the reader believing the integration maps nothing.
+        with _BrokenModules("select"):
+            block = diagnostics._appliance_block(
+                "id1",
+                {
+                    "appliance": None,
+                    "type": "REF",
+                    "attributes": {"tempZ1": 4},
+                    "statistics": {},
+                },
+            )
+        self.assertIsNone(block["entities"])
+        self.assertTrue(block["coverage"]["registries_unavailable"])
+        self.assertEqual(["tempZ1"], block["coverage"]["attributes_unmapped"])
+
+    def test_a_foreign_inventory_shape_degrades_instead_of_raising(self) -> None:
+        # `_appliance_block` is called with no try/except around it from either
+        # entry point, so every one of these must return rather than raise.
+        self.assertIsNone(diagnostics._entity_section(None, "REF"))
+        self.assertIsNone(diagnostics._entity_section("nonsense", "REF"))
+        self.assertEqual(
+            {"status": "unavailable"},
+            diagnostics._entity_section({"status": "unavailable"}, "REF"),
+        )
+        self.assertEqual(
+            {"status": "ok", "by_domain": "not-a-map"},
+            diagnostics._entity_section(
+                {"status": "ok", "by_domain": "not-a-map"}, "REF"
+            ),
+        )
+        section = diagnostics._entity_section(
+            {"status": "ok", "by_domain": {"sensor": "not-a-list"}}, "REF"
+        )
+        self.assertEqual({}, section["sources"])
+        # An appliance whose type is missing or junk still produces a section:
+        # every tag resolves to null rather than raising on a table lookup.
+        junk = diagnostics._entity_section(
+            {"status": "ok", "by_domain": {"sensor": ["temp_zone3"]}}, None
+        )
+        self.assertEqual({"sensor.temp_zone3": None}, junk["sources"])
+
+    def test_the_caller_s_inventory_is_not_mutated(self) -> None:
+        # It is a copy, like the `dict(entities)` it replaces: the inventory is
+        # built once for the whole dump and shared with the entry-level view.
+        inventory = {"status": "ok", "by_domain": {"sensor": ["temp_zone3"]}}
+        section = diagnostics._entity_section(inventory, "REF")
+        self.assertIn("sources", section)
+        self.assertNotIn("sources", inventory)
+
+
+class EntitySourceDriftGuardTest(unittest.TestCase):
+    """Nothing the cloud chose may reach this section, in either half."""
+
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def test_every_emitted_name_is_a_static_table_field(self) -> None:
+        # The value axis has NO redactor behind it: `read`/`write` are not in
+        # `_TO_REDACT`, and `_MAC_RE` only catches MAC shapes. What makes the
+        # section safe is that every name is copied out of a table in this
+        # repository, so this asserts exactly that, over every type -- and the
+        # allowed set is harvested from the PLATFORM tables, never from
+        # `_CUSTOM_ENTITY_SOURCES`, so a name typed into a custom row has to be
+        # justified by some other table or by the one-word allowlist.
+        allowed = _static_parameter_names()
+        self.assertIn("tempSelZ3", allowed)  # not vacuous
+        seen = 0
+        for app_type in ("REF", "AC", "WD", "AP", "WC", "OV", "HO", "TD", "WM"):
+            index = diagnostics._mapped_sets(app_type)[2]
+            self.assertIsNotNone(index)
+            for tag, row in index.items():
+                for name in (row or {}).get("read", []) + (row or {}).get("write", []):
+                    seen += 1
+                    bare = name
+                    for prefix in ("settings.", "startProgram."):
+                        if name.startswith(prefix):
+                            bare = name[len(prefix):]
+                    self.assertTrue(
+                        name in allowed or bare in allowed,
+                        f"{app_type} {tag}: {name} is in no static table",
+                    )
+        self.assertGreater(seen, 200, "the sweep found almost nothing to check")
+
+    def test_every_emitted_name_matches_the_closed_shape(self) -> None:
+        # A second, cheaper net under the first: whatever a future edit starts
+        # emitting must at least look like a parameter identifier and not like a
+        # value, a serial or a sentence. A LEADING DIGIT is allowed on purpose --
+        # the air conditioner really does carry `10degreeHeatingStatus` -- so the
+        # pattern is deliberately one character wider than it looks.
+        name_re = r"^[A-Za-z0-9][A-Za-z0-9_]*(\.[A-Za-z0-9][A-Za-z0-9_]*)?$"
+        tag_re = r"^[a-z_]+\.[A-Za-z0-9_]+$"
+        for app_type in ("REF", "AC", "WD", "AP"):
+            for tag, row in diagnostics._mapped_sets(app_type)[2].items():
+                self.assertRegex(tag, tag_re)
+                for name in (row or {}).get("read", []) + (row or {}).get("write", []):
+                    self.assertRegex(name, name_re)
+
+    def test_the_climate_write_half_is_the_coverage_list(self) -> None:
+        # Two INDEPENDENT statements of the same fact: `_AC_CLIMATE_PARAMS` is
+        # what coverage counts as mapped, and the literal in
+        # `_CUSTOM_ENTITY_SOURCES` is what the dump tells the reader the climate
+        # entity writes. They are written out separately on purpose, so that this
+        # comparison is a drift guard rather than a value asserted against itself.
+        row = next(
+            entry
+            for entry in diagnostics._CUSTOM_ENTITY_SOURCES
+            if entry["tag"] == "climate.climate"
+        )
+        self.assertEqual(
+            sorted(diagnostics._AC_CLIMATE_PARAMS), sorted(row["write"])
+        )
+
+    def test_sources_carry_no_identity(self) -> None:
+        # Anti-vacuity FIRST: a leak scan over an empty or absent section passes
+        # for the wrong reason, and that is how this exact test class has failed
+        # to catch things elsewhere.
+        result, entities = _ref_dump()
+        sources = entities["sources"]
+        self.assertIsNotNone(sources)
+        self.assertTrue(any(sources.values()))
+        encoded = json.dumps(sources)
+        self.assertNotIn(REF_ID, encoded)
+        self.assertNotIn("mario_fridge", encoded)
+        self.assertNotIn("REF-PLAINTEXT-SERIAL", encoded)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+        # And the same over the WHOLE document, which is what the reporter
+        # actually attaches to the issue.
+        self.assertNotIn(REF_ID, json.dumps(result))
+        self.assertNotIn("REF-PLAINTEXT-SERIAL", json.dumps(result))
+
+    def test_no_device_value_can_reach_the_row(self) -> None:
+        # The section describes the SCHEMA, never the reading. A fridge whose
+        # shadow is full of identity-shaped junk must produce byte-identical
+        # rows to one whose shadow is empty.
+        coord = _build_ref_coordinator()
+        clean = diagnostics._appliance_block(REF_ID, coord.data[REF_ID], {
+            "status": "ok", "by_domain": {"sensor": ["temp_zone3"]},
+        })
+        poisoned_data = dict(coord.data[REF_ID])
+        poisoned_data["attributes"] = {
+            "tempZ3": "AA:BB:CC:DD:EE:FF",
+            "serialNumber": "REF-PLAINTEXT-SERIAL",
+        }
+        poisoned = diagnostics._appliance_block(REF_ID, poisoned_data, {
+            "status": "ok", "by_domain": {"sensor": ["temp_zone3"]},
+        })
+        self.assertEqual(clean["entities"], poisoned["entities"])
+        self.assertEqual(
+            {"read": ["tempZ3"]}, clean["entities"]["sources"]["sensor.temp_zone3"]
+        )
+
+    def test_a_custom_row_with_a_broken_tag_is_skipped_not_raised(self) -> None:
+        # The custom-table loop sits OUTSIDE the lazy-import try, and
+        # `_appliance_block` has no try/except around it from either entry point,
+        # so a malformed row added later would cost the whole dump rather than
+        # one section. Each guard is exercised on its own shape.
+        broken = (
+            {"tag": "no-dot-here", "types": ("REF",), "read": ("tempZ3",)},
+            {"tag": ".leading", "types": ("REF",), "read": ("tempZ3",)},
+            {"tag": "trailing.", "types": ("REF",), "read": ("tempZ3",)},
+            {"tag": "sensor.orphan"},
+            {"read": ("tempZ3",), "types": ("REF",)},
+            {"tag": "sensor.no_types", "read": ("tempZ3",)},
+            {"tag": "sensor.null_types", "types": None, "read": ("tempZ3",)},
+        )
+        saved = diagnostics._CUSTOM_ENTITY_SOURCES
+        diagnostics._CUSTOM_ENTITY_SOURCES = broken
+        try:
+            index = diagnostics._mapped_sets("REF")[2]
+        finally:
+            diagnostics._CUSTOM_ENTITY_SOURCES = saved
+        self.assertNotIn("no-dot-here", index)
+        self.assertNotIn("sensor.no_types", index)
+        self.assertNotIn("sensor.null_types", index)
+        # The real table is back and still works, so the swap above cannot leave
+        # the rest of the suite testing a stub.
+        self.assertIn("select.ref_program", diagnostics._mapped_sets("REF")[2])
+
+    def test_the_custom_table_names_only_entities_that_can_exist(self) -> None:
+        # A row for a tag no platform ever creates would be dead weight the
+        # reader can never see, and a row whose domain is not a real platform
+        # would never join with `by_domain`.
+        domains = {"sensor", "binary_sensor", "number", "select", "switch",
+                   "button", "climate", "fan"}
+        for entry in diagnostics._CUSTOM_ENTITY_SOURCES:
+            domain, _dot, suffix = entry["tag"].partition(".")
+            self.assertIn(domain, domains, entry["tag"])
+            self.assertTrue(suffix, entry["tag"])
+            # TUPLES, not bare strings. `app_type not in "REF"` is a SUBSTRING
+            # test that quietly matches "R", and the same trap turns a one-name
+            # `read` into a row naming every letter of the parameter.
+            self.assertIsInstance(entry.get("types"), tuple, entry["tag"])
+            self.assertTrue(entry["types"], entry["tag"])
+            for half in ("read", "write"):
+                if half in entry:
+                    self.assertIsInstance(entry[half], tuple, entry["tag"])
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3741,10 +3741,13 @@ class _Raising:
 class _BrokenNested(Mapping):
     """A Mapping that is NOT a dict and refuses one of the keys it enumerates.
 
-    This is the object behind `hon_client.py:192-196`: the merge there goes
-    through `dict(params)`, whose argument is evaluated in full before anything
-    is merged, so one refusing key means NOTHING is flattened and the nested map
-    is the only surviving carrier of the instants.
+    Shaped like what `hon_client.py:192-196` would see, but NO producer builds
+    one: `_attribute_timestamps`' docstring traces every write of that key and
+    finds a plain `dict` or a non-Mapping, and `dict()` refuses neither. So
+    this is a witness that the guards degrade instead of raising, not evidence
+    that the degraded flatten happens in the field. See
+    `TheNestedParametersContainerIsAlwaysAPlainDictTest` at the end of this
+    file, which fails if that stops being true.
     """
 
     def __init__(self, rows, broken):
@@ -4267,9 +4270,11 @@ class AttributeTimestampNestedSourceTest(unittest.TestCase):
     """The `parameters` sub-map, and why it is read at all."""
 
     def test_the_nested_map_is_the_fallback_when_nothing_was_flattened(self):
-        # `hon_client.py:192-196`: `dict(params)` is evaluated in full before
-        # anything is merged, so one refusing key leaves NO bare parameter and
-        # the nested object as the only carrier of the instants.
+        # The fallback works. It is also inert against every producer this
+        # repository has: no write of `attributes["parameters"]` can yield a
+        # Mapping that `dict()` refuses (traced in `_attribute_timestamps`'
+        # docstring). So this pins a guard kept as insurance against a future
+        # producer, not a path a user can reach today.
         nested = _BrokenNested(
             {
                 "tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD),
@@ -5103,9 +5108,12 @@ class AttributeValuesDedupTest(unittest.TestCase):
             self.assertIn(name, block["attributes"])
 
     def test_a_nested_map_that_is_the_only_copy_is_kept(self):
-        # The `hon_client.py:192-196` path: `dict(params)` raised, so NOTHING was
-        # flattened and this sub-map holds the only copy of the values. Dropping
-        # it here would delete data, not duplication.
+        # A sub-map whose names are absent from the top level is kept because
+        # it cannot be SHOWN to be duplication, and dropping it would delete
+        # data. The reachable version of that input is a cloud payload whose
+        # own top-level `parameters` replaced the shadow container; the
+        # "`dict(params)` raised" story this comment used to tell is retracted
+        # in `_attribute_values`' docstring.
         block = _stamp_block(
             {"parameters": {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)}}
         )
@@ -5235,6 +5243,100 @@ class AttributeValuesDedupTest(unittest.TestCase):
         _, blocks = _entry_diag()
         self.assertEqual(6, blocks["AC"]["coverage"]["attributes_total"])
         self.assertEqual(22.5, blocks["AC"]["attributes"]["tempIndoor"])
+
+
+class TheNestedParametersContainerIsAlwaysAPlainDictTest(unittest.TestCase):
+    """The invariant the two nested-`parameters` docstrings now rest on.
+
+    `_attribute_timestamps` walks that sub-map as a fallback source and
+    `_attribute_values` refuses to delete it unless it is provably a copy; both
+    now state that no producer can put a Mapping there that `dict()` would
+    refuse, which is what makes the fallback inert. A docstring that says so
+    goes stale in silence, so the claim is pinned here instead. It drives the
+    REAL engine appliance over the REAL fridge capture on purpose: the claim is
+    about what the engine builds, not about what a fake can be made to build.
+    """
+
+    _INFO = {
+        "applianceTypeName": "REF",
+        "applianceModelId": "10136",
+        "macAddress": "11-22-33-44-55-66",
+        "modelName": "HDPW5620CNPK",
+        "brand": "haier",
+        "nickName": "Frigo",
+        "code": "ABC123",
+        "serialNumber": "0123456789",
+    }
+
+    @staticmethod
+    def _capture(name):
+        path = REPO_ROOT / "tests" / "fixtures" / "ref_10136" / name
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _appliance(self, app_type="REF", top_level=_ABSENT):
+        from custom_components.addhon.client.engine.appliance import HonAppliance
+
+        capture = self._capture
+
+        class _Api:
+            async def load_commands(self, appliance):
+                return capture("commands.json")
+
+            async def load_favourites(self, appliance):
+                return []
+
+            async def load_command_history(self, appliance):
+                return capture("command_history.json")
+
+            async def load_attributes(self, appliance):
+                payload = capture("attributes.json")
+                if top_level is not _ABSENT:
+                    payload["parameters"] = top_level
+                return payload
+
+        appliance = HonAppliance(
+            _Api(), dict(self._INFO, applianceTypeName=app_type)
+        )
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(appliance.load_commands())
+            try:
+                loop.run_until_complete(appliance.load_attributes())
+            except (KeyError, ValueError, IndexError, TypeError, AttributeError):
+                # Exactly client/session.py::_APPLIANCE_BUILD_ERRORS, which KEEPS
+                # the half-loaded appliance instead of dropping it -- so whatever
+                # it is left holding still reaches a dump through
+                # `build_realtime_snapshot`, and the invariant has to hold on the
+                # failed path too, not only on the happy one.
+                pass
+        finally:
+            loop.close()
+        return appliance
+
+    def test_the_engine_builds_the_shadow_container_as_a_plain_dict(self):
+        # `client/engine/appliance.py:279` creates it with a literal `{}`. Not
+        # `isinstance`: a dict SUBCLASS would pass that and still be the thing
+        # the docstrings say cannot arrive, because `dict()` takes the
+        # `PyDict_Merge` fast path on subclasses and would keep flattening.
+        params = self._appliance().attributes["parameters"]
+        self.assertIs(type(params), dict)
+
+    def test_no_cloud_payload_can_put_a_refusing_mapping_under_parameters(self):
+        # `client/engine/appliance.py:280` merges the context payload wholesale,
+        # so the TYPE of this key is cloud-controlled -- but the payload comes
+        # from `response.json()`, and JSON decodes to plain containers only.
+        # Every shape it can produce is either exactly `dict` (which `dict()`
+        # cannot refuse, so nothing degrades) or not a Mapping at all (which
+        # both helpers decline to walk). AC is used because it has no per-type
+        # layer in `client/engine/appliances/registry.py`, so nothing rejects
+        # the value before it lands: it is the most permissive path there is.
+        for value in ([], "abc", 5, 1.5, True, None, {}, {"x": "1"}):
+            with self.subTest(value=value):
+                landed = self._appliance("AC", value).attributes.get("parameters")
+                self.assertTrue(
+                    type(landed) is dict or not isinstance(landed, Mapping),
+                    f"a {type(landed).__name__} reached the dead fallback",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -21,6 +21,7 @@ import json
 import sys
 import types
 import unittest
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -660,13 +661,20 @@ class DiagnosticsDeviceTest(unittest.TestCase):
         coord = _build_coordinator()
         hass = FakeHass(coord)
         device = FakeDevice(identifiers={(DOMAIN, "does-not-exist")})
-        self.assertEqual(_run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)), {})
+        result = _run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device))
+        # No appliance resolved -- and the dump is dated anyway. Both halves
+        # matter: nothing about the device leaks into the degraded document,
+        # and the document still says when it was taken.
+        self.assertEqual(["generated_at"], list(result))
 
     def test_device_diagnostics_foreign_identifier_ignored(self):
         coord = _build_coordinator()
         hass = FakeHass(coord)
         device = FakeDevice(identifiers={("some_other_domain", WD_ID)})
-        self.assertEqual(_run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)), {})
+        result = _run(diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device))
+        # A foreign integration's identifier resolves nothing here, and the
+        # degraded dump is still dated (see the test above).
+        self.assertEqual(["generated_at"], list(result))
 
 
 class DiagnosticsDriftGuardTest(unittest.TestCase):
@@ -1692,6 +1700,529 @@ class EntityInventoryIdentityTest(unittest.TestCase):
         # side is the code-authored unique_id suffix, never the nickname slug.
         self.assertNotIn("switch.purificatore", encoded)
         self.assertIn("child_lock", encoded)
+
+
+# --- step 1: the shared clock, the shared text bound, the coverage mirror ----
+#
+# `_FrozenClock`, `FROZEN` and `FROZEN_TEXT` below are MODULE-LEVEL and SHARED:
+# the freshness section further down reuses all three. A second `class
+# _FrozenClock` or a second `FROZEN =` later in this file would silently shadow
+# these with no import error and quietly stop patching what the tests above it
+# think it patches, which is the same failure Part 2 describes for `REF_ID`.
+
+
+class _FrozenClock:
+    """Freeze `diagnostics._utcnow` for the duration of a `with` block.
+
+    `_utcnow` exists to be exactly this seam, so an age assertion never has to be
+    written against the wall clock. It also counts its calls, which is how the
+    "one instant for the whole document" claim below is checked rather than
+    assumed. Later sections that assert an age patch the same seam.
+    """
+
+    def __init__(self, moment):
+        self.moment = moment
+        self.calls = 0
+        self._saved = None
+
+    def __enter__(self):
+        self._saved = diagnostics._utcnow
+
+        def _fake():
+            self.calls += 1
+            return self.moment
+
+        diagnostics._utcnow = _fake
+        return self
+
+    def __exit__(self, *exc_info):
+        diagnostics._utcnow = self._saved
+        return False
+
+
+FROZEN = datetime(2026, 8, 13, 7, 9, 40, tzinfo=timezone.utc)
+FROZEN_TEXT = "2026-08-13T07:09:40+00:00"
+
+
+class BoundedTextTest(unittest.TestCase):
+    """`_bounded_text` masks BEFORE it cuts, which is the whole point of it."""
+
+    def test_a_mac_straddling_the_cap_is_still_masked(self):
+        # THE regression this helper exists for, and the one shape every previous
+        # "the MAC is masked" test structurally could not catch: the address does
+        # not start at offset 0, it starts at 70 with the cap at 80. A helper that
+        # cut first would hand `_MAC_RE` ten characters of a seventeen-character
+        # address -- three and a half octets, no longer matching the six-group
+        # pattern -- and ship them to a public issue in cleartext.
+        value = "x" * 70 + "3c:71:bf:bd:32:2c"
+        self.assertEqual("x" * 70 + "***", diagnostics._bounded_text(value, 80))
+        # Not vacuous: cutting first really does leak, on this exact input.
+        self.assertIn("3c:71:bf:b", value[:80])
+
+    def test_no_cut_position_leaks_a_fragment(self):
+        # The one offset above could be a lucky alignment; sweep the whole window
+        # in which the address straddles the boundary.
+        for offset in range(60, 85):
+            value = "x" * offset + "3c:71:bf:bd:32:2c"
+            bounded = diagnostics._bounded_text(value, 80)
+            self.assertNotIn(":", bounded, f"leaked at offset {offset}")
+
+    def test_the_bound_is_still_a_bound(self):
+        self.assertEqual("abcde", diagnostics._bounded_text("abcdefghij", 5))
+        self.assertEqual("abc", diagnostics._bounded_text("abc", 40))
+
+    def test_a_container_is_refused_rather_than_flattened(self):
+        # Not redundant with `_scalar_text`'s own container check: that one runs
+        # AFTER `_jsonable`, which turns a dict into its repr, so it never fires
+        # for a real Mapping. Without the guard in `_bounded_text` the whole
+        # envelope would be flattened into one string under the caller's key,
+        # permanently out of reach of key-based redaction.
+        conn_event = {"macAddress": "AA:BB:CC:DD:EE:FF", "category": "CONNECTED"}
+        self.assertEqual(
+            "{'macAddress': '***', 'category': 'CONNECTED'}",
+            diagnostics._scalar_text(conn_event),
+        )
+        self.assertIsNone(diagnostics._bounded_text(conn_event, 40))
+        self.assertIsNone(diagnostics._bounded_text(["a"], 40))
+        self.assertIsNone(diagnostics._bounded_text(None, 40))
+
+    def test_a_container_inside_a_wrapper_is_refused_too(self):
+        # The shape an outer-only isinstance check cannot see: `_jsonable`
+        # unwraps `.value` before stringifying, and the merged attributes
+        # mapping is made almost entirely of such wrappers, so the guard has to
+        # look through one level as well as at the object itself. Measured with
+        # the outer guard alone, this returned the whole envelope as a string
+        # with `mobileId` in cleartext beside a masked MAC.
+        conn_event = {
+            "macAddress": "AA:BB:CC:DD:EE:FF",
+            "category": "CONNECTED",
+            "mobileId": "phone-install-xyz",
+        }
+        self.assertIsNone(diagnostics._bounded_text(FakeWrapper(conn_event), 200))
+        self.assertIsNone(diagnostics._bounded_text(FakeWrapper(["a"]), 200))
+        self.assertIsNone(diagnostics._bounded_text({"a", "b"}, 200))
+
+    def test_a_wrapper_is_unwrapped_like_any_other_scalar(self):
+        # It routes through _scalar_text, so a HonAttribute-shaped object is
+        # unwrapped rather than stringified as "<object at 0x...>".
+        self.assertEqual("7", diagnostics._bounded_text(FakeWrapper(7), 40))
+
+    def test_a_raising_wrapper_is_refused_rather_than_propagated(self):
+        class Exploding:
+            @property
+            def value(self):
+                raise RuntimeError("boom")
+
+        self.assertIsNone(diagnostics._bounded_text(Exploding(), 40))
+
+
+class StampTextTest(unittest.TestCase):
+    """The single datetime -> ISO text conversion, and what it refuses."""
+
+    def test_an_aware_instant_is_normalised_to_utc(self):
+        moment = datetime(2026, 4, 9, 12, 34, 56, tzinfo=timezone(timedelta(hours=2)))
+        self.assertEqual("2026-04-09T10:34:56+00:00", diagnostics._stamp_text(moment))
+
+    def test_utc_normalisation_is_what_saves_the_field_from_the_mac_mask(self):
+        # A sub-minute offset makes an ISO instant look exactly like a MAC address
+        # to `_MAC_RE`, which runs over every string in the block. This is the
+        # measured reason `astimezone` is correctness and not tidiness.
+        raw = "2026-04-09T12:34:56-05:30:15"
+        self.assertEqual("2026-04-09T***", debug_utils._MAC_RE.sub("***", raw))
+        odd = timezone(-timedelta(hours=5, minutes=30, seconds=15))
+        moment = datetime(2026, 4, 9, 12, 34, 56, tzinfo=odd)
+        text = diagnostics._stamp_text(moment)
+        self.assertEqual("2026-04-09T18:05:11+00:00", text)
+        self.assertEqual(text, debug_utils._MAC_RE.sub("***", text))
+
+    def test_a_naive_instant_is_emitted_as_it_stands(self):
+        # Never shifted onto the host's zone: a reader can reason about an instant
+        # with no offset, but not about one that was quietly moved by however far
+        # the reporter's machine happens to be from UTC.
+        moment = datetime(2020, 9, 29, 10, 1, 26)
+        self.assertEqual("2020-09-29T10:01:26", diagnostics._stamp_text(moment))
+
+    def test_a_tzinfo_with_no_offset_is_treated_as_naive(self):
+        # CPython does NOT raise here: it falls back to the host's local zone and
+        # then labels the result "+00:00". A wrong time wearing an authoritative
+        # offset is worse than a time with no offset at all.
+        class NoOffset(tzinfo):
+            def utcoffset(self, dt):
+                return None
+
+            def tzname(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+        moment = datetime(2020, 9, 29, 10, 1, 26, tzinfo=NoOffset())
+        self.assertEqual("2020-09-29T10:01:26", diagnostics._stamp_text(moment))
+
+    def test_a_tzinfo_that_raises_yields_nothing(self):
+        class Exploding(tzinfo):
+            def utcoffset(self, dt):
+                raise RuntimeError("boom")
+
+        moment = datetime(2020, 9, 29, 10, 1, 26, tzinfo=Exploding())
+        self.assertIsNone(diagnostics._stamp_text(moment))
+
+    def test_a_datetime_subclass_cannot_smuggle_a_string(self):
+        # `isinstance` admits subclasses and a subclass may override isoformat, so
+        # the OUTPUT is validated too. Without that, this string would be copied
+        # verbatim into a document about to be attached to a public issue.
+        class Smuggler(datetime):
+            def isoformat(self, *args, **kwargs):
+                return "user@example.com"
+
+        self.assertIsNone(diagnostics._stamp_text(Smuggler(2026, 4, 9)))
+
+    def test_an_over_long_output_is_refused(self):
+        class Verbose(datetime):
+            def isoformat(self, *args, **kwargs):
+                return "2026-04-09T05:34:16+00:00" + "!" * 40
+
+        self.assertIsNone(diagnostics._stamp_text(Verbose(2026, 4, 9)))
+
+    def test_a_digits_only_shape_is_refused_too(self):
+        # `_ISO_RE` is narrow on purpose: it requires the 'T' separator, which a
+        # real `isoformat()` always produces, so the only shapes it admits are
+        # the ones a datetime can actually make. A subclass returning something
+        # that merely looks date-ish does not get through.
+        class Loose(datetime):
+            def isoformat(self, *args, **kwargs):
+                return "1234-56-78 90:12:34"
+
+        self.assertIsNone(diagnostics._stamp_text(Loose(2026, 4, 9)))
+
+    def test_a_cloud_string_instant_is_refused_by_design(self):
+        # `lastConnEvent.instantTime` is a cloud-chosen STRING. This helper's whole
+        # promise is that its output came out of datetime.isoformat; echoing a
+        # cloud string here would break that promise and look identical in the dump.
+        self.assertIsNone(diagnostics._stamp_text("2026-04-09T05:34:16Z"))
+        self.assertIsNone(diagnostics._stamp_text(1775712856741))
+        self.assertIsNone(diagnostics._stamp_text(None))
+
+
+class AsUtcTest(unittest.TestCase):
+    """`_as_utc` is the one place awareness is decided, so ages cannot raise."""
+
+    def test_an_aware_instant_is_converted(self):
+        moment = datetime(2026, 4, 9, 12, 0, tzinfo=timezone(timedelta(hours=2)))
+        self.assertEqual(
+            datetime(2026, 4, 9, 10, 0, tzinfo=timezone.utc),
+            diagnostics._as_utc(moment, False),
+        )
+
+    def test_a_naive_instant_follows_the_stated_policy(self):
+        naive = datetime(2026, 4, 9, 12, 0)
+        self.assertIsNone(diagnostics._as_utc(naive, False))
+        self.assertEqual(
+            datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc),
+            diagnostics._as_utc(naive, True),
+        )
+
+    def test_a_non_datetime_is_refused(self):
+        self.assertIsNone(diagnostics._as_utc("2026-04-09T12:00:00Z", True))
+        self.assertIsNone(diagnostics._as_utc(None, True))
+        self.assertIsNone(diagnostics._as_utc(1775712856741, True))
+
+    def test_a_subclass_that_refuses_to_be_normalised_is_refused(self):
+        # Everything that touches the value is inside the one guard, including
+        # the `replace` on the naive branch: the callers downstream feed this
+        # helper cloud-supplied objects, and an unguarded call there does not
+        # produce a wrong age, it produces no dump at all.
+        class Hostile(datetime):
+            def replace(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        self.assertIsNone(diagnostics._as_utc(Hostile(2026, 4, 9), True))
+
+    def test_the_result_can_always_be_subtracted_from_now(self):
+        # The property the helper exists for: whatever it returns is aware, so the
+        # subtraction every age is built on cannot raise TypeError.
+        for value in (
+            datetime(2026, 4, 9, 12, 0),
+            datetime(2026, 4, 9, 12, 0, tzinfo=timezone(timedelta(hours=-3))),
+        ):
+            converted = diagnostics._as_utc(value, True)
+            self.assertIsNotNone(converted)
+            (FROZEN - converted).total_seconds()  # must not raise
+
+
+class DumpTimestampTest(unittest.TestCase):
+    """Every document this module produces says when it was taken."""
+
+    def test_the_entry_dump_is_dated_and_dated_first(self):
+        with _FrozenClock(FROZEN):
+            result, _ = _entry_diag()
+        self.assertEqual("generated_at", next(iter(result)))
+        self.assertEqual(FROZEN_TEXT, result["generated_at"])
+
+    def test_the_stamp_is_aware_utc(self):
+        result, _ = _entry_diag()
+        self.assertTrue(result["generated_at"].endswith("+00:00"))
+
+    def test_the_whole_document_shares_one_instant(self):
+        # Two appliances, one clock read. A per-block read would let two ages in
+        # one document disagree by however long the dump took to build.
+        with _FrozenClock(FROZEN) as clock:
+            result, blocks = _entry_diag()
+        self.assertEqual(2, len(blocks))
+        self.assertEqual(1, clock.calls)
+
+    def test_the_device_dump_is_dated_and_dated_first(self):
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, WD_ID)})
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+            )
+        self.assertEqual(["generated_at", "appliance"], list(result))
+        self.assertEqual(FROZEN_TEXT, result["generated_at"])
+
+    def test_a_degraded_device_dump_is_still_dated(self):
+        # The dump most likely to be pasted into an issue as "the download gave me
+        # nothing" used to be the only undated one in the integration.
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, "does-not-exist")})
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+            )
+        self.assertEqual({"generated_at": FROZEN_TEXT}, result)
+
+    def test_a_device_dump_with_no_coordinator_data_is_still_dated(self):
+        # The second early return: the appliance id resolves but the coordinator
+        # holds nothing for it.
+        hass = FakeHass(FakeCoordinator({WD_ID: "not-a-mapping"}))
+        device = FakeDevice(identifiers={(DOMAIN, WD_ID)})
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+            )
+        self.assertEqual({"generated_at": FROZEN_TEXT}, result)
+
+    def test_no_identity_reaches_a_degraded_dump(self):
+        # A dated degraded dump must still be a degraded dump: the identifier that
+        # failed to resolve is not echoed back as evidence of what was looked for.
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, "PLAINTEXT-SERIAL")})
+        result = _run(
+            diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+        )
+        self.assertNotIn("PLAINTEXT-SERIAL", json.dumps(result))
+
+    def test_a_block_built_with_no_clock_is_still_dated_downstream(self):
+        # The two-positional-argument call site still works, and falls back to the
+        # seam rather than to a naive value.
+        with _FrozenClock(FROZEN) as clock:
+            diagnostics._appliance_block(
+                "id1",
+                {"appliance": None, "type": "AC", "attributes": {}, "statistics": {}},
+            )
+        self.assertEqual(1, clock.calls)
+
+    def test_a_naive_clock_is_promoted_not_refused(self):
+        # A caller handing in a naive datetime gets a block, not a TypeError:
+        # `_appliance_block` normalises at its boundary. Regression against the
+        # aware/naive subtraction that would take the whole dump down.
+        block = diagnostics._appliance_block(
+            "id1",
+            {"appliance": None, "type": "AC", "attributes": {}, "statistics": {}},
+            None,
+            datetime(2026, 8, 13, 7, 9, 40),
+        )
+        self.assertEqual("AC", block["type"])
+
+    def test_a_junk_clock_does_not_break_the_block(self):
+        for junk in ("2026-08-13", 0, object()):
+            block = diagnostics._appliance_block(
+                "id1",
+                {"appliance": None, "type": "AC", "attributes": {}, "statistics": {}},
+                None,
+                junk,
+            )
+            self.assertEqual("AC", block["type"])
+
+
+class CoverageExpectedAbsentTest(unittest.TestCase):
+    """The mirror axis: what this code maps and the device does not have."""
+
+    def test_a_mapped_attribute_the_device_omits_is_named(self):
+        # The WD fixture publishes machMode but neither bare key the mean-water
+        # consumption sensor reads, so the sensor exists and can never have a
+        # value. That is the "why is the control I expected not there" question.
+        _, blocks = _entry_diag()
+        absent = blocks["WD"]["coverage"]["attributes_expected_absent"]
+        self.assertIn("totalWashCycle", absent)
+        self.assertIn("totalWaterUsed", absent)
+        self.assertNotIn("machMode", absent)
+
+    def test_a_mapped_command_param_the_device_omits_is_named(self):
+        _, blocks = _entry_diag()
+        absent = blocks["WD"]["coverage"]["command_params_expected_absent"]
+        self.assertIn("prCode", absent)
+        self.assertNotIn("program", absent)
+
+    def test_the_lists_are_sorted_and_are_plain_strings(self):
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            for key in ("attributes_expected_absent", "command_params_expected_absent"):
+                names = block["coverage"][key]
+                self.assertIsInstance(names, list)
+                self.assertEqual(sorted(names), names)
+                for name in names:
+                    self.assertIsInstance(name, str)
+
+    def test_the_mirror_never_names_something_the_device_publishes(self):
+        # The invariant in one assertion, over every appliance in the fixture: a
+        # name in either list must not be findable anywhere else in the same
+        # block. A reader who can disprove a finding by scrolling down stops
+        # trusting the section. Note this one is a DRIFT GUARD rather than a
+        # behaviour test -- it restates the set difference the code performs, so
+        # it cannot fail while the implementation is that difference. The test
+        # below it is the one that discriminates.
+        _, blocks = _entry_diag()
+        for app_type, block in blocks.items():
+            bare = {k for k in block["attributes"] if "." not in k}
+            declared = set()
+            for params in block["commands"].values():
+                declared.update(params)
+            for name in block["coverage"]["attributes_expected_absent"]:
+                self.assertNotIn(name, bare, f"{app_type}: {name} is published")
+            for name in block["coverage"]["command_params_expected_absent"]:
+                self.assertNotIn(name, declared, f"{app_type}: {name} is declared")
+
+    def test_a_param_under_a_non_settings_command_is_not_reported_absent(self):
+        # The specific shape the invariant above exists to catch, and the ONLY
+        # test in this class that discriminates: measured against the settings
+        # params alone, the mirror named `program` and `prCode` on every wash
+        # appliance and `onOffStatus` on the air purifier, while the same dump
+        # printed them under `commands` a few lines below. Do not delete this as
+        # redundant with the invariant above -- the shared fixture has no
+        # `startProgram` command, so the invariant passes even when the mirror
+        # is measured against the wrong universe.
+        appliance = FakeAppliance(
+            commands={
+                "settings": FakeCommand({"spinSpeed": FakeParam(value="1000")}),
+                "startProgram": FakeCommand({
+                    "program": FakeParam(value="9"),
+                    "prCode": FakeParam(value="14"),
+                }),
+            }
+        )
+        block = diagnostics._appliance_block(
+            "id1",
+            {
+                "appliance": appliance,
+                "type": "WD",
+                "attributes": {},
+                "statistics": {},
+            },
+        )
+        absent = block["coverage"]["command_params_expected_absent"]
+        self.assertEqual([], absent)
+
+    def test_a_device_that_publishes_everything_it_maps_reports_nothing(self):
+        # The empty case, derived rather than hand-listed so it cannot rot when a
+        # table gains a row: ask the block what it expected, hand exactly that
+        # back as the device's shadow, and the mirror must fall silent.
+        def _block(attributes):
+            return diagnostics._appliance_block(
+                "id1",
+                {
+                    "appliance": FakeApplianceNoModel(commands={}),
+                    "type": "HO",
+                    "attributes": attributes,
+                    "statistics": {},
+                },
+            )
+
+        expected = _block({})["coverage"]["attributes_expected_absent"]
+        self.assertTrue(expected, "the empty case would be vacuous")
+        complete = _block({name: "0" for name in expected})
+        self.assertEqual([], complete["coverage"]["attributes_expected_absent"])
+        self.assertEqual([], complete["coverage"]["command_params_expected_absent"])
+
+    def test_the_mirror_survives_an_appliance_with_no_commands_at_all(self):
+        # A dump must degrade, never raise: a foreign appliance object with no
+        # `commands` surface still produces both lists.
+        block = diagnostics._appliance_block(
+            "id1",
+            {"appliance": object(), "type": "WD", "attributes": {}, "statistics": {}},
+        )
+        cov = block["coverage"]
+        self.assertIn("prCode", cov["command_params_expected_absent"])
+        self.assertIn("program", cov["command_params_expected_absent"])
+
+    def test_a_raising_parameters_property_is_skipped_not_propagated(self):
+        # `_command_param_names` walks commands that nothing else in the dump
+        # reads first, so it is asserted here directly rather than through a
+        # block.
+        #
+        # Scope note, verified on HEAD: this guard is a BACKSTOP, not the dump's
+        # protection. `_command_schema` reads `.parameters` on EVERY command --
+        # settings and startProgram alike -- above `_coverage` in
+        # `_appliance_block`, so through the real call path a raising property
+        # kills the dump before this helper runs. Confirmed on this same
+        # appliance: `_appliance_block` propagates RuntimeError. That exposure
+        # predates this change and is not fixed here; what the guard buys is
+        # that the helper cannot ADD a way to fail.
+        class Exploding:
+            @property
+            def parameters(self):
+                raise RuntimeError("boom")
+
+        appliance = FakeAppliance(
+            commands={
+                "startProgram": Exploding(),
+                "settings": FakeCommand({"spinSpeed": FakeParam(value="1")}),
+            }
+        )
+        self.assertEqual({"spinSpeed"}, diagnostics._command_param_names(appliance))
+
+    def test_a_commands_mapping_whose_values_view_raises_is_survived(self):
+        # The one way this helper could have ADDED a crash: `_command_schema`
+        # walks the same mapping with `.items()` and `_settings_param_names`
+        # with `.get(name)`, so an object that only breaks on `.values()` gets
+        # past both of them and would have died here.
+        class RaisingValues(dict):
+            def values(self):
+                raise RuntimeError("boom")
+
+        appliance = FakeAppliance(
+            commands=RaisingValues({"settings": FakeCommand({"spinSpeed": FakeParam(value="1")})})
+        )
+        self.assertEqual(set(), diagnostics._command_param_names(appliance))
+        block = diagnostics._appliance_block(
+            "id1",
+            {"appliance": appliance, "type": "WD", "attributes": {}, "statistics": {}},
+        )
+        self.assertEqual("WD", block["type"])
+
+    def test_the_mirror_carries_no_identity(self):
+        # Both lists are differences taken FROM the static tables, so nothing the
+        # cloud chose can reach them. Pinned, because a future edit that started
+        # listing device-side names would be a silent privacy change.
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            encoded = json.dumps(
+                {
+                    k: block["coverage"][k]
+                    for k in (
+                        "attributes_expected_absent",
+                        "command_params_expected_absent",
+                    )
+                }
+            )
+            self.assertNotIn("PLAINTEXT", encoded)
+            self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+            for name in json.loads(encoded)["attributes_expected_absent"]:
+                self.assertRegex(name, r"^[A-Za-z][A-Za-z0-9_]*$")
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -676,20 +676,51 @@ class DiagnosticsRedactionTest(unittest.TestCase):
         self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["code"], "***")
         self.assertEqual(blocks["WD"]["attributes"]["deviceInfo"]["label"], "ok")
 
+    # NAMED on purpose, never `for key in _TO_REDACT`: a loop over the constant proves
+    # every SURVIVING member still works but goes quiet when a member is removed.
+    # Measured: deleting mac_address / mobile_id / serial_number / transaction_id from
+    # _TO_REDACT, _IDENTITY_KEYS and the old test pin together left the WHOLE suite
+    # green -- they were the four names of the twenty that this list did not cover.
+    _MUST_MASK = (
+        "serial", "serialnumber", "serial_number",
+        "mac", "macaddress", "mac_address",
+        "code", "nickname", "nick_name", "email",
+        "password", "token", "access_token", "refresh_token",
+        "authorization", "secret",
+        "transactionid", "transaction_id", "mobileid", "mobile_id",
+    )
+
     def test_credential_key_names_are_redacted_anywhere_they_appear(self):
         """The entry envelope redacts with explicit literals, so the CREDENTIAL half
         of `_TO_REDACT` is reachable only through this generic path: a credential
         arriving under one of these names inside an appliance's attributes or a
         nested cloud payload. Deleting all nine names left the full suite green.
+
+        Widened from nine names to all twenty: the eleven that were missing had no
+        behavioural observer on EITHER redaction path, only a set-equality pin that
+        any consistent edit silences.
         """
-        for key in ("password", "token", "access_token", "refresh_token",
-                    "authorization", "secret", "email", "nickname", "nick_name"):
+        for key in self._MUST_MASK:
             self.assertEqual(
                 "***", diagnostics._redact({key: "s3cret"})[key], key
             )
             # and one level down, where a cloud payload actually carries them
             nested = diagnostics._redact({"attributes": {key: "s3cret"}})
             self.assertEqual("***", nested["attributes"][key], key)
+        # positive control: a non-identity sibling must survive, so the loop above
+        # cannot pass by _redact masking everything it is handed.
+        self.assertEqual("ok", diagnostics._redact({"label": "ok"})["label"])
+
+    def test_every_redacted_key_has_a_behavioural_assertion(self):
+        """Replaces nothing -- this is the assertion the drift guard only approximates.
+
+        `IdentityKeysDriftGuardTest` compares `_TO_REDACT` to `_IDENTITY_KEYS`: one
+        constant against another. Because the two sets are IDENTICAL it fires for all
+        twenty names and separates nothing, and an edit touching both is invisible to
+        it. This ties the constant to the list that actually DRIVES `_redact`, so a
+        name added to `_TO_REDACT` fails here until it is given a real assertion.
+        """
+        self.assertEqual(set(self._MUST_MASK), set(diagnostics._TO_REDACT))
 
     def test_command_history_value_borne_identity_redacted(self):
         _, blocks = _entry_diag()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1125,16 +1125,28 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
         """
         from custom_components.addhon import error_codes as ec
 
-        class _Client:
-            last_error_code = ec.NETWORK_TIMEOUT       # 400, outside the band
-            last_error_phase = "mfa_send"
-            last_mfa_summary = {"challenge_kind": "email", "can_resend": True}
-            _refresh_token = ""
+        # BOTH edges. "Outside the band" is a two-sided statement and only the
+        # upper side used to be sampled, so `160 <= code` could be deleted --
+        # or written `code <= 169` -- with the whole repository green. The lower
+        # half is the reachable one: `classify()`'s auth cascade
+        # (error_codes.py:420-429) answers 100/110/120/130/140 for exactly the
+        # "token-after-verify" failure this docstring names, and hon_client.py:748
+        # assigns it with `last_mfa_summary` still set.
+        for code in (ec.INVALID_CREDENTIALS, ec.NETWORK_TIMEOUT):  # 100 below, 400 above
+            with self.subTest(code=code.code):
 
-        hass = FakeHass(_build_coordinator())
-        hass.data[DOMAIN]["e1"]["client"] = _Client()
-        result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
-        self.assertNotIn("mfa", result["last_error"])
+                class _Client:
+                    last_error_code = code
+                    last_error_phase = "mfa_send"
+                    last_mfa_summary = {"challenge_kind": "email", "can_resend": True}
+                    _refresh_token = ""
+
+                hass = FakeHass(_build_coordinator())
+                hass.data[DOMAIN]["e1"]["client"] = _Client()
+                result = _run(
+                    diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+                )
+                self.assertNotIn("mfa", result["last_error"])
 
 
 # --- Task 10: air purifier coverage and passive future-capability capture -----
@@ -3033,9 +3045,25 @@ class EntitySourceTest(unittest.TestCase):
         # Narrowing there would turn "not looked" into "the device does not
         # declare it", which is the one substitution every section of this dump
         # refuses to make.
+        #
+        # The first assertion is the one that makes the rest reach production.
+        # `_entity_section` has a single caller (diagnostics.py:1882) and it
+        # always passes `_declared_command_params(appliance)`, so the rule is
+        # only held if THAT helper can express "unread". While it answered `{}`
+        # for an unreadable schema the guard below was dead on the only path
+        # that runs: `{}` is a Mapping, so the row was narrowed to null anyway.
+        class _Unreadable:  # an appliance whose command schema cannot be read
+            commands = "not a mapping"
+
+        self.assertIsNone(diagnostics._declared_command_params(_Unreadable()))
         section = _stop_button_section(None)
         self.assertEqual(
             {"write": ["onOffStatus"]}, section["sources"]["button.stop_program"]
+        )
+        # ... and the appliance that WAS read and declares nothing still
+        # narrows, so the two states stay distinguishable in the dump.
+        self.assertIsNone(
+            _stop_button_section({"stopProgram": []})["sources"]["button.stop_program"]
         )
 
     def test_the_purifier_fan_reads_power_without_claiming_to_write_it(self) -> None:
@@ -3339,9 +3367,32 @@ class RegistryDegradationTest(unittest.TestCase):
             attrs, params, index, missing = diagnostics._mapped_sets("REF")
         self.assertIsNone(index)
         self.assertEqual(list(_PLATFORM_MODULES), missing)
-        # No seed survives a total collapse: every mapped name comes from a walk.
+        # REF carries no static seed, so every mapped name it has comes from a
+        # walk and a total collapse leaves nothing.
         self.assertEqual(set(), attrs)
         self.assertEqual(set(), params)
+        # The general sentence "no seed survives a collapse" is FALSE, and
+        # measuring it on REF alone cannot show that: `mapped_params |=
+        # _AC_CLIMATE_PARAMS` and `mapped_params.update(PROGRAM_PARAM_NAMES)`
+        # are unconditional, so AC and the wash group keep names with all seven
+        # modules gone. That is deliberate, and the rule this pins is "nothing
+        # BEYOND the declared seeds" -- an invented one would subtract names
+        # from `command_params_unmapped` in the same block whose
+        # `registries_unavailable` says nothing could be read.
+        for app_type, seed in (
+            ("AC", set(diagnostics._AC_CLIMATE_PARAMS)),
+            ("WM", set(diagnostics.PROGRAM_PARAM_NAMES)),
+            ("TD", set(diagnostics.PROGRAM_PARAM_NAMES)),
+            ("WD", set(diagnostics.PROGRAM_PARAM_NAMES)),
+        ):
+            with self.subTest(app_type=app_type):
+                with _BrokenModules(*_PLATFORM_MODULES):
+                    seeded_attrs, seeded_params, seeded_index, _m = (
+                        diagnostics._mapped_sets(app_type)
+                    )
+                self.assertIsNone(seeded_index)
+                self.assertEqual(set(), seeded_attrs)
+                self.assertEqual(seed, seeded_params)
 
     def test_a_lost_table_gives_its_entities_one_null_each(self) -> None:
         # The AC louvers are the case that shows the difference: `select` gone,
@@ -4006,6 +4057,18 @@ class DescriptionTableCompletenessTest(unittest.TestCase):
         # An exemption that has stopped being true is worse than none: it is a
         # written promise about a dump nobody re-reads. The day the table is
         # deleted, or wired into the walk, this fails and the entry goes.
+        #
+        # Skipped rather than silently green while there is nothing to check.
+        # With an empty whitelist the loop below never runs and NEITHER
+        # assertion is ever evaluated, so the suite reported an enforced rule
+        # that had never executed -- and still paid `_unwalked_description_tables()`,
+        # which plants probes over 62 module globals and runs `_mapped_sets` 17
+        # times, purely to discard the result. The skip is what arms this the
+        # day an entry is added.
+        if not _TABLES_OUTSIDE_COVERAGE:
+            self.skipTest(
+                "`_TABLES_OUTSIDE_COVERAGE` is empty: no exemption to re-check."
+            )
         unwalked = _unwalked_description_tables()
         for qname, reason in _TABLES_OUTSIDE_COVERAGE.items():
             self.assertIn(
@@ -5521,20 +5584,29 @@ class AttributeValuesDedupTest(unittest.TestCase):
         # The other half of the docstring's reason for `is`: an `__eq__` this
         # module does not control is free to raise, and the dedupe must not be
         # the thing that costs the reporter the file.
+        # The call is RECORDED, not inferred from the outcome. Inferring it
+        # does not work: a check that consults `__eq__` and swallows the raise
+        # as "equal" drops the map too, so the assertion below would pass with
+        # the foreign `__eq__` entered on every key -- which is the whole thing
+        # this test exists to forbid, and is also the exact kill the sibling
+        # above already makes.
+        calls = []
+
         class _HostileEq:
             def __init__(self, value):
                 self.value = value
                 self.last_update = AC_STAMP_OLD
 
             def __eq__(self, other):
+                calls.append(other)
                 raise RuntimeError("boom")
 
             __hash__ = None
 
         shared = _HostileEq("4")
         block = _stamp_block({"tempZ1": shared, "parameters": {"tempZ1": shared}})
-        # Same object bare and nested -> redundant -> dropped, and `__eq__` was
-        # never consulted (it would have raised).
+        self.assertEqual([], calls)
+        # Same object bare and nested -> redundant -> dropped.
         self.assertNotIn("parameters", block["attributes"])
 
     def test_the_live_merge_binds_the_same_object_bare_and_nested(self):
@@ -5677,9 +5749,20 @@ class TheNestedParametersContainerIsAlwaysAPlainDictTest(unittest.TestCase):
         # both helpers decline to walk). AC is used because it has no per-type
         # layer in `client/engine/appliances/registry.py`, so nothing rejects
         # the value before it lands: it is the most permissive path there is.
-        for value in ([], "abc", 5, 1.5, True, None, {}, {"x": "1"}):
-            with self.subTest(value=value):
-                landed = self._appliance("AC", value).attributes.get("parameters")
+        # The values come FROM a decode, not from literals. Written as literals
+        # the six non-dict subcases could not fail whatever the engine did with
+        # them -- `not isinstance(landed, Mapping)` was already true of the
+        # tuple this test wrote, and the engine hands the key straight back by
+        # identity -- so they measured the fixture and not the code. Decoding
+        # them here pins the premise the claim actually rests on.
+        for text in ('[]', '"abc"', '5', '1.5', 'true', 'null', '{}', '{"x": "1"}'):
+            with self.subTest(text=text):
+                decoded = json.loads(text)
+                self.assertTrue(
+                    type(decoded) is dict or not isinstance(decoded, Mapping),
+                    f"json.loads produced a {type(decoded).__name__}",
+                )
+                landed = self._appliance("AC", decoded).attributes.get("parameters")
                 self.assertTrue(
                     type(landed) is dict or not isinstance(landed, Mapping),
                     f"a {type(landed).__name__} reached the dead fallback",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2556,6 +2556,24 @@ def _static_parameter_names() -> set[str]:
     return names
 
 
+def _stop_button_section(commands: dict | None) -> dict:
+    """The `entities` section for a dryer carrying `commands`, or an unread one.
+
+    `commands` maps a command name to the parameter names the DEVICE declares
+    under it -- the shape `_declared_command_params` returns. `None` stands for
+    "the schema could not be read", which must not be confused with "the device
+    declares nothing".
+    """
+    inventory = {
+        "status": "ok",
+        "by_domain": {"button": ["stop_program"], "switch": ["pause"]},
+    }
+    declared = (
+        None if commands is None else {name: set(p) for name, p in commands.items()}
+    )
+    return diagnostics._entity_section(inventory, "TD", None, declared)
+
+
 class EntitySourceTest(unittest.TestCase):
     """`entities.sources`: which raw parameter each registered entity speaks to."""
 
@@ -2686,9 +2704,48 @@ class EntitySourceTest(unittest.TestCase):
         # `button.stop_program` fixes onOffStatus="0" on the command it sends,
         # and that write appears in NO other section of the dump. Its sibling
         # fixes nothing, so it stays null rather than being given the same row.
+        # This is the TYPE-level claim; whether the device declares the name is
+        # decided per appliance, in `_entity_section` -- see the two tests below.
         index = diagnostics._mapped_sets("WD")[2]
         self.assertEqual({"write": ["onOffStatus"]}, index["button.stop_program"])
         self.assertIsNone(index["button.start_program"])
+
+    def test_a_stop_button_keeps_the_write_the_device_declares(self) -> None:
+        # The live washer: `stopProgram` carries `onOffStatus`, so the button
+        # really does fix it and the row is true as it stands.
+        section = _stop_button_section({"stopProgram": ("onOffStatus",)})
+        self.assertEqual(
+            {"write": ["onOffStatus"]}, section["sources"]["button.stop_program"]
+        )
+
+    def test_a_stop_button_claims_no_write_the_device_cannot_perform(self) -> None:
+        # The live dryer: `stopProgram` carries `returnStandby` and nothing
+        # else, and `button.py` applies a fixed parameter only `if name in
+        # params`, so the button fixes NOTHING there. `onOffStatus` is published
+        # as a bare attribute on that dryer, so a reader chasing the row would
+        # find the name and conclude the button works. Null is the same
+        # statement `select.program` already makes: the entity exists and this
+        # dump cannot name a parameter for it.
+        section = _stop_button_section({"stopProgram": ("returnStandby",)})
+        self.assertIsNone(section["sources"]["button.stop_program"])
+        # The narrowing is surgical: a sibling row on the same appliance is
+        # untouched, so this cannot be mistaken for the whole index degrading.
+        self.assertEqual(
+            {"read": ["machMode"], "write": ["pause"]},
+            section["sources"]["switch.pause"],
+        )
+
+    def test_a_stop_button_row_is_never_narrowed_on_a_lookup_that_did_not_happen(
+        self,
+    ) -> None:
+        # `declared=None` means the caller could not read the command schema.
+        # Narrowing there would turn "not looked" into "the device does not
+        # declare it", which is the one substitution every section of this dump
+        # refuses to make.
+        section = _stop_button_section(None)
+        self.assertEqual(
+            {"write": ["onOffStatus"]}, section["sources"]["button.stop_program"]
+        )
 
     def test_the_purifier_fan_reads_power_without_claiming_to_write_it(self) -> None:
         # Power is a whole-COMMAND action on the AP (startProgram / stopProgram,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1816,6 +1816,15 @@ class BoundedTextTest(unittest.TestCase):
         )
         self.assertIsNone(diagnostics._bounded_text(conn_event, 40))
         self.assertIsNone(diagnostics._bounded_text(["a"], 40))
+
+        # A bare Mapping is caught by EITHER of the two container guards, so the
+        # assertions above cannot tell them apart and the outer one can be
+        # deleted with the file still green. This envelope also exposes `.value`,
+        # so the inner guard reads a scalar and only the outer guard can refuse it.
+        class _Envelope(dict):
+            value = "CONNECTED"
+
+        self.assertIsNone(diagnostics._bounded_text(_Envelope(conn_event), 40))
         self.assertIsNone(diagnostics._bounded_text(None, 40))
 
     def test_a_container_inside_a_wrapper_is_refused_too(self):
@@ -1940,10 +1949,36 @@ class AsUtcTest(unittest.TestCase):
     """`_as_utc` is the one place awareness is decided, so ages cannot raise."""
 
     def test_an_aware_instant_is_converted(self):
+        # Aware datetimes compare by ABSOLUTE INSTANT, so an assertEqual against
+        # the converted value is satisfied whether or not the conversion happened.
+        # The representation is what has to be asserted: tzinfo and isoformat are
+        # the only observations that can tell `astimezone(utc)` from `return value`.
         moment = datetime(2026, 4, 9, 12, 0, tzinfo=timezone(timedelta(hours=2)))
+        converted = diagnostics._as_utc(moment, False)
+        self.assertEqual(datetime(2026, 4, 9, 10, 0, tzinfo=timezone.utc), converted)
+        self.assertEqual(timezone.utc, converted.tzinfo)
+        self.assertEqual("2026-04-09T10:00:00+00:00", converted.isoformat())
+
+    def test_a_tzinfo_with_no_offset_is_treated_as_naive(self):
+        # The half of the documented policy nothing exercised. A tzinfo whose
+        # `utcoffset()` returns None does NOT raise: CPython falls back to the
+        # HOST zone, so guarding on `tzinfo is not None` would move the instant
+        # by however far the reporter is from UTC and then label it '+00:00'.
+        class NoOffset(tzinfo):
+            def utcoffset(self, dt):
+                return None
+
+            def tzname(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+        moment = datetime(2020, 9, 29, 10, 1, 26, tzinfo=NoOffset())
+        self.assertIsNone(diagnostics._as_utc(moment, False))
         self.assertEqual(
-            datetime(2026, 4, 9, 10, 0, tzinfo=timezone.utc),
-            diagnostics._as_utc(moment, False),
+            datetime(2020, 9, 29, 10, 1, 26, tzinfo=timezone.utc),
+            diagnostics._as_utc(moment, True),
         )
 
     def test_a_naive_instant_follows_the_stated_policy(self):
@@ -2120,14 +2155,56 @@ class CoverageExpectedAbsentTest(unittest.TestCase):
         # below it is the one that discriminates.
         _, blocks = _entry_diag()
         for app_type, block in blocks.items():
-            bare = {k for k in block["attributes"] if "." not in k}
+            published = set(block["attributes"])
+            bare = {k for k in published if "." not in k}
+            # The attribute axis does NOT subtract bare keys, it subtracts
+            # `reachable`: bare keys PLUS every mapped name whose multi-link read
+            # chain reaches a DOTTED spelling the device publishes. Filtering
+            # every dotted key out of the comparison is exactly where the false
+            # positives live -- the live TD publishes `tumblingStatus` only as
+            # `settings.tumblingStatus`/`startProgram.tumblingStatus`, the live
+            # WM `delayTime` only as `startProgram.delayTime`.
+            #
+            # `settings.<name>` is excluded: it is the COMMAND-parameter mirror,
+            # which no entity reads and which the attribute axis subtracts on
+            # purpose (a writable param is absent from the READ axis even when
+            # its settings twin is printed -- `spinSpeed` on the WD fixture).
+            dotted_tails = {
+                k.split(".", 1)[1]
+                for k in published
+                if "." in k and not k.startswith("settings.")
+            }
             declared = set()
             for params in block["commands"].values():
                 declared.update(params)
             for name in block["coverage"]["attributes_expected_absent"]:
                 self.assertNotIn(name, bare, f"{app_type}: {name} is published")
+                self.assertNotIn(
+                    name,
+                    dotted_tails,
+                    f"{app_type}: {name} is published as a dotted spelling",
+                )
             for name in block["coverage"]["command_params_expected_absent"]:
                 self.assertNotIn(name, declared, f"{app_type}: {name} is declared")
+
+    def test_a_mapped_name_published_only_under_a_dotted_spelling_is_not_absent(self):
+        # The behaviour test behind the `reachable` rule, which nothing pinned.
+        # On the live 2026-06-22 TD `tumblingStatus` exists ONLY as
+        # `settings.tumblingStatus` / `startProgram.tumblingStatus`, and the
+        # option switch reads it through that chain, so it is present, not
+        # absent. A single-link chain keeps the strict bare test.
+        block = diagnostics._appliance_block(
+            "id1",
+            {
+                "appliance": FakeApplianceNoModel(commands={}),
+                "type": "TD",
+                "attributes": {"startProgram.tumblingStatus": "1"},
+                "statistics": {},
+            },
+        )
+        absent = block["coverage"]["attributes_expected_absent"]
+        self.assertNotIn("tumblingStatus", absent)
+        self.assertTrue(absent, "the empty case would be vacuous")
 
     def test_a_param_under_a_non_settings_command_is_not_reported_absent(self):
         # The specific shape the invariant above exists to catch, and the ONLY
@@ -2556,6 +2633,37 @@ class EntitySourceTest(unittest.TestCase):
         self.assertNotIn("switch.pause", ref_index)
         self.assertIn("climate.climate", diagnostics._mapped_sets("AC")[2])
         self.assertIn("switch.pause", diagnostics._mapped_sets("WD")[2])
+        # Both tags above come from ONE code path -- the `_CUSTOM_ENTITY_SOURCES`
+        # type filter. The registry walk builds type-scoped rows through three
+        # OTHER mechanisms (the `app_type == APPLIANCE_AC` louver block, the
+        # `app_type == APPLIANCE_AP` fixed-key block, and the per-desc `types`
+        # filter), and a general-sounding name over a single-path check is how a
+        # leak from one of the others ships unnoticed. Assert the property over
+        # every type instead of sampling it.
+        owners: dict[str, set[str]] = {}
+        for app_type in ("REF", "AC", "WD", "AP", "WC", "OV", "HO", "TD", "WM"):
+            for tag in diagnostics._mapped_sets(app_type)[2]:
+                owners.setdefault(tag, set()).add(app_type)
+        self.assertEqual({"AC"}, owners["select.fan_direction_vertical"])
+        self.assertEqual({"AC"}, owners["select.fan_direction_horizontal"])
+        self.assertEqual({"AC"}, owners["climate.climate"])
+        self.assertEqual({"AP"}, owners["fan.purifier"])
+        self.assertEqual({"WM", "WD", "TD"}, owners["switch.pause"])
+
+    def test_the_binary_sensor_rows_name_the_parameters_they_read(self) -> None:
+        # 63 of the 381 names this section emits are binary_sensor rows, and
+        # nothing asserted a single one: the whole walk could be deleted, or
+        # `binary_sensor.connectivity` pointed at another parameter, and the
+        # suite stayed green. One row from each of the three tables that build
+        # them -- the per-type registry, the universal connectivity row, and the
+        # gated universal row.
+        ref_index = diagnostics._mapped_sets("REF")[2]
+        self.assertEqual({"read": ["doorStatusZ1"]}, ref_index["binary_sensor.door_zone1"])
+        self.assertEqual({"read": ["available"]}, ref_index["binary_sensor.connectivity"])
+        self.assertEqual(
+            {"read": ["remoteCtrValid"]},
+            diagnostics._mapped_sets("WD")[2]["binary_sensor.remote_control"],
+        )
 
     def test_a_stop_button_names_the_parameter_it_writes(self) -> None:
         # `button.stop_program` fixes onOffStatus="0" on the command it sends,
@@ -2762,10 +2870,12 @@ class EntitySourceDriftGuardTest(unittest.TestCase):
         allowed = _static_parameter_names()
         self.assertIn("tempSelZ3", allowed)  # not vacuous
         seen = 0
+        swept_domains: dict[str, set[str]] = {}
         for app_type in ("REF", "AC", "WD", "AP", "WC", "OV", "HO", "TD", "WM"):
             index = diagnostics._mapped_sets(app_type)[2]
             self.assertIsNotNone(index)
             for tag, row in index.items():
+                swept_domains.setdefault(app_type, set()).add(tag.split(".")[0])
                 for name in (row or {}).get("read", []) + (row or {}).get("write", []):
                     seen += 1
                     bare = name
@@ -2776,7 +2886,28 @@ class EntitySourceDriftGuardTest(unittest.TestCase):
                         name in allowed or bare in allowed,
                         f"{app_type} {tag}: {name} is in no static table",
                     )
-        self.assertGreater(seen, 200, "the sweep found almost nothing to check")
+        # A floor of 200 against a real count of 381 lets an ENTIRE table stop
+        # being walked unnoticed: the sensor.* rows alone are 113 names and
+        # binary_sensor.* 63, so deleting either leaves the count above the
+        # floor. A union floor is also blind to a table that stops being walked
+        # for ONE type, because the other eight keep the domain in the union.
+        # Pin the SHAPE of the sweep, per type, and not only a number.
+        self.assertGreater(seen, 375, f"the sweep shrank to {seen} names")
+        self.assertEqual(
+            {
+                "REF": {"binary_sensor", "number", "select", "sensor"},
+                "AC": {"binary_sensor", "climate", "select", "sensor", "switch"},
+                "WD": {"binary_sensor", "button", "number", "select", "sensor", "switch"},
+                "AP": {"binary_sensor", "fan", "number", "select", "sensor", "switch"},
+                "WC": {"binary_sensor", "number", "sensor", "switch"},
+                "OV": {"binary_sensor", "number", "sensor"},
+                "HO": {"binary_sensor", "sensor"},
+                "TD": {"binary_sensor", "button", "number", "select", "sensor", "switch"},
+                "WM": {"binary_sensor", "button", "number", "select", "sensor", "switch"},
+            },
+            swept_domains,
+            "a table stopped being walked for some appliance type",
+        )
 
     def test_every_emitted_name_matches_the_closed_shape(self) -> None:
         # A second, cheaper net under the first: whatever a future edit starts
@@ -2869,6 +3000,14 @@ class EntitySourceDriftGuardTest(unittest.TestCase):
         self.assertNotIn("no-dot-here", index)
         self.assertNotIn("sensor.no_types", index)
         self.assertNotIn("sensor.null_types", index)
+        # Seven broken shapes go in; assert all of them, not three. The tag guard
+        # is a TWO-clause condition (`not domain or not suffix`) and only the
+        # suffix half was covered -- `if not domain` could be deleted and nothing
+        # in the suite noticed, so a row tagged '.leading' shipped with an empty
+        # domain that joins with no `by_domain` entry.
+        self.assertNotIn(".leading", index)
+        self.assertNotIn("trailing.", index)
+        self.assertNotIn("sensor.orphan", index)
         # The real table is back and still works, so the swap above cannot leave
         # the rest of the suite testing a stub.
         self.assertIn("select.ref_program", diagnostics._mapped_sets("REF")[2])
@@ -3157,15 +3296,18 @@ class AttributeTimestampNewestTest(unittest.TestCase):
         (FROZEN - newest).total_seconds()  # must not raise
 
     def test_a_subclass_that_refuses_to_compare_does_not_kill_the_dump(self):
-        # The one unguarded expression this helper could have shipped: the first
-        # instant is short-circuited by `newest is None`, so the comparison only
-        # runs on the SECOND stamped parameter -- which is why a single-value
-        # test would have missed it entirely.
+        # A hostile `__gt__` is NOT what this guard catches: production rebuilds
+        # the instant into a plain `datetime` from its integer fields one line
+        # earlier, so by the comparison both operands are ordinary datetimes and
+        # an overridden `__gt__` is never invoked (measured: zero calls). What
+        # CAN raise inside the guard is the rebuild itself, so the subclass has
+        # to be hostile on a field the rebuild reads.
         class Hostile(datetime):
-            def __gt__(self, other):
+            @property
+            def year(self):
                 raise RuntimeError("boom")
 
-        block = _stamp_block(
+        stamps, _, newest = diagnostics._attribute_timestamps(
             {
                 "a": FakeShadowAttribute("1", AC_STAMP_OLD),
                 "b": FakeShadowAttribute(
@@ -3173,9 +3315,12 @@ class AttributeTimestampNewestTest(unittest.TestCase):
                 ),
             }
         )
-        self.assertEqual(
-            "2026-04-09T05:31:02+00:00", block["attributes_last_update"]["a"]
-        )
+        # The hostile value is skipped for the newest, not fatal ...
+        self.assertEqual(AC_STAMP_OLD, newest)
+        # ... and its own ROW still prints, because `_stamp_text` is a separate
+        # path that never touches the comparison.
+        self.assertEqual("2026-04-09T06:00:00+00:00", stamps["b"])
+        self.assertEqual("2026-04-09T05:31:02+00:00", stamps["a"])
 
     def test_the_newest_is_none_when_no_instant_ever_arrived(self):
         stamps, _, newest = diagnostics._attribute_timestamps(
@@ -3184,10 +3329,49 @@ class AttributeTimestampNewestTest(unittest.TestCase):
         self.assertEqual({"a": None}, stamps)
         self.assertIsNone(newest)
 
+    def test_a_shadow_stamped_only_with_the_epoch_sentinel_has_no_newest(self):
+        # The route a real appliance actually takes. Every one of the 33
+        # `lastUpdate` values in the only REF capture this repository holds is
+        # exactly '1970-01-01T00:00:00.0Z', so a real fridge arrives with every
+        # shadow parameter carrying a PARSED, aware, non-None datetime. The
+        # `instant > _NEVER_STAMPED` clause is the only thing between that and a
+        # freshness header reading "56 years stale" on a connected appliance.
+        epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        stamps, _, newest = diagnostics._attribute_timestamps(
+            {"a": FakeShadowAttribute("1", epoch), "b": FakeShadowAttribute("2", epoch)}
+        )
+        # The rows still PRINT what the cloud sent -- the map is an echo ...
+        self.assertEqual(
+            {"a": "1970-01-01T00:00:00+00:00", "b": "1970-01-01T00:00:00+00:00"},
+            stamps,
+        )
+        # ... but the sentinel is not an instant, so no age is derivable from it.
+        self.assertIsNone(newest)
+        self.assertIsNone(diagnostics._freshness(None, {}, newest, FROZEN).get("shadow"))
+
     def test_the_newest_is_never_emitted_from_here(self):
-        # It is a datetime, which HA's JSON encoder raises on. Nothing in the
-        # block may carry it: only `_stamp_text` output reaches the document.
+        # `json.dumps` CANNOT see this on its own: `_appliance_block` returns
+        # `_redact(block)`, and `_jsonable` stringifies any datetime it meets, so
+        # a leaked instant arrives as '2026-04-09 05:31:02+00:00' -- the
+        # space-separated shape `_ISO_RE` exists to reject -- without raising.
+        # Assert the type and the shape, then keep the serialisation check.
         _, blocks = _entry_diag()
+
+        def _leaves(node):
+            if isinstance(node, dict):
+                for value in node.values():
+                    yield from _leaves(value)
+            elif isinstance(node, (list, tuple)):
+                for value in node:
+                    yield from _leaves(value)
+            else:
+                yield node
+
+        for stamp in blocks["AC"]["attributes_last_update"].values():
+            if stamp is not None:
+                self.assertIsNotNone(diagnostics._ISO_RE.fullmatch(stamp), stamp)
+        for leaf in _leaves(blocks["AC"]):
+            self.assertNotIsInstance(leaf, datetime)
         json.dumps(blocks["AC"])  # must not raise
 
 
@@ -3693,6 +3877,19 @@ class FreshnessShippedFieldsTest(unittest.TestCase):
         )
         self.assertEqual(["category", "at", "age_s"], list(full["last_conn_event"]))
         self.assertEqual(["at", "age_s"], list(full["shadow"]))
+        # `_full_section` calls `_freshness` DIRECTLY, so the order it measures is
+        # the one the helper returns, not the one the document prints. Order is
+        # decided by the LAST writer of the dict -- the block assembly and
+        # `_redact` -- so assert it again on the shipped path or a reordering
+        # introduced downstream leaves this test green.
+        shipped = _freshness_of(
+            {"available": False, "lastConnEvent": _conn_event()},
+            FakeLinkAppliance(False),
+        )
+        self.assertEqual(["connected", "available", "last_conn_event"], list(shipped))
+        self.assertEqual(["category", "at", "age_s"], list(shipped["last_conn_event"]))
+        _, blocks = _entry_diag()
+        self.assertEqual("shadow", list(blocks["AC"]["freshness"])[-1])
 
     def test_a_thin_appliance_emits_a_subset_and_never_a_new_name(self):
         # The conditional keys drop out; nothing else appears in their place.
@@ -4026,6 +4223,15 @@ class FreshnessPrivacyTest(unittest.TestCase):
             for text in stamps:
                 self.assertTrue(text.endswith("+00:00"), text)
                 self.assertEqual(text, debug_utils._MAC_RE.sub("***", text))
+        # Both fixtures above are ALREADY UTC, so neither can observe the
+        # normalisation the comment credits. Straddle the hazard: a sub-minute
+        # offset is what makes an ISO instant match `_MAC_RE`, and the contract
+        # is that the instant is SHIFTED to UTC, not dropped.
+        odd = timezone(timedelta(hours=-5, minutes=-30, seconds=-15))
+        skewed = diagnostics._freshness(
+            None, {}, datetime(2026, 4, 9, 12, 34, 56, tzinfo=odd), FROZEN
+        )
+        self.assertEqual("2026-04-09T18:05:11+00:00", skewed["shadow"]["at"])
 
 
 class FreshnessDegradationTest(unittest.TestCase):
@@ -4089,6 +4295,17 @@ class FreshnessDegradationTest(unittest.TestCase):
         for block in blocks.values():
             self.assertTrue(_json_native(block["freshness"]))
             json.dumps(block)  # must not raise
+        # Everything above is observed AFTER `_redact`/`_jsonable`, which
+        # stringify any datetime they meet -- so the defect this test is named
+        # for is erased by the pipeline used to look for it. Assert it on the
+        # UNREDACTED return value too, which is the only place it is visible.
+        raw = diagnostics._freshness(
+            FakeLinkAppliance(False),
+            {"available": False, "lastConnEvent": _conn_event()},
+            AC_STAMP_NEW,
+            FROZEN,
+        )
+        self.assertTrue(_json_native(raw))
 
     def test_a_naive_dump_instant_never_reaches_a_subtraction(self):
         # The TypeError that would take the whole dump down. `_appliance_block`
@@ -4190,13 +4407,66 @@ class AttributeValuesDedupTest(unittest.TestCase):
         # means the merge this optimisation relies on did not happen the way it
         # is documented, so the copy stays. Equality would also mean calling an
         # `__eq__` this module does not control.
+        #
+        # The fixture has to be an object for which `is` and `==` DISAGREE.
+        # `FakeShadowAttribute` inherits `object.__eq__`, so on it `==` degenerates
+        # to `is` and the assertion below cannot tell the two operators apart.
+        class _AlwaysEqual:
+            def __init__(self, value):
+                self.value = value
+                self.last_update = AC_STAMP_OLD
+
+            def __eq__(self, other):
+                return True
+
+            __hash__ = None
+
         block = _stamp_block(
             {
-                "tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD),
-                "parameters": {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)},
+                "tempZ1": _AlwaysEqual("4"),
+                "parameters": {"tempZ1": _AlwaysEqual("4")},
             }
         )
         self.assertIn("parameters", block["attributes"])
+
+    def test_the_redundancy_check_never_calls_a_foreign_eq(self):
+        # The other half of the docstring's reason for `is`: an `__eq__` this
+        # module does not control is free to raise, and the dedupe must not be
+        # the thing that costs the reporter the file.
+        class _HostileEq:
+            def __init__(self, value):
+                self.value = value
+                self.last_update = AC_STAMP_OLD
+
+            def __eq__(self, other):
+                raise RuntimeError("boom")
+
+            __hash__ = None
+
+        shared = _HostileEq("4")
+        block = _stamp_block({"tempZ1": shared, "parameters": {"tempZ1": shared}})
+        # Same object bare and nested -> redundant -> dropped, and `__eq__` was
+        # never consulted (it would have raised).
+        self.assertNotIn("parameters", block["attributes"])
+
+    def test_the_live_merge_binds_the_same_object_bare_and_nested(self):
+        # The cross-module premise the whole optimisation rests on, stated in the
+        # production docstring and, until now, in no test. `_attribute_values`
+        # decides redundancy with `is`; that is only ever True because
+        # `_get_attributes` merges the shadow with `attributes.update(params)`,
+        # binding the SAME objects bare and nested. Rewrite that merge to copy and
+        # the dedupe silently stops firing on every real appliance.
+        from custom_components.addhon.hon_client import _get_attributes
+
+        shadow = FakeShadowAttribute("4", AC_STAMP_OLD)
+
+        class _App:
+            attributes = {"parameters": {"tempZ1": shadow}}
+
+        merged = _get_attributes(_App())
+        self.assertIs(shadow, merged["tempZ1"])
+        self.assertIs(shadow, merged["parameters"]["tempZ1"])
+        self.assertNotIn("parameters", diagnostics._attribute_values(merged))
 
     def test_a_non_mapping_parameters_value_is_left_alone(self):
         block = _stamp_block({"parameters": "not-a-map", "x": 1})

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -856,7 +856,7 @@ class WcSettingsSwitchCoverageTest(unittest.TestCase):
         })})
 
     def test_lightstatus_in_mapped_params(self):
-        _, mapped_params, _sources = diagnostics._mapped_sets("WC")
+        _, mapped_params, _sources, _missing = diagnostics._mapped_sets("WC")
         self.assertIn("lightStatus", mapped_params)
 
     def test_lightstatus_not_reported_unmapped(self):
@@ -2454,6 +2454,21 @@ class _BrokenModules:
         return False
 
 
+# Every platform module `_mapped_sets` imports, in the order it imports them.
+# Written out here rather than derived, so that a module dropped from the walk
+# leaves a test breaking on a name nothing reads instead of a sweep that quietly
+# checks six things.
+_PLATFORM_MODULES = (
+    "air_purifier",
+    "binary_sensor",
+    "number",
+    "program_options",
+    "select",
+    "sensor",
+    "switch",
+)
+
+
 def _ref_dump(rows=REF_ROWS, states=None, raises=False, entries=None):
     """The fridge's `entities` section, built through the real registry path."""
     if entries is None:
@@ -2712,7 +2727,7 @@ class EntitySourceTest(unittest.TestCase):
         # existed `windDirectionHorizontal` sat in `command_params_unmapped`
         # while nothing disproved it; now `sources` names its writer, so the
         # coverage numerator has to agree.
-        mapped_attrs, mapped_params, index = diagnostics._mapped_sets("AC")
+        mapped_attrs, mapped_params, index, _missing = diagnostics._mapped_sets("AC")
         self.assertIn("windDirectionHorizontal", mapped_params)
         self.assertEqual(
             ["windDirectionHorizontal"],
@@ -2766,34 +2781,63 @@ class EntitySourceTest(unittest.TestCase):
         self.assertEqual({"status": "unavailable"}, result["platforms"])
 
     def test_unreadable_registries_give_ONE_null_not_a_null_per_entity(self) -> None:
-        # The lazy import is what fails here, not the entity registry: the
+        # The lazy imports are what fail here, not the entity registry: the
         # section knows WHICH entities exist and cannot say what any of them
         # speaks to. A map of nulls would read as "all six were looked up and
         # none is known", which is a finding; one null is the absence of one.
-        with _BrokenModules("select"):
+        # It takes the TOTAL collapse to reach that now. One broken module
+        # leaves most of the walk readable, and the honest statement is then per
+        # entity -- see the test below, which is the other half of this one.
+        with _BrokenModules(*_PLATFORM_MODULES):
             _result, entities = _ref_dump()
         self.assertIsNone(entities["sources"])
         self.assertEqual(6, sum(len(v) for v in entities["by_domain"].values()))
+
+    def test_one_broken_module_names_the_entities_it_did_not_lose(self) -> None:
+        # The other half, and the reason the per-import guards exist. With
+        # `select` unimportable the fridge's select row is the only one that
+        # cannot be named; blanking the map would throw away five rows that were
+        # read correctly, and it used to travel with a coverage block accusing
+        # the integration of not mapping tempSelZ1/Z2/Z3.
+        with _BrokenModules("select"):
+            result, entities = _ref_dump()
+        sources = entities["sources"]
+        self.assertIsNotNone(sources)
+        self.assertEqual(
+            {"read": ["tempSelZ3"], "write": ["tempSelZ3"]},
+            sources["number.target_temp_zone3"],
+        )
+        self.assertEqual({"read": ["tempZ3"]}, sources["sensor.temp_zone3"])
+        coverage = result["appliances"][0]["coverage"]
+        self.assertEqual(["select"], coverage["registries_unavailable"])
+        for name in ("tempSelZ1", "tempSelZ2", "tempSelZ3"):
+            self.assertNotIn(name, coverage["command_params_unmapped"])
 
     def test_the_two_sections_share_one_degradation_decision(self) -> None:
         # Correction 6 made real. With the walk folded into `_mapped_sets`, a
         # broken platform module degrades coverage AND sources together; two
         # independent import blocks would let one dump report `tempSelZ3` as
         # confidently mapped while the other half claimed nothing was readable.
+        # What is shared is the DECISION, not its blast radius: each import
+        # fails on its own, so `select` costs the select tag on BOTH sides and
+        # leaves `tempSelZ3` mapped on both sides.
         with _BrokenModules("select"):
             result, entities = _ref_dump()
-            mapped_attrs, mapped_params, index = diagnostics._mapped_sets("REF")
-        self.assertIsNone(index)
-        self.assertEqual(set(), mapped_params)
-        self.assertEqual(set(), mapped_attrs)
+            mapped_attrs, mapped_params, index, missing = diagnostics._mapped_sets(
+                "REF"
+            )
+        self.assertEqual(["select"], missing)
+        self.assertIn("tempSelZ3", mapped_params)
+        self.assertIn("tempZ3", mapped_attrs)
         # ... and the dump SAYS SO in both halves, which is the actual claim.
-        self.assertIsNone(entities["sources"])
         coverage = result["appliances"][0]["coverage"]
-        self.assertTrue(coverage["registries_unavailable"])
-        # Positive control: the same calls with the module intact are populated
-        # and carry no marker, so the assertions above cannot pass for the wrong
+        self.assertEqual(["select"], coverage["registries_unavailable"])
+        self.assertIsNotNone(entities["sources"])
+        # Positive control: the same calls with the module intact carry no
+        # marker at all, so the assertions above cannot pass for the wrong
         # reason.
-        mapped_attrs, mapped_params, index = diagnostics._mapped_sets("REF")
+        mapped_attrs, mapped_params, index, missing = diagnostics._mapped_sets("REF")
+        self.assertEqual([], missing)
         self.assertIsNotNone(index)
         self.assertIn("tempSelZ3", mapped_params)
         _result, healthy = _ref_dump()
@@ -2806,7 +2850,10 @@ class EntitySourceTest(unittest.TestCase):
         # The case `entities.sources` structurally cannot cover: there is no
         # inventory to decorate, so the coverage marker is the only thing in the
         # document that stops the reader believing the integration maps nothing.
-        with _BrokenModules("select"):
+        # `sensor` is the module broken here, because it is the one that owns
+        # `tempZ1`: the marker has to be shown naming a loss that actually moved
+        # a number, or the test would pass on a module whose absence is free.
+        with _BrokenModules("sensor"):
             block = diagnostics._appliance_block(
                 "id1",
                 {
@@ -2817,7 +2864,7 @@ class EntitySourceTest(unittest.TestCase):
                 },
             )
         self.assertIsNone(block["entities"])
-        self.assertTrue(block["coverage"]["registries_unavailable"])
+        self.assertEqual(["sensor"], block["coverage"]["registries_unavailable"])
         self.assertEqual(["tempZ1"], block["coverage"]["attributes_unmapped"])
 
     def test_a_foreign_inventory_shape_degrades_instead_of_raising(self) -> None:
@@ -2853,6 +2900,188 @@ class EntitySourceTest(unittest.TestCase):
         section = diagnostics._entity_section(inventory, "REF")
         self.assertIn("sources", section)
         self.assertNotIn("sources", inventory)
+
+
+class RegistryDegradationTest(unittest.TestCase):
+    """One unimportable platform module costs its own tables and nothing else.
+
+    Before the per-import guards, ANY of the seven brought the whole walk down:
+    on the four archived live appliances a single broken module roughly doubled
+    or tripled `attributes_unmapped`, and the REF's three declared setpoints
+    turned into `command_params_unmapped` entries -- an accusation, on the list
+    this dump calls the gold signal, about controls the integration ships and
+    the reporter is using. These tests pin the blast radius and not the figures,
+    which move whenever a table gains a row and differ again depending on how an
+    appliance is rebuilt from an archived dump.
+
+    Five of the seven are leaves and genuinely degrade alone: `binary_sensor`,
+    `number`, `select`, `sensor`, `switch`. `air_purifier` is imported by all
+    five and `program_options` by three, so breaking either takes its importers
+    with it however these guards are arranged -- `setUp` explains why. The
+    worked example for what this rescues is `sensor` on a fridge or `select` on
+    an AC, not the air purifier.
+    """
+
+    def setUp(self) -> None:
+        # Each guard in `_mapped_sets` is per-IMPORT, and an import only fails
+        # ALONE when the module is already in `sys.modules`. Five of the seven
+        # import `air_purifier` and three import `program_options`, so on a cold
+        # interpreter breaking either takes its importers down with it. Home
+        # Assistant has loaded all seven at platform setup long before anyone
+        # downloads a dump, so the cached tree is the state this class measures
+        # -- import them HERE instead of inheriting whichever test ran first, or
+        # `pytest -k RegistryDegradation` turns green into red on correct code.
+        for module in _PLATFORM_MODULES:
+            importlib.import_module(f"custom_components.addhon.{module}")
+
+    def tearDown(self) -> None:
+        _restore_registry()
+
+    def test_no_single_break_empties_the_walk(self) -> None:
+        # The contract in one place, over every module and five types: nothing
+        # is invented (each broken set is a subset of the healthy one) and
+        # nothing is wiped (an index survives), and the marker names exactly the
+        # module that failed.
+        for app_type in ("REF", "AC", "WD", "TD", "AP"):
+            healthy_attrs, healthy_params, healthy_index, healthy_missing = (
+                diagnostics._mapped_sets(app_type)
+            )
+            self.assertEqual([], healthy_missing)
+            for module in _PLATFORM_MODULES:
+                with self.subTest(app_type=app_type, module=module):
+                    with _BrokenModules(module):
+                        attrs, params, index, missing = diagnostics._mapped_sets(
+                            app_type
+                        )
+                    self.assertEqual([module], missing)
+                    self.assertIsNotNone(index)
+                    self.assertTrue(index)
+                    self.assertLessEqual(attrs, healthy_attrs)
+                    self.assertLessEqual(params, healthy_params)
+                    self.assertLessEqual(set(index), set(healthy_index))
+
+    def test_a_broken_module_stops_accusing_the_fridge_of_its_own_setpoints(
+        self,
+    ) -> None:
+        # The defect this follow-up exists for, on the appliance it was measured
+        # on. `NUMBERS["REF"]` is what maps tempSelZ1/Z2/Z3, so `number` losing
+        # them is truthful and is asserted as such; the other six modules used to
+        # lose them too, and the dump then told the reporter to go and add three
+        # controls they were already using.
+        for module in _PLATFORM_MODULES:
+            with self.subTest(module=module):
+                with _BrokenModules(module):
+                    result, _entities = _ref_dump()
+                coverage = result["appliances"][0]["coverage"]
+                self.assertEqual([module], coverage["registries_unavailable"])
+                unmapped = coverage["command_params_unmapped"]
+                for name in ("tempSelZ1", "tempSelZ2", "tempSelZ3"):
+                    if module == "number":
+                        self.assertIn(name, unmapped)
+                    else:
+                        self.assertNotIn(name, unmapped)
+
+    def test_only_a_total_collapse_blanks_the_whole_map(self) -> None:
+        # `_CUSTOM_ENTITY_SOURCES` is a literal in diagnostics.py and its rows
+        # survive any import failure, so the None decision cannot be taken on
+        # the size of the finished map -- REF keeps `select.ref_program` even
+        # with all seven modules gone. It is taken on whether any PLATFORM table
+        # produced a row, which is the question the null answers.
+        with _BrokenModules(*_PLATFORM_MODULES):
+            attrs, params, index, missing = diagnostics._mapped_sets("REF")
+        self.assertIsNone(index)
+        self.assertEqual(list(_PLATFORM_MODULES), missing)
+        self.assertEqual(
+            set(diagnostics._CUSTOM_MAPPED_ATTRS.get("REF", ())), attrs
+        )
+        self.assertEqual(set(), params)
+
+    def test_a_lost_table_gives_its_entities_one_null_each(self) -> None:
+        # The AC louvers are the case that shows the difference: `select` gone,
+        # and only the two select rows lose their names while the climate row
+        # beside them keeps every one of its reads.
+        inventory = {
+            "status": "ok",
+            "by_domain": {
+                "select": ["fan_direction_vertical", "fan_direction_horizontal"],
+                "climate": ["climate"],
+            },
+        }
+        with _BrokenModules("select"):
+            section = diagnostics._entity_section(inventory, "AC")
+        self.assertEqual(
+            {
+                "select.fan_direction_vertical": None,
+                "select.fan_direction_horizontal": None,
+            },
+            {k: v for k, v in section["sources"].items() if k.startswith("select.")},
+        )
+        self.assertTrue(section["sources"]["climate.climate"]["read"])
+        # Positive control on the same inventory: healthy, both selects are named.
+        healthy = diagnostics._entity_section(inventory, "AC")
+        self.assertEqual(
+            ["windDirectionVertical"],
+            healthy["sources"]["select.fan_direction_vertical"]["write"],
+        )
+
+    def test_a_lost_startprogram_name_never_invents_an_absence(self) -> None:
+        # `program_options` owns one string in this walk: the command the
+        # buffered options are read under. Emitting the read chain without it
+        # would leave a one-link chain, and `_coverage` would then report every
+        # option the device publishes only under `startProgram` as a control the
+        # device does not have -- while `entities.sources` named its writer two
+        # sections below. Measured on the live TD, that is `tumblingStatus`.
+        # Skipping the loop costs coverage and states nothing false, and the
+        # discriminator is that the option's TAG is gone from the index too.
+        appliance = FakeAppliance(
+            commands={
+                "settings": FakeCommand({"tumblingStatus": FakeParam(value="1")}),
+                "startProgram": FakeCommand(
+                    {"tumblingStatus": FakeParam(value="1")}
+                ),
+            }
+        )
+        entry = {
+            "appliance": appliance,
+            "type": "TD",
+            "attributes": {"startProgram.tumblingStatus": "1"},
+            "statistics": {},
+        }
+        with _BrokenModules("program_options"):
+            index = diagnostics._mapped_sets("TD")[2]
+            coverage = diagnostics._appliance_block("id1", entry)["coverage"]
+        self.assertEqual(["program_options"], coverage["registries_unavailable"])
+        self.assertNotIn("switch.opt_tumbling", index)
+        self.assertNotIn("tumblingStatus", coverage["attributes_expected_absent"])
+        # Positive control: healthy, the tag is there and the name is mapped, so
+        # the two assertions above cannot be passing on an empty walk.
+        self.assertIn("switch.opt_tumbling", diagnostics._mapped_sets("TD")[2])
+        healthy = diagnostics._appliance_block("id1", entry)["coverage"]
+        self.assertNotIn("registries_unavailable", healthy)
+        self.assertNotIn("tumblingStatus", healthy["attributes_expected_absent"])
+        self.assertNotIn("tumblingStatus", healthy["command_params_unmapped"])
+
+    def test_the_walk_degrades_and_never_raises(self) -> None:
+        # `_appliance_block` is called with no try/except around it from either
+        # entry point, and seven guards are seven more places to raise from --
+        # `_CONNECTIVITY` in particular is the one table entry with no type gate
+        # and nothing to be empty, so it is a None and not a `()`. Every
+        # one-missing and the all-missing case, on a real block.
+        entry = {
+            "appliance": FakeAppliance(commands={}),
+            "type": "WD",
+            "attributes": {"machMode": "1"},
+            "statistics": {},
+        }
+        cases = [(module,) for module in _PLATFORM_MODULES]
+        cases.append(_PLATFORM_MODULES)
+        for modules in cases:
+            with self.subTest(modules=modules):
+                with _BrokenModules(*modules):
+                    block = diagnostics._appliance_block("id1", entry)
+                self.assertEqual(
+                    list(modules), block["coverage"]["registries_unavailable"]
+                )
 
 
 class EntitySourceDriftGuardTest(unittest.TestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -21,6 +21,7 @@ import json
 import sys
 import types
 import unittest
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 
@@ -202,6 +203,19 @@ class FakeWrapper:
         self.value = value
 
 
+class FakeShadowAttribute:
+    """A HonAttribute: a `.value` PLUS the cloud instant that last moved it.
+
+    Deliberately NOT folded into `FakeWrapper` above: that one stands for every
+    `.value` wrapper in the engine (a HonParameter has no instant), and giving
+    it a `last_update` would put a row in every timestamp map in this file.
+    """
+
+    def __init__(self, value, last_update=None):
+        self.value = value
+        self.last_update = last_update
+
+
 class Opaque:
     """A non-primitive value with NO `.value` (must be stringified, not crash JSON)."""
 
@@ -274,6 +288,13 @@ class FakeHass:
         self.data = {DOMAIN: {entry_id: {"coordinator": coordinator}}}
 
 
+# Pinned instants for the shared AC fixture. They are constants rather than
+# offsets from now() so that a section asserting an AGE can subtract them from a
+# frozen clock; a fixture built on the wall clock is how age assertions turn
+# into tests that fail once a year on a slow machine.
+AC_STAMP_OLD = datetime(2026, 4, 9, 5, 31, 2, tzinfo=timezone.utc)
+AC_STAMP_NEW = datetime(2026, 4, 9, 5, 34, 16, tzinfo=timezone.utc)
+
 AC_ID = "ac-unique"
 WD_ID = "wd-unique"
 
@@ -316,7 +337,11 @@ def _build_coordinator() -> FakeCoordinator:
             "serial": "PLAINTEXT-SERIAL",
             "mac": "AA:BB:CC:DD:EE:FF",
             "attributes": {
-                "tempIndoor": 22.5,           # mapped (sensor + custom)
+                # Wrapped the way the real shadow arrives: a value AND the
+                # instant the cloud last moved it. Every other section must be
+                # blind to the wrapper -- `_jsonable` still unwraps it to 22.5,
+                # and the coverage denominator still counts one bare key.
+                "tempIndoor": FakeShadowAttribute(22.5, AC_STAMP_OLD),  # mapped
                 "available": True,            # mapped (connectivity)
                 "settings.machMode": "1",     # dotted -> excluded from attr axis
                 "weirdAcSensor": 9,           # UNMAPPED bare telemetry
@@ -324,8 +349,13 @@ def _build_coordinator() -> FakeCoordinator:
                 # writable params also surface BARE in the device shadow; they must
                 # NOT be reported as unmapped read-only attributes (fix: subtract
                 # settings params from the attribute axis).
-                "tempSel": "22",
-                "machMode": "1",
+                # tempSel carries the NEWEST instant in this fixture, so a
+                # section reporting "when did anything last move" has a
+                # deterministic answer. machMode carries none, which is the
+                # `null` row: `attributes.py:73` is a walrus guard, so an update
+                # with no lastUpdate never clears a previous instant.
+                "tempSel": FakeShadowAttribute("22", AC_STAMP_NEW),
+                "machMode": FakeShadowAttribute("1", None),
                 # wrapper objects (HonAttribute/HonParameter) must be JSON-coerced.
                 "liveParam": FakeWrapper(7),
                 "opaqueObj": Opaque(),
@@ -2861,6 +2891,597 @@ class EntitySourceDriftGuardTest(unittest.TestCase):
             for half in ("read", "write"):
                 if half in entry:
                     self.assertIsInstance(entry[half], tuple, entry["tag"])
+
+
+# --- step 3: the per-parameter cloud instants (P1) ---------------------------
+
+
+class _Raising:
+    """A shadow value whose `last_update` PROPERTY raises when it is read.
+
+    Not a contrived shape: `last_update` is a property on the real
+    `HonAttribute`, and a foreign or half-migrated appliance implementation is
+    free to compute it. `_appliance_block` is called with no try/except around
+    it from either entry point, so this is the object that decides whether one
+    bad parameter costs one row or the whole document.
+    """
+
+    def __init__(self):
+        self.value = "1"
+
+    @property
+    def last_update(self):
+        raise RuntimeError("boom")
+
+
+class _BrokenNested(Mapping):
+    """A Mapping that is NOT a dict and refuses one of the keys it enumerates.
+
+    This is the object behind `hon_client.py:192-196`: the merge there goes
+    through `dict(params)`, whose argument is evaluated in full before anything
+    is merged, so one refusing key means NOTHING is flattened and the nested map
+    is the only surviving carrier of the instants.
+    """
+
+    def __init__(self, rows, broken):
+        self._rows = dict(rows)
+        self._broken = broken
+
+    def __getitem__(self, key):
+        if key == self._broken:
+            raise RuntimeError("boom")
+        return self._rows[key]
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def __len__(self):
+        return len(self._rows)
+
+
+def _stamp_block(attributes, app_type="AC"):
+    """A single appliance block built from an ad-hoc attributes mapping.
+
+    Built here rather than by bolting keys onto `_build_coordinator`: that
+    fixture's AC and WD attribute dicts are hand-counted by
+    `test_coverage_totals` (`attributes_total == 6`), so a section that needs an
+    extra key builds its own appliance instead of perturbing the shared one.
+    """
+    return diagnostics._appliance_block(
+        "id1",
+        {
+            "appliance": FakeApplianceNoModel(commands={}),
+            "type": app_type,
+            "attributes": attributes,
+            "statistics": {},
+        },
+    )
+
+
+class AttributeTimestampTest(unittest.TestCase):
+    """The per-parameter cloud instants `_jsonable` used to throw away."""
+
+    def test_the_map_sits_beside_the_values_it_describes(self):
+        # Placement is the feature: a reader scrolling `attributes` finds the
+        # instants in the next section, not after `future_capabilities`.
+        _, blocks = _entry_diag()
+        keys = list(blocks["AC"])
+        self.assertEqual(
+            keys.index("attributes") + 1, keys.index("attributes_last_update")
+        )
+        self.assertEqual(
+            keys.index("attributes_last_update") + 1, keys.index("commands")
+        )
+
+    def test_every_shadow_parameter_gets_a_row(self):
+        _, blocks = _entry_diag()
+        self.assertEqual(
+            {
+                "machMode": None,
+                "tempIndoor": "2026-04-09T05:31:02+00:00",
+                "tempSel": "2026-04-09T05:34:16+00:00",
+            },
+            blocks["AC"]["attributes_last_update"],
+        )
+
+    def test_a_value_with_no_last_update_surface_gets_no_row(self):
+        # The map answers "which keys are shadow parameters", so a plain scalar,
+        # a bare `.value` wrapper, an opaque object and an envelope dict must all
+        # be absent -- not present with a null, which would claim they are shadow
+        # parameters that never carried an instant.
+        _, blocks = _entry_diag()
+        rows = blocks["AC"]["attributes_last_update"]
+        for name in (
+            "weirdAcSensor",
+            "available",
+            "liveParam",
+            "opaqueObj",
+            "commandHistory",
+            "macAddress",
+        ):
+            self.assertNotIn(name, rows)
+
+    def test_a_shadow_parameter_with_no_instant_is_null_not_missing(self):
+        # machMode is wrapped and carries no instant. Dropping the row would
+        # merge "no parseable instant has ever arrived" into "not a shadow
+        # parameter", which are two different findings.
+        _, blocks = _entry_diag()
+        rows = blocks["AC"]["attributes_last_update"]
+        self.assertIn("machMode", rows)
+        self.assertIsNone(rows["machMode"])
+
+    def test_an_appliance_with_no_shadow_wrappers_emits_an_empty_map(self):
+        # The WD fixture is plain scalars throughout. An empty map is the honest
+        # answer; it is not omitted, because "this device sent no instants" and
+        # "this dump did not look" must stay distinguishable.
+        _, blocks = _entry_diag()
+        self.assertEqual({}, blocks["WD"]["attributes_last_update"])
+
+    def test_the_rows_are_sorted_across_both_sources(self):
+        # Sorted ONCE at the end and not per source: the nested `parameters` map
+        # is walked second, so a per-source sort would emit a map whose second
+        # half restarts the alphabet.
+        _, blocks = _entry_diag()
+        rows = list(blocks["AC"]["attributes_last_update"])
+        self.assertEqual(sorted(rows), rows)
+        mixed, _, _ = diagnostics._attribute_timestamps(
+            {
+                "zzz": FakeShadowAttribute("1", AC_STAMP_OLD),
+                "parameters": {"aaa": FakeShadowAttribute("1", AC_STAMP_NEW)},
+            }
+        )
+        self.assertEqual(["aaa", "zzz"], list(mixed))
+
+    def test_every_stamp_is_aware_utc_iso_text(self):
+        # The shape guard. `read`/`write`-style free text is not in `_TO_REDACT`
+        # and `_MAC_RE` catches only MAC shapes, so the only thing keeping this
+        # field safe is that it cannot be anything but an instant.
+        result, _ = _entry_diag()
+        seen = 0
+        for block in result["appliances"]:
+            for stamp in block["attributes_last_update"].values():
+                if stamp is None:
+                    continue
+                seen += 1
+                self.assertRegex(
+                    stamp,
+                    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?\+00:00$",
+                )
+        self.assertEqual(2, seen, "the guard would be vacuous with no stamps")
+
+    def test_the_wrapped_fixture_still_reads_as_a_plain_value(self):
+        # The wrappers must be invisible to every other section: `_jsonable`
+        # unwraps `.value`, and the coverage denominator is a key count.
+        _, blocks = _entry_diag()
+        self.assertEqual(22.5, blocks["AC"]["attributes"]["tempIndoor"])
+        self.assertEqual("1", blocks["AC"]["attributes"]["machMode"])
+        self.assertEqual(6, blocks["AC"]["coverage"]["attributes_total"])
+
+
+class AttributeTimestampTruncationTest(unittest.TestCase):
+    """The row cap announces itself, and never silently drops a row."""
+
+    @staticmethod
+    def _many(count):
+        rows = {
+            "p%03d" % i: FakeShadowAttribute(str(i), AC_STAMP_OLD)
+            for i in range(count)
+        }
+        # Alphabetically LAST, so the cap is guaranteed to drop it. That is what
+        # makes the "the newest is computed over the dropped rows too" claim
+        # below a real test rather than a restatement.
+        rows["zzz_newest"] = FakeShadowAttribute("9", AC_STAMP_NEW)
+        return rows
+
+    def test_the_flag_is_absent_when_nothing_was_dropped(self):
+        _, blocks = _entry_diag()
+        self.assertNotIn("attributes_last_update_truncated", blocks["AC"])
+        self.assertNotIn("attributes_last_update_truncated", blocks["WD"])
+
+    def test_the_cap_drops_rows_and_says_so_adjacently(self):
+        block = _stamp_block(self._many(250))
+        self.assertEqual(200, len(block["attributes_last_update"]))
+        self.assertTrue(block["attributes_last_update_truncated"])
+        keys = list(block)
+        self.assertEqual(
+            keys.index("attributes_last_update") + 1,
+            keys.index("attributes_last_update_truncated"),
+        )
+
+    def test_the_newest_is_computed_over_the_rows_the_cap_dropped(self):
+        # The third element exists so a freshness header cannot report the
+        # newest SURVIVING instant as the newest instant. Here the newest row is
+        # provably not in the emitted map.
+        rows = self._many(250)
+        stamps, truncated, newest = diagnostics._attribute_timestamps(rows)
+        self.assertTrue(truncated)
+        self.assertNotIn("zzz_newest", stamps)
+        self.assertEqual(AC_STAMP_NEW, newest)
+
+    def test_exactly_at_the_cap_nothing_is_flagged(self):
+        rows = {
+            "p%03d" % i: FakeShadowAttribute("1", AC_STAMP_OLD)
+            for i in range(diagnostics._STAMP_MAX_ROWS)
+        }
+        stamps, truncated, _ = diagnostics._attribute_timestamps(rows)
+        self.assertEqual(diagnostics._STAMP_MAX_ROWS, len(stamps))
+        self.assertFalse(truncated)
+
+    def test_the_cap_clears_the_largest_real_device(self):
+        # Anti-rot: the cap is a runaway guard, not a filter. The biggest shadow
+        # this repository holds a dump from is the WM at 112 parameters
+        # (diagnostics/live-2026-06-22/device-WM.json).
+        self.assertGreater(diagnostics._STAMP_MAX_ROWS, 112)
+
+
+class AttributeTimestampNewestTest(unittest.TestCase):
+    """The third element: one pass, so nothing downstream can disagree with it."""
+
+    def test_the_newest_is_the_maximum_not_the_last_seen(self):
+        stamps, _, newest = diagnostics._attribute_timestamps(
+            {
+                "a": FakeShadowAttribute("1", AC_STAMP_NEW),
+                "b": FakeShadowAttribute("1", AC_STAMP_OLD),
+            }
+        )
+        self.assertEqual(AC_STAMP_NEW, newest)
+        self.assertEqual(2, len(stamps))
+
+    def test_the_newest_is_aware_utc_whatever_arrived(self):
+        # It is returned for subtraction, so it has to be aware or the age that
+        # uses it raises TypeError and takes the whole dump down.
+        for value in (
+            datetime(2026, 4, 9, 5, 34, 16),
+            datetime(2026, 4, 9, 5, 34, 16, tzinfo=timezone(timedelta(hours=3))),
+        ):
+            _, _, newest = diagnostics._attribute_timestamps(
+                {"a": FakeShadowAttribute("1", value)}
+            )
+            self.assertIsNotNone(newest)
+            self.assertIsNotNone(newest.utcoffset())
+
+    def test_the_newest_is_a_plain_datetime_whatever_arrived(self):
+        # Rebuilt from the integer fields, so a hostile subclass cannot ride out
+        # of this helper into whatever subtracts it next.
+        class Hostile(datetime):
+            def __sub__(self, other):
+                raise RuntimeError("boom")
+
+            def __rsub__(self, other):
+                raise RuntimeError("boom")
+
+        _, _, newest = diagnostics._attribute_timestamps(
+            {"a": FakeShadowAttribute("1", Hostile(2026, 4, 9, tzinfo=timezone.utc))}
+        )
+        self.assertIs(type(newest), datetime)
+        (FROZEN - newest).total_seconds()  # must not raise
+
+    def test_a_subclass_that_refuses_to_compare_does_not_kill_the_dump(self):
+        # The one unguarded expression this helper could have shipped: the first
+        # instant is short-circuited by `newest is None`, so the comparison only
+        # runs on the SECOND stamped parameter -- which is why a single-value
+        # test would have missed it entirely.
+        class Hostile(datetime):
+            def __gt__(self, other):
+                raise RuntimeError("boom")
+
+        block = _stamp_block(
+            {
+                "a": FakeShadowAttribute("1", AC_STAMP_OLD),
+                "b": FakeShadowAttribute(
+                    "1", Hostile(2026, 4, 9, 6, 0, 0, tzinfo=timezone.utc)
+                ),
+            }
+        )
+        self.assertEqual(
+            "2026-04-09T05:31:02+00:00", block["attributes_last_update"]["a"]
+        )
+
+    def test_the_newest_is_none_when_no_instant_ever_arrived(self):
+        stamps, _, newest = diagnostics._attribute_timestamps(
+            {"a": FakeShadowAttribute("1", None)}
+        )
+        self.assertEqual({"a": None}, stamps)
+        self.assertIsNone(newest)
+
+    def test_the_newest_is_never_emitted_from_here(self):
+        # It is a datetime, which HA's JSON encoder raises on. Nothing in the
+        # block may carry it: only `_stamp_text` output reaches the document.
+        _, blocks = _entry_diag()
+        json.dumps(blocks["AC"])  # must not raise
+
+
+class AttributeTimestampConversionTest(unittest.TestCase):
+    """What reaches the map is `_stamp_text` output and nothing else."""
+
+    def test_a_sub_minute_offset_survives_the_mac_mask(self):
+        # End to end, through `_redact`. An aware instant is normalised to UTC
+        # first, and that is CORRECTNESS: `_MAC_RE` reads '12:34:56-05:30:15' as
+        # six octet groups and eats the field down to '2026-04-09T***'.
+        odd = timezone(-timedelta(hours=5, minutes=30, seconds=15))
+        block = _stamp_block(
+            {"a": FakeShadowAttribute("1", datetime(2026, 4, 9, 12, 34, 56, tzinfo=odd))}
+        )
+        self.assertEqual(
+            "2026-04-09T18:05:11+00:00", block["attributes_last_update"]["a"]
+        )
+        self.assertNotIn("***", json.dumps(block["attributes_last_update"]))
+
+    def test_a_naive_instant_is_not_shifted_onto_the_host_zone(self):
+        block = _stamp_block(
+            {"a": FakeShadowAttribute("1", datetime(2020, 9, 29, 10, 1, 26))}
+        )
+        self.assertEqual("2020-09-29T10:01:26", block["attributes_last_update"]["a"])
+
+    def test_a_tzinfo_whose_offset_is_none_is_treated_as_naive(self):
+        # CPython does not raise here: it re-reads the instant in the HOST's zone
+        # and labels it '+00:00'. A wrong time wearing an authoritative offset is
+        # worse than a time with no offset at all.
+        class NoOffset(tzinfo):
+            def utcoffset(self, dt):
+                return None
+
+            def tzname(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+        block = _stamp_block(
+            {
+                "a": FakeShadowAttribute(
+                    "1", datetime(2020, 9, 29, 10, 1, 26, tzinfo=NoOffset())
+                )
+            }
+        )
+        self.assertEqual("2020-09-29T10:01:26", block["attributes_last_update"]["a"])
+
+    def test_a_datetime_subclass_cannot_smuggle_a_string(self):
+        # `isinstance(x, datetime)` admits subclasses and a subclass may return
+        # anything from `isoformat`. The row survives as a null; the string does
+        # not reach a document about to be attached to a public issue. This is
+        # also the THIRD way a `null` row is reached, and the docstring says so.
+        class Smuggler(datetime):
+            def isoformat(self, *args, **kwargs):
+                return "user@example.com"
+
+        block = _stamp_block({"a": FakeShadowAttribute("1", Smuggler(2026, 4, 9))})
+        self.assertEqual({"a": None}, block["attributes_last_update"])
+        self.assertNotIn("user@example.com", json.dumps(block))
+
+    def test_a_non_datetime_instant_is_a_null_row(self):
+        # A cloud STRING instant is refused by design: the map's promise is that
+        # every value in it was built by `datetime.isoformat`.
+        block = _stamp_block(
+            {
+                "a": FakeShadowAttribute("1", "2026-04-09T05:34:16Z"),
+                "b": FakeShadowAttribute("1", 1775712856741),
+            }
+        )
+        self.assertEqual({"a": None, "b": None}, block["attributes_last_update"])
+
+
+class AttributeTimestampEngineSemanticsTest(unittest.TestCase):
+    """Pinned against the real `HonAttribute`, not against a fake of it."""
+
+    @staticmethod
+    def _attr(payload):
+        # Imported inside the test on purpose: the point of these two cases is
+        # that the map's `null` semantics match the ENGINE's, so a fake would
+        # test nothing. Local, so the module's import block stays untouched.
+        from custom_components.addhon.client.engine.attributes import HonAttribute
+
+        return HonAttribute(payload)
+
+    def test_a_stale_stamp_survives_a_stampless_update(self):
+        # `attributes.py:73` is a walrus guard, so an update with no
+        # `lastUpdate` at all leaves the previous instant standing. This is why
+        # the docstring must NOT say a null means "the cloud stopped stamping
+        # it", and why a stamp may legitimately be older than the value beside
+        # it with nothing wrong anywhere.
+        attr = self._attr({"parNewVal": "1", "lastUpdate": "2020-09-29 10:01:26"})
+        attr.update({"parNewVal": "2"})
+        self.assertEqual("2", str(attr))
+        stamps, _, _ = diagnostics._attribute_timestamps({"a": attr})
+        self.assertEqual({"a": "2020-09-29T10:01:26"}, stamps)
+
+    def test_an_unparseable_instant_resets_the_row_to_null(self):
+        # The other half of the same guard (`attributes.py:75-77`): a
+        # present-but-unparseable value is the ONLY thing that clears an instant.
+        attr = self._attr({"parNewVal": "1", "lastUpdate": "2020-09-29 10:01:26"})
+        attr.update({"parNewVal": "2", "lastUpdate": "not-a-date"})
+        stamps, _, newest = diagnostics._attribute_timestamps({"a": attr})
+        self.assertEqual({"a": None}, stamps)
+        self.assertIsNone(newest)
+
+    def test_a_real_engine_attribute_produces_a_row(self):
+        # Anti-vacuity for the two cases above: the engine class really does
+        # expose the surface this section keys on.
+        attr = self._attr({"parNewVal": "1", "lastUpdate": "2026-04-09T05:34:16"})
+        stamps, _, newest = diagnostics._attribute_timestamps({"a": attr})
+        self.assertEqual({"a": "2026-04-09T05:34:16"}, stamps)
+        self.assertEqual(datetime(2026, 4, 9, 5, 34, 16, tzinfo=timezone.utc), newest)
+
+
+class AttributeTimestampDegradationTest(unittest.TestCase):
+    """A dump degrades; it never raises. `_appliance_block` has no net."""
+
+    def test_a_raising_property_becomes_a_null_row_not_a_missing_one(self):
+        stamps, truncated, newest = diagnostics._attribute_timestamps(
+            {"boom": _Raising(), "ok": FakeShadowAttribute("1", AC_STAMP_NEW)}
+        )
+        self.assertEqual(
+            {"boom": None, "ok": "2026-04-09T05:34:16+00:00"}, stamps
+        )
+        self.assertFalse(truncated)
+        self.assertEqual(AC_STAMP_NEW, newest)
+
+    def test_a_raising_property_does_not_break_the_dump(self):
+        block = _stamp_block({"boom": _Raising()})
+        self.assertEqual({"boom": None}, block["attributes_last_update"])
+
+    def test_an_empty_mapping_is_an_empty_map(self):
+        self.assertEqual(({}, False, None), diagnostics._attribute_timestamps({}))
+
+    def test_a_non_string_key_still_produces_a_row(self):
+        # The dump has to be JSON-native, and a non-string key would make HA's
+        # encoder the place the failure surfaces.
+        stamps, _, _ = diagnostics._attribute_timestamps(
+            {7: FakeShadowAttribute("1", AC_STAMP_NEW)}
+        )
+        self.assertEqual({"7": "2026-04-09T05:34:16+00:00"}, stamps)
+        json.dumps(stamps)  # must not raise
+
+    def test_a_mapping_that_refuses_the_parameters_key_is_survived(self):
+        # This helper makes the FIRST read of `attributes` in the block, so an
+        # unguarded `.get` here would take the dump down ahead of `_coverage`,
+        # which reads the same object a few lines below. `Mapping.get` only
+        # swallows KeyError, so a `__getitem__` raising anything else escapes it.
+        nested = _BrokenNested(
+            {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)}, broken="parameters"
+        )
+        self.assertEqual(
+            ({"tempZ1": "2026-04-09T05:31:02+00:00"}, False, AC_STAMP_OLD),
+            diagnostics._attribute_timestamps(nested),
+        )
+
+
+class AttributeTimestampNestedSourceTest(unittest.TestCase):
+    """The `parameters` sub-map, and why it is read at all."""
+
+    def test_the_nested_map_is_the_fallback_when_nothing_was_flattened(self):
+        # `hon_client.py:192-196`: `dict(params)` is evaluated in full before
+        # anything is merged, so one refusing key leaves NO bare parameter and
+        # the nested object as the only carrier of the instants.
+        nested = _BrokenNested(
+            {
+                "tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD),
+                "tempZ3": FakeShadowAttribute("-43", AC_STAMP_NEW),
+            },
+            broken=None,
+        )
+        stamps, _, newest = diagnostics._attribute_timestamps({"parameters": nested})
+        self.assertEqual(
+            {
+                "tempZ1": "2026-04-09T05:31:02+00:00",
+                "tempZ3": "2026-04-09T05:34:16+00:00",
+            },
+            stamps,
+        )
+        self.assertEqual(AC_STAMP_NEW, newest)
+
+    def test_a_bare_row_wins_over_the_nested_copy(self):
+        # On a healthy device the two agree, so this only matters if they ever
+        # stop agreeing: the bare value is what `attributes` prints, so it is
+        # the one the instants must describe.
+        bare = FakeShadowAttribute("1", AC_STAMP_NEW)
+        shadow = FakeShadowAttribute("1", AC_STAMP_OLD)
+        stamps, _, _ = diagnostics._attribute_timestamps(
+            {"tempZ1": bare, "parameters": {"tempZ1": shadow}}
+        )
+        self.assertEqual({"tempZ1": "2026-04-09T05:34:16+00:00"}, stamps)
+
+    def test_the_nested_key_itself_never_becomes_a_row(self):
+        stamps, _, _ = diagnostics._attribute_timestamps(
+            {"parameters": {"tempZ1": FakeShadowAttribute("1", AC_STAMP_NEW)}}
+        )
+        self.assertNotIn("parameters", stamps)
+
+    def test_a_non_mapping_parameters_value_is_not_walked(self):
+        # Deliberate: this runs on the event loop and `len()` is the only bound
+        # available before iterating, so an iterator under that key is left
+        # alone rather than consumed to rescue a degraded corner. Measured: with
+        # the `isinstance(nested, Mapping)` guard relaxed to `hasattr(nested,
+        # "__iter__")`, an endless iterator here hangs the test run forever,
+        # which on the event loop is a Home Assistant that stops responding.
+        #
+        # The witness is a FLAG and a finite generator rather than an endless
+        # one, on purpose: a test that proves its point by hanging is a test
+        # that hangs CI instead of reporting.
+        walked = []
+
+        def _rows():
+            walked.append(True)
+            yield ("x", FakeShadowAttribute("1", AC_STAMP_NEW))
+
+        stamps, _, _ = diagnostics._attribute_timestamps({"parameters": _rows()})
+        self.assertEqual({}, stamps)
+        self.assertEqual([], walked, "the iterator was consumed")
+        self.assertEqual({}, diagnostics._attribute_timestamps({"parameters": []})[0])
+
+    def test_one_refusing_key_costs_one_row_not_the_section(self):
+        # Scope note, verified on HEAD: this is asserted on the helper, not on a
+        # whole block, because a Mapping like this one already takes the entire
+        # dump down at `_redact(block)` -- which walks it with `.items()` and has
+        # no guard of its own. That exposure predates this section and is not
+        # fixed here; what IS fixed is that the new section is not the thing
+        # that dies, and that the instants it can read still get through.
+        nested = _BrokenNested(
+            {
+                "bad": FakeShadowAttribute("1", AC_STAMP_OLD),
+                "good": FakeShadowAttribute("1", AC_STAMP_NEW),
+            },
+            broken="bad",
+        )
+        stamps, _, newest = diagnostics._attribute_timestamps({"parameters": nested})
+        self.assertEqual({"good": "2026-04-09T05:34:16+00:00"}, stamps)
+        self.assertEqual(AC_STAMP_NEW, newest)
+
+
+class AttributeTimestampPrivacyTest(unittest.TestCase):
+    """The map adds no name and no value the dump did not already carry."""
+
+    def test_no_identity_reaches_the_whole_dump(self):
+        # The first whole-document identity scan outside `future_capabilities`
+        # and the entity inventory. The instants are a new section reading a new
+        # surface off cloud objects, so it is worth pinning at the document
+        # level rather than field by field.
+        result, _ = _entry_diag()
+        encoded = json.dumps(result)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+        self.assertNotIn("PLAINTEXT-SERIAL", encoded)
+        self.assertNotIn("SN-PLAINTEXT", encoded)
+        self.assertNotIn("phone-install-xyz", encoded)
+
+    def test_a_stamp_under_a_redacted_key_name_is_still_redacted(self):
+        # No re-keying: the row keeps the cloud's own parameter name, so
+        # `_redact` -- which matches by EXACT key name -- still reaches it. A map
+        # that renamed its rows to something generic would put them permanently
+        # out of the redactor's reach, and that is the failure this pins.
+        block = _stamp_block(
+            {"serialNumber": FakeShadowAttribute("SN-X", AC_STAMP_NEW)}
+        )
+        self.assertEqual("***", block["attributes_last_update"]["serialNumber"])
+
+    def test_the_row_names_are_names_the_attributes_section_already_prints(self):
+        # The map introduces no new string into the document: on the bare path
+        # its keys are keys of `attributes`, which is emitted verbatim one
+        # section earlier, and on the nested-fallback path they are the keys of
+        # the `parameters` sub-map printed one level deeper in that same
+        # section. That is why the keys need no cap of their own.
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            self.assertLessEqual(
+                set(block["attributes_last_update"]), set(block["attributes"])
+            )
+        nested_block = _stamp_block(
+            {"parameters": {"tempZ1": FakeShadowAttribute("4", AC_STAMP_OLD)}}
+        )
+        self.assertEqual(
+            set(nested_block["attributes_last_update"]),
+            set(nested_block["attributes"]["parameters"]),
+        )
+
+    def test_a_stamp_can_only_ever_be_an_instant(self):
+        # The values are `_stamp_text` output, validated against `_ISO_RE`
+        # before they are returned, so the row cannot carry free text however
+        # the cloud object behaves.
+        class Sneaky:
+            value = "1"
+            last_update = "AA:BB:CC:DD:EE:FF"
+
+        block = _stamp_block({"a": Sneaky()})
+        self.assertEqual({"a": None}, block["attributes_last_update"])
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3484,5 +3484,643 @@ class AttributeTimestampPrivacyTest(unittest.TestCase):
         self.assertEqual({"a": None}, block["attributes_last_update"])
 
 
+# --- step 4: the reduced `freshness` block (P2b) -----------------------------
+#
+# The clock seam, FROZEN and FROZEN_TEXT are step 1's and are REUSED, not
+# redefined: a second `class _FrozenClock` further down this file would silently
+# shadow the first and quietly stop patching what the earlier tests think it does.
+#
+# Every appliance below is built HERE. Nothing in this section touches
+# `_build_coordinator`: its AC/WD attribute dicts are hand-counted by
+# `test_coverage_totals` (`attributes_total == 6`), so bolting a `lastConnEvent`
+# onto them to save a fixture would break an assertion three hundred lines away
+# for a reason nobody reading it could guess.
+
+# The pinned connection event, and the age that follows from it by hand:
+# 07:09:40 (FROZEN) - 07:02:46 = 6m54s = 414s. The epoch spelling is the same
+# instant to the millisecond, so a test can tell WHICH of the two fields the code
+# read only by making them disagree on purpose (see the preference test).
+CONN_STAMP_TEXT = "2026-08-13T07:02:46+00:00"
+CONN_STAMP_EPOCH_MS = 1786604566000
+CONN_STAMP_ISO = "2026-08-13T07:02:46Z"
+CONN_AGE_S = 414
+# An OLD instant used only to prove which field wins: years away from the one
+# above, so a preference bug cannot hide inside a rounding difference.
+OLD_STAMP_ISO = "2020-09-29T10:01:26Z"
+OLD_STAMP_TEXT = "2020-09-29T10:01:26+00:00"
+
+MAC_IN_THE_CLEAR = "3c:71:bf:bd:32:2c"
+
+
+class FakeLinkAppliance:
+    """An appliance exposing the engine's `connection` surface.
+
+    `HonAppliance.connection` is a property backed by `_connection`, and the whole
+    point of the `connected` field is to print what that property says, so the
+    fixture has to have one rather than relying on a bare attribute lookup that
+    happens to succeed.
+    """
+
+    def __init__(self, connection):
+        self.commands = {}
+        self.connection = connection
+
+
+class FakeExplodingLinkAppliance:
+    """An appliance whose `connection` property RAISES.
+
+    Not a hypothetical: `connection` is a real property, `_appliance_block` is
+    called with no try/except around it from either entry point, and the dumps
+    that matter most are the ones taken while something is already broken.
+    """
+
+    def __init__(self):
+        self.commands = {}
+
+    @property
+    def connection(self):
+        raise RuntimeError("boom")
+
+
+class ExplodingMapping(dict):
+    """A Mapping whose `.get` raises, i.e. a hostile cloud envelope."""
+
+    def get(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
+def _conn_event(**overrides):
+    """The live `lastConnEvent` shape, MAC sibling included.
+
+    Verified against diagnostics/live-2026-06-22/device-REF.json: the envelope
+    really does carry a `macAddress` next to the `category`, which is the reason
+    `category` is type-guarded instead of stringified.
+    """
+    event = {
+        "macAddress": "AA:BB:CC:DD:EE:FF",
+        "category": "DISCONNECTED",
+        "instantTime": CONN_STAMP_ISO,
+        "timestampEvent": CONN_STAMP_EPOCH_MS,
+    }
+    event.update(overrides)
+    return event
+
+
+def _freshness_of(attributes, appliance=None, now=FROZEN, app_type="REF"):
+    """A `freshness` section produced by the REAL block, redaction included.
+
+    Deliberately not a direct `_freshness` call: the section has to survive
+    `_redact` and `_jsonable` on the way out, and a helper that skipped them would
+    pass while the shipped dump raised on a datetime.
+    """
+    block = diagnostics._appliance_block(
+        "id1",
+        {
+            "appliance": appliance,
+            "type": app_type,
+            "attributes": attributes,
+            "statistics": {},
+        },
+        None,
+        now,
+    )
+    return block["freshness"]
+
+
+def _json_native(value) -> bool:
+    """True when `value` is something HA's JSON encoder will not raise on."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return True
+    if isinstance(value, list):
+        return all(_json_native(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(k, str) and _json_native(v) for k, v in value.items()
+        )
+    return False
+
+
+def _iter_stamps(section):
+    """Every `at` string anywhere in a freshness section."""
+    for value in section.values():
+        if isinstance(value, dict) and isinstance(value.get("at"), str):
+            yield value["at"]
+
+
+class FreshnessPlacementTest(unittest.TestCase):
+    """Where the section sits, which is most of what it buys."""
+
+    def test_freshness_sits_between_the_identity_keys_and_the_model(self):
+        # The section's whole claim is prominence: `available` was already in the
+        # dump as one of sixty attribute keys. If it drifts below `attributes` it
+        # stops answering the question before the values arrive and becomes a
+        # duplicate of a scalar that was always there.
+        _, blocks = _entry_diag()
+        for app_type, block in blocks.items():
+            keys = list(block)
+            self.assertIn("freshness", keys, app_type)
+            self.assertEqual("mac", keys[keys.index("freshness") - 1], app_type)
+            self.assertEqual(
+                "model_attributes", keys[keys.index("freshness") + 1], app_type
+            )
+
+    def test_every_appliance_block_carries_the_section(self):
+        # Including the one with nothing to say. An absent section would read as
+        # "this dump does not do freshness"; an empty-ish one reads as "nothing
+        # here reported a connection state", which is the honest finding.
+        _, blocks = _entry_diag()
+        for app_type, block in blocks.items():
+            self.assertIsInstance(block["freshness"], dict, app_type)
+
+    def test_the_device_dump_carries_it_too(self):
+        coord = _build_coordinator()
+        hass = FakeHass(coord)
+        device = FakeDevice(identifiers={(DOMAIN, AC_ID)})
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(hass, FakeEntry(), device)
+            )
+        self.assertIn("freshness", result["appliance"])
+
+
+class FreshnessShippedFieldsTest(unittest.TestCase):
+    """The reduced shape, pinned so the dropped fields cannot creep back."""
+
+    def _full_section(self):
+        """Every field this block can emit, all four present at once.
+
+        Asserting a key set against a thin fixture only proves what happened to be
+        missing; this one has a connection state, an availability flag, a conn
+        event and a shadow, so the assertions below are about what IS shipped.
+        """
+        return diagnostics._freshness(
+            FakeLinkAppliance(False),
+            {"available": False, "lastConnEvent": _conn_event()},
+            AC_STAMP_NEW,
+            FROZEN,
+        )
+
+    def test_the_dropped_connectivity_fields_never_appear(self):
+        # `decided_by`, `realtime` and `realtime_ttl_s` were designed for this
+        # block and dropped for three independent reasons, all of which make them
+        # print a claim the same dump disproves a line later. The sharpest:
+        # `mark_realtime_disconnected` sets connection False and CLEARS both
+        # realtime marks while leaving the cached lastConnEvent at its last REST
+        # value, so the mirror would print `connected: false` beside a CONNECTED
+        # category and two empty marks -- every printed input saying online. This
+        # test is here so reintroducing them is a deliberate act with a failing
+        # test attached, not a merge that looked harmless.
+        section = self._full_section()
+        for dropped in ("decided_by", "realtime", "realtime_ttl_s"):
+            self.assertNotIn(dropped, section)
+        encoded = json.dumps(section)
+        for dropped in ("decided_by", "realtime", "rest_connected"):
+            self.assertNotIn(dropped, encoded)
+
+    def test_poll_is_absent_and_that_is_deliberate(self):
+        # There is no honest source for it from inside `_appliance_block`. The
+        # coordinator entry carries no fetch instant, the coordinator itself is not
+        # passed in and must not be, and the engine's `_last_update` is private,
+        # NAIVE and in the host's zone (so read as UTC it prints a negative age for
+        # every reporter east of Greenwich), and only advances on the HTTP path, so
+        # on a realtime snapshot it would call the freshest data the stalest.
+        self.assertNotIn("poll", self._full_section())
+
+    def test_the_key_set_and_its_order_are_exactly_the_shipped_ones(self):
+        full = self._full_section()
+        self.assertEqual(
+            ["connected", "available", "last_conn_event", "shadow"], list(full)
+        )
+        self.assertEqual(["category", "at", "age_s"], list(full["last_conn_event"]))
+        self.assertEqual(["at", "age_s"], list(full["shadow"]))
+
+    def test_a_thin_appliance_emits_a_subset_and_never_a_new_name(self):
+        # The conditional keys drop out; nothing else appears in their place.
+        thin = _freshness_of({})
+        self.assertLessEqual(
+            set(thin), {"connected", "available", "last_conn_event", "shadow"}
+        )
+
+
+class FreshnessConnectivityTest(unittest.TestCase):
+    """`connected` and `available`, guarded as booleans or reported as nothing."""
+
+    def test_a_disconnected_appliance_says_so_at_the_top_of_its_block(self):
+        # The one thing P2 was chartered to deliver, and it survives the reduction
+        # intact: "this dump was taken while the appliance was offline".
+        section = _freshness_of(
+            {"available": False, "lastConnEvent": _conn_event()},
+            FakeLinkAppliance(False),
+        )
+        self.assertIs(False, section["connected"])
+        self.assertIs(False, section["available"])
+        self.assertEqual("DISCONNECTED", section["last_conn_event"]["category"])
+
+    def test_a_connected_appliance_says_that_too(self):
+        section = _freshness_of({"available": True}, FakeLinkAppliance(True))
+        self.assertIs(True, section["connected"])
+        self.assertIs(True, section["available"])
+
+    def test_a_non_boolean_connection_is_reported_as_null(self):
+        # The engine writes real bools into both surfaces. A "true" or a 1 arriving
+        # here means something upstream is no longer what this section thinks it
+        # is, and printing it anyway would launder that into an unquestionable fact.
+        for junk in ("true", 1, 0, "", [], {"a": 1}):
+            with self.subTest(junk=junk):
+                section = _freshness_of({}, FakeLinkAppliance(junk))
+                self.assertIsNone(section["connected"])
+
+    def test_an_appliance_with_no_connection_surface_gives_null(self):
+        section = _freshness_of({}, FakeApplianceNoModel(commands={}))
+        self.assertIsNone(section["connected"])
+
+    def test_a_raising_connection_property_does_not_break_the_dump(self):
+        # `_appliance_block` has no try/except around it from either entry point,
+        # so an unguarded read here does not produce a wrong field, it produces no
+        # dump at all.
+        section = _freshness_of({"available": True}, FakeExplodingLinkAppliance())
+        self.assertIsNone(section["connected"])
+        self.assertIs(True, section["available"])
+
+    def test_available_is_read_as_a_boolean_or_not_at_all(self):
+        self.assertIsNone(_freshness_of({})["available"])
+        self.assertIsNone(_freshness_of({"available": "false"})["available"])
+        self.assertIsNone(_freshness_of({"available": FakeWrapper(True)})["available"])
+        self.assertIs(False, _freshness_of({"available": False})["available"])
+
+
+class FreshnessConnEventTest(unittest.TestCase):
+    """The `last_conn_event` row: what the cloud last said, and how long ago."""
+
+    def test_the_row_carries_category_at_and_age(self):
+        row = _freshness_of({"lastConnEvent": _conn_event()})["last_conn_event"]
+        self.assertEqual(
+            {"category": "DISCONNECTED", "at": CONN_STAMP_TEXT, "age_s": CONN_AGE_S},
+            row,
+        )
+
+    def test_the_epoch_field_is_preferred_over_the_iso_string(self):
+        # Not a coin toss: it is the same order, on the same two keys, that
+        # `HonAppliance.load_attributes` uses when deciding whether a REST
+        # disconnect is newer than the last realtime traffic. A dump that quietly
+        # preferred the other key would, on a payload where the two disagree,
+        # explain a decision the engine did not make. Made observable by pointing
+        # the two fields at instants six years apart.
+        row = _freshness_of(
+            {"lastConnEvent": _conn_event(instantTime=OLD_STAMP_ISO)}
+        )["last_conn_event"]
+        self.assertEqual(CONN_STAMP_TEXT, row["at"])
+        self.assertNotEqual(OLD_STAMP_TEXT, row["at"])
+
+    def test_an_unparseable_epoch_falls_back_to_the_iso_string(self):
+        # The engine falls back on PARSE failure, not on absence; mirrored here.
+        row = _freshness_of(
+            {"lastConnEvent": _conn_event(timestampEvent="not-a-time")}
+        )["last_conn_event"]
+        self.assertEqual(CONN_STAMP_TEXT, row["at"])
+
+    def test_a_null_epoch_falls_back_to_the_iso_string(self):
+        row = _freshness_of(
+            {"lastConnEvent": _conn_event(timestampEvent=None)}
+        )["last_conn_event"]
+        self.assertEqual(CONN_STAMP_TEXT, row["at"])
+
+    def test_a_row_with_no_usable_instant_still_reports_its_category(self):
+        # `at` and `age_s` appear together or not at all: an `at` with no age makes
+        # the reader do the arithmetic this section exists to have already done,
+        # and an age with no `at` is a number with nothing to check it against.
+        row = _freshness_of(
+            {
+                "lastConnEvent": _conn_event(
+                    timestampEvent="garbage", instantTime="also-garbage"
+                )
+            }
+        )["last_conn_event"]
+        self.assertEqual({"category": "DISCONNECTED"}, row)
+
+    def test_the_shared_fixture_has_no_conn_event_and_still_builds(self):
+        # ABSENT, not present-and-null. Missing means the appliance carries no such
+        # envelope; present with a null category means it carries one and the field
+        # inside was not usable text. Folding them together would report "never
+        # reported a connection event" and "malformed payload" as one finding.
+        _, blocks = _entry_diag()
+        for app_type, block in blocks.items():
+            self.assertNotIn("last_conn_event", block["freshness"], app_type)
+
+    def test_a_non_mapping_conn_event_is_ignored(self):
+        for junk in ("DISCONNECTED", 1, ["DISCONNECTED"], None):
+            with self.subTest(junk=junk):
+                self.assertNotIn(
+                    "last_conn_event", _freshness_of({"lastConnEvent": junk})
+                )
+
+    def test_a_raising_conn_event_mapping_does_not_break_the_dump(self):
+        # A cloud-supplied Mapping is free to have a `.get` that raises, and from
+        # here that would abort the whole dump rather than one row of it.
+        row = _freshness_of({"lastConnEvent": ExplodingMapping()})["last_conn_event"]
+        self.assertEqual({"category": None}, row)
+
+    def test_a_raising_attributes_mapping_does_not_break_the_dump(self):
+        # The same shape one level up. `_coverage` reaches `.get` only while it
+        # still has unmapped bare keys to classify, so on an appliance whose bare
+        # keys are all mapped this section makes the FIRST such call in the block
+        # and an unguarded read here would be a brand new way to lose the dump.
+        self.assertEqual(
+            {"connected": None, "available": None},
+            _freshness_of(ExplodingMapping({"tempIndoor": 1}), app_type="AC"),
+        )
+
+    def test_a_non_string_category_is_reported_as_null(self):
+        for junk in (1, True, None, ["DISCONNECTED"], FakeWrapper("DISCONNECTED")):
+            with self.subTest(junk=junk):
+                row = _freshness_of({"lastConnEvent": _conn_event(category=junk)})
+                self.assertIsNone(row["last_conn_event"]["category"])
+
+    def test_an_empty_category_reads_as_null_and_the_docstring_says_why(self):
+        # An empty string IS a string, and `_bounded_text` refuses it along with
+        # every other empty scalar -- so this prints null where the ENGINE saw a
+        # decision (`lce.get("category", "") != "DISCONNECTED"` is True for "").
+        # Pinned rather than fixed: `connected` on the line above already carries
+        # the finding, and a bare "" in a dump reads as a rendering bug.
+        row = _freshness_of({"lastConnEvent": _conn_event(category="")})
+        self.assertIsNone(row["last_conn_event"]["category"])
+        # A category that is only whitespace is not empty and survives, which is
+        # what makes the line above a statement about `or None` and not about str.
+        spaced = _freshness_of({"lastConnEvent": _conn_event(category="   ")})
+        self.assertEqual("   ", spaced["last_conn_event"]["category"])
+
+
+class FreshnessShadowAgeTest(unittest.TestCase):
+    """`shadow`: the newest instant the cloud stamped on any parameter."""
+
+    def test_the_shadow_is_the_newest_instant_the_cloud_stamped(self):
+        # Pinned against the wrapped AC fixture: tempSel carries AC_STAMP_NEW,
+        # tempIndoor the older one, machMode none at all. The age is derived from
+        # the two pinned constants rather than typed out, so the assertion says
+        # "the code did this subtraction" and not "the code returned 10892124".
+        with _FrozenClock(FROZEN):
+            _, blocks = _entry_diag()
+        self.assertEqual(
+            {
+                "at": "2026-04-09T05:34:16+00:00",
+                "age_s": int((FROZEN - AC_STAMP_NEW).total_seconds()),
+            },
+            blocks["AC"]["freshness"]["shadow"],
+        )
+
+    def test_the_shadow_matches_the_printed_timestamp_map(self):
+        # The Part 2 requirement made checkable: the two sections are one pass, so
+        # they cannot disagree. If a future edit re-derives the shadow from a
+        # second walk, this is what catches it.
+        with _FrozenClock(FROZEN):
+            _, blocks = _entry_diag()
+        block = blocks["AC"]
+        printed = [v for v in block["attributes_last_update"].values() if v]
+        self.assertTrue(printed, "the fixture would make this vacuous")
+        self.assertEqual(max(printed), block["freshness"]["shadow"]["at"])
+
+    def test_the_shadow_is_absent_when_no_instant_has_ever_arrived(self):
+        # The WD fixture wraps nothing, so no parameter exposes a `last_update`.
+        with _FrozenClock(FROZEN):
+            _, blocks = _entry_diag()
+        self.assertNotIn("shadow", blocks["WD"]["freshness"])
+
+    def test_the_shadow_is_the_instant_it_was_HANDED_not_one_it_recomputes(self):
+        # The invariant that survives a truncated map: `_freshness` is given the
+        # newest instant by the same pass that built the printed rows, including
+        # rows the row cap dropped. Handing it an instant that appears NOWHERE in
+        # `attributes` proves it does not go looking for its own.
+        section = diagnostics._freshness(
+            None,
+            {"tempZ1": FakeShadowAttribute("3", AC_STAMP_OLD)},
+            AC_STAMP_NEW,
+            FROZEN,
+        )
+        self.assertEqual("2026-04-09T05:34:16+00:00", section["shadow"]["at"])
+
+    def test_a_naive_shadow_instant_is_read_as_utc_and_still_paired(self):
+        # `at` and `age_s` appear together or not at all. Handing the section a
+        # naive instant used to print an offset-less `at` beside a null age --
+        # the exact shape this block refuses everywhere else -- so awareness is
+        # decided here rather than trusted from the caller.
+        section = diagnostics._freshness(
+            None, {}, datetime(2026, 8, 13, 7, 0, 0), FROZEN
+        )
+        self.assertEqual(
+            {"at": "2026-08-13T07:00:00+00:00", "age_s": 580}, section["shadow"]
+        )
+
+    def test_a_future_instant_gives_a_negative_age_rather_than_zero(self):
+        # Not clamped, on purpose. The instants here are stamped by the CLOUD while
+        # `now` is stamped by the reporter's host, so a negative age is the dump
+        # saying the two clocks disagree -- itself a finding, and one that explains
+        # connectivity decisions the engine makes by ordering those timestamps.
+        ahead = FROZEN + timedelta(seconds=90)
+        section = diagnostics._freshness(None, {}, ahead, FROZEN)
+        self.assertEqual(-90, section["shadow"]["age_s"])
+
+    def test_a_junk_newest_stamp_produces_no_shadow(self):
+        for junk in ("2026-04-09T05:34:16Z", 1775712856741, object(), True):
+            with self.subTest(junk=junk):
+                self.assertNotIn(
+                    "shadow", diagnostics._freshness(None, {}, junk, FROZEN)
+                )
+
+    def test_an_uncomputable_age_degrades_to_null(self):
+        # The only reason `_age_seconds` carries a guard at all: both its operands
+        # are aware UTC by construction, but a foreign datetime subclass with an
+        # opinion about subtraction would otherwise take the whole dump down from
+        # inside a field that is never more than a convenience.
+        class HostileMoment:
+            def __rsub__(self, other):
+                raise RuntimeError("boom")
+
+        self.assertIsNone(diagnostics._age_seconds(HostileMoment(), FROZEN))
+
+    def test_an_age_is_a_whole_number_of_seconds(self):
+        moment = FROZEN - timedelta(seconds=9, milliseconds=900)
+        section = diagnostics._freshness(None, {}, moment, FROZEN)
+        self.assertEqual(9, section["shadow"]["age_s"])
+        self.assertIsInstance(section["shadow"]["age_s"], int)
+
+
+class FreshnessPrivacyTest(unittest.TestCase):
+    """Nothing identity-shaped may reach the section, by any route."""
+
+    def test_the_conn_event_mac_never_reaches_the_section(self):
+        section = _freshness_of({"lastConnEvent": _conn_event()})
+        encoded = json.dumps(section)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+        self.assertNotIn("macAddress", encoded)
+
+    def test_a_mac_straddling_the_category_cap_is_masked(self):
+        # THE regression the shared `_bounded_text` exists for, exercised through
+        # THIS field: the address starts at offset 30 with the cap at 40, so a
+        # helper that cut before masking would hand `_MAC_RE` ten characters of a
+        # seventeen-character address -- no longer six groups, no longer a match --
+        # and ship the remains to a public issue.
+        category = "x" * 30 + MAC_IN_THE_CLEAR
+        section = _freshness_of({"lastConnEvent": _conn_event(category=category)})
+        self.assertEqual("x" * 30 + "***", section["last_conn_event"]["category"])
+        # Not vacuous: cutting first really does leak on this exact input, and it
+        # leaks the plan's measured fragment -- three and a half octets.
+        self.assertEqual("x" * 30 + "3c:71:bf:b", category[:40])
+
+    def test_a_category_that_is_the_envelope_itself_is_refused(self):
+        # `str()` on the Mapping would flatten the sibling `macAddress` into one
+        # string filed under `category`, where `_redact` -- which matches by exact
+        # key NAME -- can never reach it again.
+        event = _conn_event()
+        event["category"] = dict(event)
+        section = _freshness_of({"lastConnEvent": event})
+        self.assertIsNone(section["last_conn_event"]["category"])
+        encoded = json.dumps(section)
+        self.assertNotIn("macAddress", encoded)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+
+    def test_a_cloud_string_instant_is_never_echoed(self):
+        # `instantTime` is cloud-chosen text. The only way it reaches the dump is
+        # by being PARSED into a datetime and re-rendered from that datetime's own
+        # fields, so a payload smuggled into the slot yields no `at` at all.
+        section = _freshness_of(
+            {
+                "lastConnEvent": _conn_event(
+                    timestampEvent=None, instantTime="user@example.com"
+                )
+            }
+        )
+        self.assertNotIn("at", section["last_conn_event"])
+        self.assertNotIn("user@example.com", json.dumps(section))
+
+    def test_the_category_is_bounded(self):
+        section = _freshness_of({"lastConnEvent": _conn_event(category="z" * 400)})
+        self.assertEqual(40, len(section["last_conn_event"]["category"]))
+
+    def test_the_whole_section_carries_no_identity(self):
+        # A whole-dump scan over the shared fixture, which carries a plaintext
+        # serial, a plaintext MAC and a nested commandHistory, plus an ad-hoc
+        # appliance whose conn event carries a MAC of its own.
+        _, blocks = _entry_diag()
+        ad_hoc = _freshness_of({"lastConnEvent": _conn_event()})
+        # Anti-vacuity FIRST: a scan over a section that lost its conn event
+        # passes for the wrong reason, which is how leak tests rot.
+        self.assertEqual("DISCONNECTED", ad_hoc["last_conn_event"]["category"])
+        sections = [json.dumps(b["freshness"]) for b in blocks.values()]
+        sections.append(json.dumps(ad_hoc))
+        for encoded in sections:
+            self.assertNotIn("PLAINTEXT", encoded)
+            self.assertNotIn("AA:BB:CC:DD:EE:FF", encoded)
+            self.assertNotIn("11:22:33:44:55:66", encoded)
+            self.assertNotIn("SN-", encoded)
+
+    def test_an_emitted_instant_cannot_look_like_a_mac(self):
+        # A sub-minute offset makes an ISO instant match `_MAC_RE`. Everything this
+        # section emits goes through `_stamp_text`, which normalises to UTC first,
+        # so the offset is always "+00:00" and the field survives the mask intact.
+        for section in (
+            _freshness_of({"lastConnEvent": _conn_event()}),
+            diagnostics._freshness(None, {}, AC_STAMP_NEW, FROZEN),
+        ):
+            stamps = list(_iter_stamps(section))
+            self.assertTrue(stamps, "the fixture would make this vacuous")
+            for text in stamps:
+                self.assertTrue(text.endswith("+00:00"), text)
+                self.assertEqual(text, debug_utils._MAC_RE.sub("***", text))
+
+
+class FreshnessDegradationTest(unittest.TestCase):
+    """A dump degrades, never raises. `_appliance_block` has no net under it."""
+
+    def test_a_foreign_appliance_object_still_produces_a_section(self):
+        section = _freshness_of({}, object())
+        self.assertEqual({"connected": None, "available": None}, section)
+
+    def test_an_appliance_with_no_attributes_at_all_still_produces_a_section(self):
+        block = diagnostics._appliance_block(
+            "id1",
+            {"appliance": None, "type": "REF", "attributes": None, "statistics": None},
+            None,
+            FROZEN,
+        )
+        self.assertEqual({"connected": None, "available": None}, block["freshness"])
+
+    def test_the_section_survives_every_malformed_conn_event_shape(self):
+        shapes = (
+            {},
+            {"category": None},
+            {"category": {}},
+            {"category": "OK", "timestampEvent": {}},
+            {"category": "OK", "timestampEvent": [1]},
+            {"category": "OK", "timestampEvent": True},
+            {"category": "OK", "timestampEvent": 10 ** 400},
+            {"category": "OK", "instantTime": ""},
+            {"category": "OK", "instantTime": "2026-13-45T99:99:99Z"},
+            {"instantTime": CONN_STAMP_ISO},
+            ExplodingMapping(),
+        )
+        for shape in shapes:
+            with self.subTest(shape=repr(shape)[:40]):
+                section = _freshness_of({"lastConnEvent": shape})
+                self.assertIsInstance(section["last_conn_event"], dict)
+                self.assertTrue(_json_native(section))
+
+    def test_a_raising_instant_read_does_not_discard_a_category_already_read(self):
+        # Two guards rather than one: the category is read first and kept, so a
+        # `.get` that only breaks on the instant keys costs the instant and not
+        # the finding the reader actually came for.
+        class HalfBroken(dict):
+            def get(self, key, *args):
+                if key == "category":
+                    return "DISCONNECTED"
+                raise RuntimeError("boom")
+
+        row = _freshness_of({"lastConnEvent": HalfBroken()})["last_conn_event"]
+        self.assertEqual({"category": "DISCONNECTED"}, row)
+
+    def test_every_emitted_value_is_json_native(self):
+        # HA's encoder raises on a datetime, and this is the one section of the
+        # dump that handles datetimes at all.
+        section = _freshness_of(
+            {"available": False, "lastConnEvent": _conn_event()},
+            FakeLinkAppliance(False),
+        )
+        self.assertTrue(_json_native(section))
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            self.assertTrue(_json_native(block["freshness"]))
+            json.dumps(block)  # must not raise
+
+    def test_a_naive_dump_instant_never_reaches_a_subtraction(self):
+        # The TypeError that would take the whole dump down. `_appliance_block`
+        # normalises at its boundary, so a caller handing in a naive datetime gets
+        # the same age as one handing in an aware one.
+        naive = _freshness_of(
+            {"lastConnEvent": _conn_event()},
+            now=datetime(2026, 8, 13, 7, 9, 40),
+        )
+        self.assertEqual(CONN_AGE_S, naive["last_conn_event"]["age_s"])
+
+    def test_a_block_built_with_no_instant_at_all_still_dates_its_ages(self):
+        # The two-positional-argument call site: `now` falls back to the seam.
+        with _FrozenClock(FROZEN):
+            block = diagnostics._appliance_block(
+                "id1",
+                {
+                    "appliance": None,
+                    "type": "REF",
+                    "attributes": {"lastConnEvent": _conn_event()},
+                    "statistics": {},
+                },
+            )
+        self.assertEqual(CONN_AGE_S, block["freshness"]["last_conn_event"]["age_s"])
+
+    def test_an_unusable_cloud_parser_degrades_to_no_instant(self):
+        # The lazy import mirrors `_mapped_sets`: on any import hiccup the row
+        # loses its instant instead of the dump losing everything.
+        with _BrokenModules("client.helpers"):
+            row = _freshness_of({"lastConnEvent": _conn_event()})["last_conn_event"]
+        self.assertEqual({"category": "DISCONNECTED"}, row)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -15,8 +15,10 @@ registries can be imported for the coverage axis). No real Home Assistant instal
 """
 from __future__ import annotations
 
+import ast
 import asyncio
 import dataclasses
+import importlib
 import json
 import sys
 import types
@@ -3030,6 +3032,460 @@ class EntitySourceDriftGuardTest(unittest.TestCase):
             for half in ("read", "write"):
                 if half in entry:
                     self.assertIsInstance(entry[half], tuple, entry["tag"])
+
+
+# --- the walk is complete: no platform table is invisible to it -------------
+
+
+# The integration modules whose description tables `_mapped_sets` is expected to
+# account for. This IS a whitelist, and a whitelist is the defect this section
+# exists to close -- so it is not trusted:
+# `test_no_other_module_grew_a_description_table` below derives the same set from
+# the SOURCE of every file under custom_components/addhon and fails if the two
+# disagree. The chain therefore bottoms out in something no contributor has to
+# remember to update.
+_TABLE_MODULES = ("binary_sensor", "number", "select", "sensor", "switch")
+
+# Tables that deliberately contribute no parameter the dump should account for.
+#
+# EMPTY, and that is the honest state: every description table in the five
+# modules above is reached by the walk today. An entry here is a promise that a
+# reader of a dump is not misled by the absence of these parameters from
+# `coverage` and `entities.sources`, so the reason must say what the dump prints
+# for them INSTEAD and why that is right -- not that the table is new, internal,
+# experimental or special. `test_every_exemption_is_still_needed` deletes the
+# entry for you the day it stops being true, by failing.
+_TABLES_OUTSIDE_COVERAGE: dict[str, str] = {}
+
+# Planted into a clone of every table at once, then looked for in the tags
+# `_mapped_sets` emits. The counter appended to it is fixed width, so no probe
+# key can be a suffix of another; the prefix is spelled unlike any real
+# translation key so a leak into a real dump would be unmistakable.
+_PROBE_KEY = "zz_completeness_probe_"
+
+
+def _is_entity_description(obj) -> bool:
+    """True for a description INSTANCE of any of the ten description classes.
+
+    Duck-typed rather than isinstance-checked against a base: the ten classes
+    have no common ancestor. Four extend Home Assistant's `EntityDescription`
+    (itself stubbed differently by conftest and by this file) and six --
+    `HonSettingsSwitchDescription`, `HonProgramOptionSelectDescription` and their
+    siblings -- are plain local dataclasses that extend nothing. What all ten
+    share, and what the walk actually reads, is that they are dataclass instances
+    carrying a `key`.
+    """
+    return (
+        dataclasses.is_dataclass(obj)
+        and not isinstance(obj, type)
+        and any(field.name == "key" for field in dataclasses.fields(obj))
+    )
+
+
+def _descriptions_in(value, seen=None) -> list:
+    """Every description reachable from one module-level binding.
+
+    The real tables are not one shape. `SENSORS` and `_SETTINGS_SWITCHES` are
+    dicts keyed by appliance type; `_PROGRAM_OPTION_SWITCHES` and `_WASH_EXTRA`
+    are flat tuples; `_CONNECTIVITY` is a single description with no container at
+    all. Recursing over containers instead of matching a shape means a table
+    added in a shape nobody anticipated is still found, and the `seen` set means
+    a table that appears twice (`_REMOTE_CONTROL` is also inside
+    `_UNIVERSAL_GATED`) cannot loop or double-count.
+    """
+    seen = set() if seen is None else seen
+    if id(value) in seen:
+        return []
+    seen.add(id(value))
+    if _is_entity_description(value):
+        return [value]
+    found: list = []
+    if isinstance(value, Mapping):
+        for item in value.values():
+            found.extend(_descriptions_in(item, seen))
+    elif isinstance(value, (tuple, list, set, frozenset)):
+        for item in value:
+            found.extend(_descriptions_in(item, seen))
+    return found
+
+
+def _with_probe_row(value, probe):
+    """`value` plus one extra description, or None if it cannot be built.
+
+    Returning None rather than guessing is deliberate: a table shape this cannot
+    augment is a table whose reachability cannot be MEASURED, and the guard says
+    so out loud instead of reporting the silence as a pass.
+    """
+    if _is_entity_description(value):
+        augmented = probe
+    elif isinstance(value, Mapping):
+        augmented = dict(value)
+        for key, item in list(augmented.items()):
+            if isinstance(item, tuple):
+                augmented[key] = item + (probe,)
+            elif isinstance(item, list):
+                augmented[key] = [*item, probe]
+            elif _is_entity_description(item):
+                augmented[key] = probe
+    elif isinstance(value, tuple):
+        augmented = value + (probe,)
+    elif isinstance(value, list):
+        augmented = [*value, probe]
+    elif isinstance(value, frozenset):
+        augmented = value | {probe}
+    elif isinstance(value, set):
+        augmented = set(value) | {probe}
+    else:
+        return None
+    # Prove the probe really landed. A Mapping of some future shape could come
+    # back unchanged, and an unchanged clone would report a walked table as
+    # unwalked -- a failure the maintainer could not act on.
+    if not any(item is probe for item in _descriptions_in(augmented)):
+        return None
+    return augmented
+
+
+def _appliance_types() -> tuple[str, ...]:
+    """Every appliance type the integration knows, harvested from `const`.
+
+    Read off the module rather than listed here so a type added next year is
+    probed the day it is added.
+    """
+    from custom_components.addhon import const
+
+    return tuple(sorted({
+        value
+        for name, value in vars(const).items()
+        if name.startswith("APPLIANCE_") and isinstance(value, str)
+    }))
+
+
+def _description_tables() -> dict:
+    """{"<module>.<NAME>": (module, attr, value, {id of each description})}."""
+    tables: dict = {}
+    for name in _TABLE_MODULES:
+        try:
+            module = importlib.import_module(f"custom_components.addhon.{name}")
+        except Exception as err:  # pragma: no cover - a missing stub, not drift
+            raise AssertionError(
+                f"custom_components/addhon/{name}.py could not be imported under "
+                f"this file's Home Assistant stubs ({err!r}), so its description "
+                "tables cannot be checked against the diagnostics walk. Add what "
+                "it needs to `_install_stubs` at the top of this file."
+            ) from err
+        for attr, value in list(vars(module).items()):
+            if attr.startswith("__"):
+                continue
+            rows = _descriptions_in(value)
+            if rows:
+                tables[f"{name}.{attr}"] = (module, attr, value, {id(r) for r in rows})
+    return tables
+
+
+# Marks a table the probe could not be planted in, so `_completeness_failure`
+# can say "not measured" instead of "not walked". The distinction is not
+# pedantry: a per-zone `dict[str, dict[str, Description]]` wired correctly into
+# `_mapped_sets` is unprobeable, and reporting it as invisible to the dump would
+# print a falsehood and then ask the contributor to write it down.
+_UNMEASURED = "unmeasured: "
+
+
+def _unwalked_description_tables() -> dict:
+    """{"<module>.<NAME>": why} for every table the dump cannot see.
+
+    MEASURED, not read off a list: one extra description with a unique key is
+    planted in a clone of every table, `_mapped_sets` is run for every appliance
+    type, and a table counts as walked when its planted key comes back as an
+    `entities.sources` tag. Asking the walk what it read -- instead of listing
+    what it is supposed to read -- is the whole point; a second hand-kept list
+    would have exactly the blind spot of the first.
+
+    A table whose probe never surfaces still passes when every description in it
+    is also inside a table that did surface. That is not a loophole, it is the
+    normal case: `_WASH_CONSUMPTION` and the other thirty per-type tuples are
+    concatenated into `SENSORS` at import, so replacing the tuple afterwards
+    cannot reach the walk, while the descriptions themselves are read every time.
+    Containment is by object identity, so a tuple that only LOOKS like part of
+    `SENSORS` is not excused.
+    """
+    tables = _description_tables()
+    order = sorted(tables)
+    probes: dict[str, str] = {}
+    unprobeable: dict[str, str] = {}
+    restore = [(tables[qname][0], tables[qname][1], tables[qname][2])
+               for qname in order]
+    try:
+        for position, qname in enumerate(order):
+            module, attr, value, _ids = tables[qname]
+            key = f"{_PROBE_KEY}{position:03d}"
+            try:
+                probe = dataclasses.replace(_descriptions_in(value)[0], key=key)
+                augmented = _with_probe_row(value, probe)
+            except Exception as err:
+                augmented = None
+                unprobeable[qname] = (
+                    _UNMEASURED + f"it could not be cloned to probe it: {err!r}"
+                )
+            if augmented is None:
+                unprobeable.setdefault(
+                    qname,
+                    _UNMEASURED + "`_with_probe_row` has no rule for its shape",
+                )
+                continue
+            probes[key] = qname
+            setattr(module, attr, augmented)
+        walked: set[str] = set()
+        for app_type in _appliance_types():
+            for tag in diagnostics._mapped_sets(app_type)[2] or {}:
+                _before, marker, position = str(tag).partition(_PROBE_KEY)
+                planted = probes.get(marker + position) if marker else None
+                if planted:
+                    walked.add(planted)
+    finally:
+        for module, attr, value in restore:
+            setattr(module, attr, value)
+
+    if probes and not walked:
+        # Restore first, then complain. `_mapped_sets` returns a None index when
+        # any of the platform modules it lazily imports fails to import, and on
+        # that path EVERY table would be reported unwalked at once -- sixty-odd
+        # lines of consequence hiding one cause.
+        raise AssertionError(
+            "`_mapped_sets` produced no `entities.sources` index for any of the "
+            f"{len(_appliance_types())} appliance types, so nothing could be "
+            "measured. That is its documented degraded path: one of the platform "
+            "modules it imports lazily raised on import. Fix that first."
+        )
+
+    reached: set[int] = set()
+    for qname in walked:
+        if qname in tables:
+            reached |= tables[qname][3]
+    unwalked = dict(unprobeable)
+    for qname, (_module, _attr, _value, ids) in tables.items():
+        if qname in walked or qname in unwalked or ids <= reached:
+            continue
+        unwalked[qname] = (
+            f"{len(ids)} description(s), and no table the walk reads contains them"
+        )
+    return unwalked
+
+
+def _modules_declaring_descriptions() -> set[str]:
+    """Every integration module whose SOURCE constructs an entity description.
+
+    Parsed, never imported: this is the check that has to keep working for a
+    module the stubs in this file cannot import (climate.py needs a
+    `homeassistant.components.climate` nobody stubs today), which is exactly the
+    module a table could be added to without any of this noticing.
+    """
+    package = REPO_ROOT / "custom_components" / "addhon"
+    found: set[str] = set()
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if isinstance(name, str) and name.endswith("Description"):
+                found.add(path.relative_to(package).with_suffix("").as_posix())
+                break
+    return found
+
+
+def _completeness_failure(unwalked: dict) -> str:
+    """The whole value of this guard is that whoever trips it knows what to do.
+
+    Two populations, and telling them apart is the point. A table the probe
+    reached and the walk did not is PROVEN invisible to the dump. A table the
+    probe could not be planted in is merely UNMEASURED -- the walk may well read
+    it. Rendering the second under the first's headline would print a false
+    statement and then offer, as remedy, writing that false statement down as an
+    exemption. A dict-of-dict per-zone table wired correctly into `_mapped_sets`
+    is exactly that case, and it is the shape the worked example uses.
+    """
+    if not unwalked:
+        return ""
+    unmeasured = {
+        q: why[len(_UNMEASURED):]
+        for q, why in unwalked.items()
+        if str(why).startswith(_UNMEASURED)
+    }
+    unwalked = {q: why for q, why in unwalked.items() if q not in unmeasured}
+    lines: list[str] = []
+    if unmeasured:
+        lines += ["", "Entity description tables this guard could not MEASURE:", ""]
+        for qname in sorted(unmeasured):
+            module, _dot, attr = qname.rpartition(".")
+            lines.append(
+                f"    custom_components/addhon/{module}.py :: {attr}"
+                f"   ({unmeasured[qname]})"
+            )
+        lines += [
+            "",
+            "This guard plants one extra description row in a clone of every",
+            "table and looks for it in the tags `_mapped_sets` emits. It says",
+            "nothing about whether the walk reads these -- it may well. Teach",
+            "`_with_probe_row` the shape (about four lines per container kind)",
+            "rather than exempting the table: an exemption here would record a",
+            "promise about the dump that is probably false.",
+        ]
+    if not unwalked:
+        return "\n".join(lines)
+    lines += ["", "Entity description tables the diagnostics dump cannot see:", ""]
+    for qname in sorted(unwalked):
+        module, _dot, attr = qname.rpartition(".")
+        lines.append(
+            f"    custom_components/addhon/{module}.py :: {attr}"
+            f"   ({unwalked[qname]})"
+        )
+    example = sorted(unwalked)[0]
+    lines += [
+        "",
+        "`diagnostics._mapped_sets` never reads them, so on an appliance that has",
+        "these entities the dump makes two statements the reader can see",
+        "contradict each other, a few lines apart: `entities.by_domain` lists the",
+        "entity, and then `coverage` reports the parameter it reads and writes as",
+        "unmapped, with no row in `entities.sources` to disprove it. The walk and",
+        "the test-side harvest are both whitelists, which is why a table neither",
+        "was told about is invisible to both.",
+        "",
+        "Do ONE of these:",
+        "",
+        "1. Have the walk read it. Add the name to the lazy-import block in",
+        "   `_mapped_sets` (custom_components/addhon/diagnostics.py), give it a",
+        "   loop that puts its parameters into `mapped_attrs` and/or",
+        "   `mapped_params` and writes an `entities.sources` row, and add it to",
+        "   `_static_parameter_names` in this file -- the drift guard over the",
+        "   emitted names, which fails until it is told about the new table.",
+        "",
+        "2. If the table genuinely contributes no parameter the dump should",
+        "   account for, record why, next to this test:",
+        "",
+        "       _TABLES_OUTSIDE_COVERAGE = {",
+        f'           "{example}":',
+        '               "<what the dump prints for these parameters instead,',
+        '                and why that is right>",',
+        "       }",
+        "",
+        "   'It is new', 'it is internal' and 'it is experimental' are not",
+        "   reasons: a dump is read by whoever is debugging the appliance, and",
+        "   none of those three changes what it says about the parameter.",
+    ]
+    return "\n".join(lines)
+
+
+class DescriptionTableCompletenessTest(unittest.TestCase):
+    """Every platform description table is either walked, or excused in writing.
+
+    `_mapped_sets` names twelve description tables in an explicit import list of
+    fourteen names -- the other two, `AP_ENTITY_PARAMS` and
+    `STARTPROGRAM_COMMAND`, are a set of parameter names and a string, not
+    tables -- and `_static_parameter_names` re-lists the same twelve by hand.
+    Both are
+    whitelists, so neither can notice a table nobody added to it: a contributor
+    who adds `_REF_ZONE_SELECTS` to select.py gets a green suite and a dump that
+    accuses the integration of not mapping the parameter while `by_domain` lists
+    the entity two sections above -- the dump lying by omission, silently, on the
+    one section a maintainer reads to decide whether to write an entity that
+    already exists.
+
+    The two whitelists do police EACH OTHER in one direction: a table added to
+    the walk but not to the harvest fails
+    `test_every_emitted_name_is_a_static_table_field`, because the walk starts
+    emitting names the harvest has never heard of. The direction neither covers
+    is a table added to NEITHER, and that is the direction this class measures.
+    """
+
+    def test_no_other_module_grew_a_description_table(self) -> None:
+        # `_TABLE_MODULES` is itself a whitelist; this is what stops it being one
+        # more thing to remember. Source, not imports, so a module the stubs here
+        # cannot load is still checked.
+        declared = _modules_declaring_descriptions()
+        scanned = set(_TABLE_MODULES)
+        self.assertEqual(
+            scanned,
+            declared,
+            "\nModules that construct entity descriptions: "
+            f"{sorted(declared)}\nModules this guard checks:              "
+            f"{sorted(scanned)}\n"
+            "\nA module in the first list and not the second has description "
+            "tables nothing compares against the diagnostics walk: add its name "
+            "to `_TABLE_MODULES` above (and whatever stub it needs to "
+            "`_install_stubs`). A module in the second and not the first no "
+            "longer has any: drop it, so this guard keeps meaning what it says.",
+        )
+
+    def test_every_description_table_reaches_the_dump(self) -> None:
+        unwalked = _unwalked_description_tables()
+        surprises = {
+            qname: why
+            for qname, why in unwalked.items()
+            if qname not in _TABLES_OUTSIDE_COVERAGE
+        }
+        self.assertEqual({}, surprises, _completeness_failure(surprises))
+
+    def test_every_exemption_is_still_needed(self) -> None:
+        # An exemption that has stopped being true is worse than none: it is a
+        # written promise about a dump nobody re-reads. The day the table is
+        # deleted, or wired into the walk, this fails and the entry goes.
+        unwalked = _unwalked_description_tables()
+        for qname, reason in _TABLES_OUTSIDE_COVERAGE.items():
+            self.assertIn(
+                qname,
+                unwalked,
+                f"`{qname}` is exempted from the coverage walk but is now either "
+                "walked or gone. Delete the entry from `_TABLES_OUTSIDE_COVERAGE`.",
+            )
+            self.assertGreaterEqual(
+                len(reason.split()),
+                8,
+                f"`{qname}`'s exemption is not a reason: {reason!r}. It has to say "
+                "what the dump prints for these parameters instead and why that "
+                "is right, in a sentence the next reader can check.",
+            )
+
+    def test_the_guard_notices_a_table_nobody_walks(self) -> None:
+        # A completeness guard that cannot fail is a completeness guard that is
+        # not there. `select` is the module the worked example uses, and the
+        # table is planted on the module OBJECT rather than in the file so this
+        # proves the measurement rather than a fixture. The name is one no
+        # platform would ever use, and it is restored through `_ABSENT` rather
+        # than deleted, so that planting it on a module that later grows a real
+        # attribute of the same name cannot delete the real one.
+        from custom_components.addhon import select as select_module
+
+        name = "_COMPLETENESS_SELF_TEST_TABLE"
+        planted = (
+            dataclasses.replace(
+                select_module._PROGRAM_OPTION_SELECTS[0],
+                key="zone_temperature",
+                param="tempSelZ9",
+            ),
+        )
+        before = _unwalked_description_tables()
+        previous = getattr(select_module, name, _ABSENT)
+        setattr(select_module, name, planted)
+        try:
+            unwalked = _unwalked_description_tables()
+        finally:
+            if previous is _ABSENT:
+                delattr(select_module, name)
+            else:
+                setattr(select_module, name, previous)
+        # Differential, not absolute: the one thing that changed is the table
+        # this test invented. Asserting an empty result instead would turn one
+        # real unwalked table into TWO failures, the second of them accusing
+        # this test of leaking when it had not.
+        self.assertEqual({f"select.{name}"}, set(unwalked) - set(before))
+        message = _completeness_failure(unwalked)
+        self.assertIn(f"select.py :: {name}", message)
+        self.assertIn("_static_parameter_names", message)
+        self.assertIn("_TABLES_OUTSIDE_COVERAGE", message)
+        self.assertEqual(
+            before, _unwalked_description_tables(), "the plant leaked past this test"
+        )
 
 
 # --- step 3: the per-parameter cloud instants (P1) ---------------------------

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -553,7 +553,7 @@ class ExtraIdentityKeysBehaviouralTest(unittest.TestCase):
     """
 
     _LOGGER_NAME = "custom_components.addhon.command_diagnostics"
-    _SECRET = "CANARY-IDENTIFIER-VALUE"
+    _CANARY_VALUE = "CANARY-IDENTIFIER-VALUE"
 
     # Named, not derived -- a loop over the constant goes quiet when a member leaves.
     _MUST_MASK = ("accountid", "applianceid", "cloudid", "deviceid", "uniqueid", "userid")
@@ -569,7 +569,7 @@ class ExtraIdentityKeysBehaviouralTest(unittest.TestCase):
             for spelling in (key, key.upper(), f"{stem}_id", f"{stem}Id", f"{stem}-ID"):
                 with self.subTest(key=spelling):
                     with self.assertLogs(self._LOGGER_NAME, level="DEBUG") as captured:
-                        emit_command_event("command_payload", {spelling: self._SECRET})
+                        emit_command_event("command_payload", {spelling: self._CANARY_VALUE})
                     decoded = json.loads(captured.records[0].getMessage())
                     # Assert the VALUE, not just absence: _encode_record enforces a
                     # 4096-byte budget by DROPPING whole keys, so an assertNotIn alone

--- a/tests/test_log_identity_redaction.py
+++ b/tests/test_log_identity_redaction.py
@@ -536,5 +536,62 @@ class CommandDiagnosticReviewTest(unittest.TestCase):
         self.assertLessEqual(len(record), 4096)
 
 
+class ExtraIdentityKeysBehaviouralTest(unittest.TestCase):
+    """`command_diagnostics._EXTRA_IDENTITY_KEYS` is the THIRD identity key set, and
+    it was the thinnest-covered constant in the repository: five of its six names
+    (accountid, applianceid, deviceid, uniqueid, userid) could be deleted -- one at a
+    time or all five at once -- with the whole suite green at rc=0. Unlike
+    `_IDENTITY_KEYS` it never even had a set-equality pin. Only `cloudid` had an
+    observer, and only incidentally, because one unrelated test's record carries a
+    `cloud_id` field.
+
+    These names are not decoration: `deviceId` is the key api.py:72-76 posts the phone
+    install id under (`json={"deviceId": device_id}` where device_id is
+    `device.mobile_id`), the same value diagnostics.py:105-107 calls "the phone-install
+    id of whoever issued the last command (often a third party)" when it arrives as
+    `mobileId`.
+    """
+
+    _LOGGER_NAME = "custom_components.addhon.command_diagnostics"
+    _SECRET = "CANARY-IDENTIFIER-VALUE"
+
+    # Named, not derived -- a loop over the constant goes quiet when a member leaves.
+    _MUST_MASK = ("accountid", "applianceid", "cloudid", "deviceid", "uniqueid", "userid")
+
+    def test_named_extra_identity_keys_are_masked_on_the_command_path(self) -> None:
+        from custom_components.addhon.command_diagnostics import emit_command_event
+
+        for key in self._MUST_MASK:
+            stem = key[: -len("id")]
+            # _identity_key strips every non-alphanumeric before lookup, so ONE entry
+            # is meant to cover all of these spellings. That matching RULE is part of
+            # the guarantee, so it is asserted here rather than assumed.
+            for spelling in (key, key.upper(), f"{stem}_id", f"{stem}Id", f"{stem}-ID"):
+                with self.subTest(key=spelling):
+                    with self.assertLogs(self._LOGGER_NAME, level="DEBUG") as captured:
+                        emit_command_event("command_payload", {spelling: self._SECRET})
+                    decoded = json.loads(captured.records[0].getMessage())
+                    # Assert the VALUE, not just absence: _encode_record enforces a
+                    # 4096-byte budget by DROPPING whole keys, so an assertNotIn alone
+                    # could pass because the key was budgeted out rather than masked.
+                    self.assertEqual("***", decoded[spelling])
+
+    def test_every_extra_identity_key_has_a_behavioural_assertion(self) -> None:
+        from custom_components.addhon import command_diagnostics
+
+        self.assertEqual(
+            set(self._MUST_MASK), set(command_diagnostics._EXTRA_IDENTITY_KEYS)
+        )
+
+    def test_non_identity_key_survives_the_command_path(self) -> None:
+        # Positive control: the assertions above are not passing because the command
+        # path masks or drops everything it is handed.
+        from custom_components.addhon.command_diagnostics import emit_command_event
+
+        with self.assertLogs(self._LOGGER_NAME, level="DEBUG") as captured:
+            emit_command_event("command_payload", {"programName": "ECO40"})
+        self.assertEqual("ECO40", json.loads(captured.records[0].getMessage())["programName"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Automated release PR for `v5.13.0`.

<!-- release-tag: v5.13.0 -->

## Summary by Sourcery

Prepare diagnostics and CI for v5.13.0 with stronger identity redaction, richer diagnostics metadata, and stricter commit hygiene.

Enhancements:
- Extend diagnostics coverage data and entity source mapping to describe which raw parameters each entity reads and writes, and to report attributes and command params expected to be absent per appliance type.
- Add per-attribute cloud timestamp tracking and shadow freshness reporting to diagnostics outputs, including a top-level generated_at timestamp for entry and device dumps.
- Refine air purifier diagnostics so off-state machMode=0 is treated as a handled value instead of a future capability, and adjust coverage calculations and drift guards accordingly.
- Introduce helpers for bounded text, datetime handling, and UTC-normalization used across diagnostics to ensure robust, privacy-safe serialization of timestamps and cloud strings.
- Tighten diagnostics behaviour in degraded scenarios so broken registry modules, malformed mappings, or hostile objects degrade output without crashing while preserving truthful coverage and sources.

CI:
- Add a commit-trailers CI job that runs a shared shell script over base..head commit messages in pull requests to reject AI-assistant authorship trailers.
- Ensure the CI workflow checks out full history and executes the commit trailer guard script from the base branch to avoid PR-side tampering.

Documentation:
- Update integration manifest version to 5.13.0 to reflect the new release.

Tests:
- Greatly expand diagnostics-related tests to cover attribute timestamping, freshness computation, entity source maps, registry degradation behaviour, description-table completeness, commit trailer guard behaviour, and privacy properties of new sections.
- Add tests ensuring air purifier coverage, future capability capture, and custom entity mappings behave deterministically and remain aligned with registry tables.
- Add tests around commit trailer rejection to verify the shared shell matcher and its integration into local hooks and CI workflows.

Chores:
- Introduce a shared no-assistant-trailer shell script and a commit-msg hook to enforce local rejection of AI-assistant authorship trailers across contributors.
- Adjust diagnostics internals to reuse shared helpers and constants, including explicit appliance type constants for refrigerators and washers, and to remove now-redundant custom mapped attribute seeds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release updates the integration to v5.13.0, substantially enriches diagnostics and coverage reporting, recognizes the air-purifier off sentinel as handled, and adds local/CI enforcement against assistant authorship trailers.

- Adds diagnostic entity-source, expected-absent, registry, freshness, and timestamp information with expanded redaction and behavioral tests.
- Adds a shared commit-message guard used by a versioned local hook and a pull-request CI job.
- Updates the integration manifest version to 5.13.0.

<h3>Confidence Score: 4/5</h3>

The pull request should not merge until the commit guard distinguishes known assistant identities from legitimate human co-authors.

The new matcher is used by both the local hook and required pull-request workflow, and its unqualified substring search causes valid human-authored commits to be rejected.

**Files Needing Attention:** scripts/no-assistant-trailer.sh

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/diagnostics.py | Adds extensive diagnostics coverage, entity reconciliation, freshness metadata, and defensive degradation behavior; no concrete blocking defect was established. |
| scripts/no-assistant-trailer.sh | Adds the shared authorship-trailer matcher, but its substring-based identity check rejects legitimate human co-authors named Claude. |
| .github/workflows/ci.yml | Adds a full-history pull-request job that executes the base branch's trailer checker. |
| custom_components/addhon/air_purifier.py | Correctly distinguishes the handled off-state sentinel from writable purifier modes. |
| custom_components/addhon/manifest.json | Advances the integration version from 5.12.0 to 5.13.0. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20tis24dev%2Faddhon%20PR%20%2379%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=tis24dev%2Faddhon&pr=79&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fno-assistant-trailer.sh%3A31-32%0A**Human%20co-authors%20are%20rejected**%0A%0AWhen%20a%20legitimate%20human%20co-author%20has%20%60claude%60%20or%20%60anthropic%60%20in%20their%20name%20or%20email%2C%20the%20substring-based%20matcher%20classifies%20the%20authorship%20trailer%20as%20assistant%20credit%2C%20causing%20both%20the%20local%20hook%20and%20pull-request%20CI%20job%20to%20reject%20the%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=tis24dev%2Faddhon&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fno-assistant-trailer.sh%3A31-32%0A**Human%20co-authors%20are%20rejected**%0A%0AWhen%20a%20legitimate%20human%20co-author%20has%20%60claude%60%20or%20%60anthropic%60%20in%20their%20name%20or%20email%2C%20the%20substring-based%20matcher%20classifies%20the%20authorship%20trailer%20as%20assistant%20credit%2C%20causing%20both%20the%20local%20hook%20and%20pull-request%20CI%20job%20to%20reject%20the%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tis24dev%2Faddhon%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fno-assistant-trailer.sh%3A31-32%0A**Human%20co-authors%20are%20rejected**%0A%0AWhen%20a%20legitimate%20human%20co-author%20has%20%60claude%60%20or%20%60anthropic%60%20in%20their%20name%20or%20email%2C%20the%20substring-based%20matcher%20classifies%20the%20authorship%20trailer%20as%20assistant%20credit%2C%20causing%20both%20the%20local%20hook%20and%20pull-request%20CI%20job%20to%20reject%20the%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=tis24dev%2Faddhon&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.13.0"](https://github.com/tis24dev/addhon/commit/bc4220344443b11ec8c9dbbbca5072f41a864f4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53580532)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->