### PR TITLE
Release v5.14.0

### DIFF
--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -224,10 +224,25 @@ class HonCommand:
             and params.command is self
         ):
             params = self.canonical_exact_payload(params)
-        ancillary_params = dict(
-            self.parameter_groups.get("ancillaryParameters", {})
-        )
-        ancillary_params.pop("programRules", None)
+        # Built from the parameters rather than from `parameter_groups`, which has
+        # already collapsed everything to `intern_value` and so cannot tell a value the
+        # schema asked for from one a subclass invented to keep reads non-None. Only
+        # the former belongs on the wire: a descriptor-only node such as the AC's
+        # windDirectionVerticalPositionSequence would otherwise travel as "0", a value
+        # outside its own enumValues, into the slot the app reads the louvre position
+        # sequence from. See `HonParameter.declares_value`.
+        #
+        # programRules is dropped deliberately, NOT for parity: the app does send it
+        # back on an AC startProgram. It is the constraint set the cloud handed us, we
+        # have already applied it locally, and echoing it risks re-pinning parameters
+        # the user has since moved.
+        ancillary_params = {
+            name: parameter.intern_value
+            for name, parameter in self._parameters.items()
+            if parameter.group == "ancillaryParameters"
+            and name != "programRules"
+            and parameter.declares_value
+        }
         if sync_shadow:
             self.appliance.sync_command_to_params(self.name)
         result = await self.api.send_command(

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -36,6 +36,25 @@ class HonParameter:
         return self._key
 
     @property
+    def declares_value(self) -> bool:
+        """True when the schema itself said what this parameter should carry.
+
+        Some nodes are pure descriptors: they list `enumValues` so a client can render
+        a control, and state no `defaultValue`/`fixedValue` because there is nothing to
+        send. The subclasses still materialize a value (see HonParameterEnum, which
+        falls back to "0" so reads never return None), so the fallback is
+        indistinguishable from a real one once you only look at `intern_value`. This
+        keeps the distinction available to the payload builder.
+
+        A declared "0" counts, hence the comparison against None/"" rather than a
+        truthiness test -- a numeric 0 default is a value the schema asked for.
+        """
+        return any(
+            self._attributes.get(name) not in (None, "")
+            for name in ("defaultValue", "fixedValue")
+        )
+
+    @property
     def value(self) -> str | float:
         return self._value if self._value is not None else "0"
 

--- a/custom_components/addhon/climate.py
+++ b/custom_components/addhon/climate.py
@@ -27,7 +27,6 @@ from .const import (
     AC_TEMP_PARAM,
     AC_MODE_PARAM,
     AC_FAN_PARAM,
-    AC_ON_OFF_PARAM,
     AC_ATTR_ON_OFF,
     AC_ATTR_CURRENT_TEMP,
     AC_ATTR_FAN_SPEED,
@@ -317,22 +316,25 @@ class HaierClimateEntity(HonBaseEntity, ClimateEntity):
     def _is_program_based(self) -> bool:
         """True for AC models that drive power/mode via startProgram/stopProgram.
 
-        Two AC write models exist (see AC_PROGRAM_MAP in const.py):
-        - settings-based (e.g. AS35PBPHRA-PRE): the `settings` command carries
-          onOffStatus + machMode, so power/mode are written into `settings`.
-        - program-based (e.g. AD71S2SM3FA(H)): the `settings` command has NO
-          onOffStatus; ON goes through startProgram (program enum, onOffStatus fixed
-          "1") and OFF through stopProgram (onOffStatus fixed "0"). Writing
-          onOffStatus/machMode into `settings` on such a model raises
-          "Parameter(s) not found" before the request ever reaches the cloud, which
-          is exactly why every on/off/mode command looked "ignored".
+        The gate is the presence of a startProgram command, and nothing else. On a
+        room AC the official app knows only that surface for power and mode: ON is a
+        startProgram, OFF a stopProgram, and choosing a mode is simply starting the
+        matching program. It never writes machMode through the settings command.
 
-        The gate: NO onOffStatus among the settings params AND a startProgram command
-        exists. Temperature/fan stay on the settings path in BOTH models (tempSel /
-        windSpeed live on `settings` either way), so only power/mode is rerouted.
+        Models such as AS35PBPHRA-PRE also expose onOffStatus/machMode inside
+        `settings`, and that used to demote them to a "settings-based" class written
+        that way. The device obeyed, so the divergence stayed invisible from Home
+        Assistant -- but only a program command moves the cloud's active-program
+        pointer. On a unit driven solely from HA the pointer keeps naming whatever
+        program some other channel started last, and the app renders its program
+        screen from that stale schema node: the fan enum, the temperature range and
+        the vertical louvre position sequence all resolve empty. See
+        apk/analysis/ac-power-mode-and-winddir-rendering.md.
+
+        Temperature and fan stay on the settings path in both models (tempSel /
+        windSpeed live on `settings` either way), so only power/mode is routed here.
+        A model without startProgram keeps the settings path: it has no other surface.
         """
-        if settings_param(self._appliance, AC_ON_OFF_PARAM) is not None:
-            return False
         return startprogram_command(self._appliance) is not None
 
     def _startprogram_programs(self) -> list[str]:

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.13.0"
+  "version": "5.14.0"
 }

--- a/tests/test_ac_write_path.py
+++ b/tests/test_ac_write_path.py
@@ -207,8 +207,9 @@ def _program_climate(program_enum: list | None = None, *, with_onoff: bool = Fal
     NOT by onOffStatus/machMode in `settings`. temp/fan still live on `settings`.
 
     ``with_onoff=True`` adds onOffStatus to `settings` to reproduce the AS35-style
-    settings-based model even though startProgram/stopProgram also exist: the gate
-    must then stay on the settings path (regression guard).
+    model that declares BOTH write surfaces. The program path must still win: the
+    official app drives every RAC through startProgram/stopProgram regardless of
+    what `settings` happens to expose (see AcClimateProgramWinsOverSettingsTest).
 
     Returns (entity, settings_cmd, start_cmd, stop_cmd, coordinator).
     """
@@ -724,35 +725,64 @@ class AcClimateProgramWritePathTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(0, coordinator.refreshes)
 
 
-class AcClimateSettingsRegressionTest(unittest.IsolatedAsyncioTestCase):
-    """Regression: an AS35-style settings-with-onOffStatus model keeps the settings
-    write path for on/off/mode EVEN IF startProgram/stopProgram also exist. The gate
-    keys on onOffStatus being present in `settings`, so it must never reroute here.
+class AcClimateProgramWinsOverSettingsTest(unittest.IsolatedAsyncioTestCase):
+    """A model declaring BOTH surfaces must still drive power/mode via programs.
+
+    The AS35 family exposes onOffStatus/machMode inside `settings` AND a full
+    startProgram/stopProgram pair. The gate used to read that as "settings-based"
+    and route power/mode into `settings`, which the official app never does on a
+    RAC: there, ON is startProgram, OFF is stopProgram and a mode change is just
+    another startProgram.
+
+    The divergence is not cosmetic. The cloud tracks the appliance's active
+    program from the last program command; a `settings` write updates values but
+    leaves that pointer untouched. On a unit driven only from Home Assistant the
+    pointer therefore keeps naming whatever program was last started by some other
+    channel, and the app renders the program screen from that stale schema node --
+    empty fan list, temperature picker collapsed to 0, `Fissa(NaN)` for the vertical
+    louvre. Observed on two units in the wild; see
+    apk/analysis/ac-power-mode-and-winddir-rendering.md.
+
+    temp/fan stay on `settings` in both models and are covered above.
     """
 
-    async def test_turn_on_uses_settings_onoffstatus(self) -> None:
+    async def test_turn_on_uses_startprogram(self) -> None:
         entity, settings, start, stop, coord = _program_climate(with_onoff=True)
         await entity.async_turn_on()
-        self.assertEqual(1, settings.send_calls)
-        self.assertEqual("1", settings.sent["onOffStatus"])
-        self.assertEqual(0, start.send_calls)
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual(
+            {"onOffStatus": "1", "program": "iot_simple_start"}, start.sent
+        )
+        self.assertEqual(0, settings.send_calls)
         self.assertEqual(0, stop.send_calls)
         self.assertEqual(1, coord.refreshes)
 
-    async def test_set_mode_uses_settings_machmode(self) -> None:
+    async def test_set_mode_uses_startprogram(self) -> None:
         entity, settings, start, stop, _ = _program_climate(with_onoff=True)
-        await entity.async_set_hvac_mode(HVACMode.HEAT)  # golden machMode heat=4
-        self.assertEqual("4", settings.sent["machMode"])
-        self.assertEqual("1", settings.sent["onOffStatus"])
-        self.assertEqual(0, start.send_calls)
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+        self.assertEqual(1, start.send_calls)
+        self.assertEqual({"onOffStatus": "1", "program": "iot_heat"}, start.sent)
+        self.assertEqual(0, settings.send_calls)
         self.assertEqual(0, stop.send_calls)
 
-    async def test_off_uses_settings_onoffstatus(self) -> None:
+    async def test_off_uses_stopprogram(self) -> None:
         entity, settings, start, stop, _ = _program_climate(with_onoff=True)
         await entity.async_set_hvac_mode(HVACMode.OFF)
-        self.assertEqual("0", settings.sent["onOffStatus"])
-        self.assertEqual(0, stop.send_calls)
+        self.assertEqual(1, stop.send_calls)
+        self.assertEqual({"onOffStatus": "0"}, stop.sent)
+        self.assertEqual(0, settings.send_calls)
         self.assertEqual(0, start.send_calls)
+
+    async def test_settings_only_model_keeps_settings_path(self) -> None:
+        # The gate now keys on startProgram alone, so a model WITHOUT it must still
+        # write power/mode into `settings` -- otherwise this change would silently
+        # break every AC that has no program surface at all.
+        entity, settings, _ = _climate(
+            {"onOffStatus": Param("0"), "machMode": Param("0")}
+        )
+        await entity.async_turn_on()
+        self.assertEqual(1, settings.send_calls)
+        self.assertEqual("1", settings.sent["onOffStatus"])
 
 
 class AcClimateReadPathTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -950,6 +950,86 @@ class ClusterBehaviorTest(unittest.TestCase):
         self.assertEqual(c.parameters["windDirectionVertical"].value, "3")
 
 
+# REAL AC IOT_COOL ancillary block (apk/dump/ac_live), minus programRules which has its
+# own coverage. Four of the five keys carry a value the schema itself states; the fifth,
+# windDirectionVerticalPositionSequence, declares neither defaultValue nor fixedValue --
+# it is a pure descriptor, and the app drops such keys instead of inventing a value.
+_AC_ANCILLARY_REAL = {
+    "description": "d",
+    "protocolType": "MQTT",
+    "parameters": {
+        "onOffStatus": {"typology": "fixed", "category": "command", "mandatory": 1, "fixedValue": "1"},
+    },
+    "ancillaryParameters": {
+        "ecoMode": {"typology": "range", "category": "general", "mandatory": 1,
+                    "defaultValue": "0", "minimumValue": "0", "maximumValue": "1", "incrementValue": "1"},
+        "programFamily": {"typology": "enum", "category": "cluster", "mandatory": 1,
+                          "defaultValue": "[dashboard|standard]", "enumValues": ["dashboard", "standard"]},
+        "remoteActionable": {"typology": "fixed", "category": "general", "mandatory": 0, "fixedValue": "1"},
+        "remoteVisible": {"typology": "fixed", "category": "general", "mandatory": 0, "fixedValue": "1"},
+        "windDirectionVerticalPositionSequence": {"typology": "enum", "category": "general",
+                                                  "mandatory": 0, "enumValues": [2, 4, 5, 6, 8]},
+    },
+}
+
+
+class _SendingAppliance(FakeAppliance):
+    def __init__(self) -> None:
+        super().__init__()
+        self.api = FakeApi()
+
+    def sync_command_to_params(self, name: str) -> None:
+        pass
+
+
+class AncillaryPayloadTest(unittest.TestCase):
+    """What leaves in `ancillaryParameters`.
+
+    An enum whose schema states no defaultValue has nothing to send. The engine still
+    materializes one, because HonParameterEnum falls back to "0" so that reads never
+    return None -- but "0" is not even among that parameter's own enumValues, and on
+    windDirectionVerticalPositionSequence the app expects the louvre position sequence
+    there, not a scalar. Sending a fabricated value writes noise into a slot the real
+    client leaves untouched, so the payload builder drops keys the schema never valued.
+
+    The four keys that DO carry a schema value stay, verbatim -- including
+    programFamily's bracketed "[dashboard|standard]", which is the cloud's own way of
+    writing that option list and not a value to be normalized.
+    """
+
+    def _send(self, schema: dict) -> dict:
+        appliance = _SendingAppliance()
+        command = NaCommand(
+            "startProgram",
+            json.loads(json.dumps(schema)),
+            appliance,
+            category_name="PROGRAMS.AC.IOT_COOL",
+        )
+        asyncio.run(command.send())
+        _, _, ancillary, _ = appliance.api.sent[0]
+        return ancillary
+
+    def test_valued_keys_survive_verbatim(self) -> None:
+        ancillary = self._send(_AC_ANCILLARY_REAL)
+        self.assertEqual("[dashboard|standard]", ancillary["programFamily"])
+        self.assertEqual("1", ancillary["remoteActionable"])
+        self.assertEqual("1", ancillary["remoteVisible"])
+        self.assertIn("ecoMode", ancillary)
+
+    def test_key_the_schema_never_valued_is_dropped(self) -> None:
+        ancillary = self._send(_AC_ANCILLARY_REAL)
+        self.assertNotIn("windDirectionVerticalPositionSequence", ancillary)
+
+    def test_a_zero_the_schema_asked_for_still_goes(self) -> None:
+        # Discriminates "dropped because valueless" from "dropped because falsy": ecoMode
+        # defaults to "0" by declaration and must survive, exactly as the app sends it.
+        schema = json.loads(json.dumps(_AC_ANCILLARY_REAL))
+        schema["ancillaryParameters"] = {"ecoMode": schema["ancillaryParameters"]["ecoMode"]}
+        ancillary = self._send(schema)
+        self.assertEqual(["ecoMode"], list(ancillary))
+        self.assertEqual(0.0, float(ancillary["ecoMode"]))
+
+
 class NativeEnumEdgeBehaviorTest(unittest.TestCase):
     """Pin of the BABYCARE fix that the cluster exposes on favourites/recover/rule-default:
     the native side accepts a re-cased enum and keeps the raw value in intern_value."""


### PR DESCRIPTION
Automated release PR for `v5.14.0`.

<!-- release-tag: v5.14.0 -->

## Summary by Sourcery

Adjust AC command routing and ancillary payload construction to align with cloud expectations and prevent invalid descriptor values from being sent.

Enhancements:
- Route AC power and mode through program commands whenever startProgram exists, keeping settings-based routing only for models without program surfaces.
- Derive ancillaryParameters payloads from parameters that the schema explicitly values, and drop descriptor-only nodes and programRules to avoid sending fabricated or stale constraints.
- Expose a declares_value flag on parameters to distinguish schema-declared values from internal fallbacks for payload building.

Tests:
- Add AncillaryPayloadTest to verify ancillaryParameters payload only includes schema-valued keys and preserves declared defaults, including zero values.
- Update AC climate write-path tests to assert program-based routing for models exposing both settings and startProgram/stopProgram, and preserve settings routing for settings-only models.

Chores:
- Bump integration manifest version to 5.14.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for air conditioners that use program-based power and mode controls alongside settings-based temperature and fan controls.
  * Ancillary command data now includes only explicitly valued parameters, while preserving valid zero values.

* **Bug Fixes**
  * Corrected command handling for models exposing both program and settings controls.
  * Prevented unconfigured ancillary parameters from being sent.

* **Chores**
  * Updated the integration version to 5.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release updates AC command routing and ancillary payload construction while bumping the integration to v5.14.0.
- Routes AC power and mode changes through program commands whenever `startProgram` is available.
- Omits descriptor-only ancillary parameters that declare neither a default nor fixed value.
- Adds regression coverage for dual-surface AC models, settings-only models, and ancillary payload filtering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The changed routing and payload-filtering behavior is covered for dual-surface and settings-only AC models as well as declared, zero-valued, and descriptor-only ancillary parameters, and no reachable regression was established.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/commands.py | Rebuilds ancillary payloads from command parameters and excludes schema nodes that declare no value. |
| custom_components/addhon/client/engine/parameter/base.py | Adds schema-level detection of whether a parameter declares a default or fixed value. |
| custom_components/addhon/climate.py | Makes the presence of `startProgram` determine whether AC power and mode use program commands. |
| custom_components/addhon/manifest.json | Bumps the integration version from 5.13.0 to 5.14.0. |
| tests/test_ac_write_path.py | Updates AC write-path tests to require program routing on dual-surface models while preserving settings-only behavior. |
| tests/test_engine_cluster.py | Adds coverage ensuring declared ancillary values survive and descriptor-only nodes are omitted. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Climate power or mode request] --> B{startProgram available?}
    B -->|Yes| C[Use startProgram or stopProgram]
    B -->|No| D[Write onOffStatus or machMode through settings]
    C --> E[Build command payload]
    D --> E
    E --> F{Ancillary parameter declares default or fixed value?}
    F -->|Yes| G[Include ancillary value]
    F -->|No| H[Omit descriptor-only node]
    G --> I[Send command]
    H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.14.0"](https://github.com/tis24dev/addhon/commit/d34239731155f4e026d357054ccf9638cb8567a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53596900)</sub>

<!-- /greptile_comment -->