### PR TITLE
Release v5.14.1

### DIFF
--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.14.0"
+  "version": "5.14.1"
 }

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -101,7 +101,7 @@ _SETTINGS_SWITCHES: dict[str, tuple[HonSettingsSwitchDescription, ...]] = {
 
 
 @dataclass(frozen=True, kw_only=True)
-class HonAirPurifierSwitchDescription:
+class HonAirPurifierSwitchDescription(SwitchEntityDescription):
     """Air purifier 0/1 toggle written as a SPARSE settings patch.
 
     Deliberately separate from HonSettingsSwitchDescription: that one drives
@@ -112,13 +112,19 @@ class HonAirPurifierSwitchDescription:
 
     `capability` names the AirPurifierCapabilities property that gates the write
     half; `action` names the `ap_patch` intent that performs it.
+
+    Subclasses SwitchEntityDescription because HonAirPurifierSwitch publishes it as
+    `entity_description`, and Home Assistant reads `entity_description.device_class`
+    while computing the entity's name at ADD time. A plain dataclass has no such
+    field, so every purifier toggle raised AttributeError inside
+    `entity_platform._async_add_entity` and was dropped -- built, logged as built,
+    never registered (issue #67). HonSettingsSwitchDescription stays a plain
+    dataclass because its entity keeps it in `_desc`, out of HA's reach.
     """
 
-    key: str            # translation_key + unique_id suffix
     param: str          # the settings parameter, and the attribute read back
     capability: str
     action: str
-    icon: str | None = None
 
 
 # Confirmed 0/1 purifier toggles (AP_PARAMS_ENUM "Toggles"). `child_lock` reuses the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,11 +234,42 @@ def _install_entity_platform_stubs() -> None:
     light.ColorMode = getattr(light, "ColorMode", ColorMode)
     light.ATTR_BRIGHTNESS = getattr(light, "ATTR_BRIGHTNESS", "brightness")
 
-    # Bare platform bases: the addhon entities define every property themselves,
-    # so nothing beyond the class is needed to subclass them.
     switch = _ensure_module("homeassistant.components.switch")
     components.switch = switch
-    switch.SwitchEntity = getattr(switch, "SwitchEntity", type("SwitchEntity", (), {}))
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class SwitchEntityDescription:
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        icon: str | None = None
+        device_class: object | None = None
+        entity_category: object | None = None
+
+    class SwitchEntity:
+        """Mirror of HA's SwitchEntity, `device_class` included.
+
+        This class was a bare `type("SwitchEntity", (), {})` under the reasoning
+        that the addhon entities define every property themselves. They do not
+        define this one: real HA resolves `device_class` off `entity_description`,
+        and reads it while computing the entity name at add time. The bare stub
+        made an entity whose description lacked the field look perfectly healthy
+        under test while Home Assistant refused to add it (issue #67, four
+        purifier toggles). Kept faithful to HA's precedence -- `_attr_` first,
+        then the description -- so the same class of mismatch fails here first."""
+
+        @property
+        def device_class(self):
+            if hasattr(self, "_attr_device_class"):
+                return self._attr_device_class
+            if hasattr(self, "entity_description"):
+                return self.entity_description.device_class
+            return None
+
+    switch.SwitchEntity = getattr(switch, "SwitchEntity", SwitchEntity)
+    switch.SwitchEntityDescription = getattr(
+        switch, "SwitchEntityDescription", SwitchEntityDescription
+    )
 
     select = _ensure_module("homeassistant.components.select")
     components.select = select

--- a/tests/test_air_purifier_entities.py
+++ b/tests/test_air_purifier_entities.py
@@ -1456,6 +1456,53 @@ class AirPurifierSwitchArchitectureTest(unittest.TestCase):
         self.assertNotIn("async_send_settings", source)
 
 
+class AirPurifierSwitchAddTimeTest(unittest.IsolatedAsyncioTestCase):
+    """What Home Assistant does to the entity BEFORE it exists (issue #67).
+
+    Both toggles were built, logged as built, and then dropped by
+    `entity_platform._async_add_entity`, which reads `entity.name` -> device class
+    -> `entity_description.device_class`. The description was a plain dataclass
+    without that field, so all four (two toggles x two purifiers) died with
+    AttributeError. Every existing test built the entity and then asked it a
+    question of its own -- is_on, unique_id, the write path -- which is the one
+    thing HA does not do first.
+    """
+
+    async def test_the_toggles_survive_the_add_path(self) -> None:
+        entities, _client, _coordinator = await _build_switches(schema=_toggle_schema())
+        for key, entity in _switch_by_key(entities).items():
+            with self.subTest(key=key):
+                # The exact attribute lookup that raised, through HA's own
+                # precedence. No device class is intended: None, not a crash.
+                self.assertIsNone(entity.device_class, key)
+
+    def test_the_description_carries_what_home_assistant_reads(self) -> None:
+        """The description is published as `entity_description`, so it is HA's to
+        read: it must be an actual SwitchEntityDescription, not a look-alike."""
+        from custom_components.addhon import switch
+
+        self.assertTrue(
+            issubclass(
+                switch.HonAirPurifierSwitchDescription, switch.SwitchEntityDescription
+            )
+        )
+        for description in switch._AIR_PURIFIER_SWITCHES:
+            with self.subTest(key=description.key):
+                self.assertIsNone(description.device_class)
+
+    def test_only_the_published_description_needs_the_ha_base(self) -> None:
+        """The sibling description stays a plain dataclass on purpose: its entity
+        keeps it in `_desc`, so HA never reads it. Pinned so a future "make them
+        consistent" pass does not read the fix as a rule about all of them."""
+        import inspect
+
+        from custom_components.addhon import switch
+
+        source = inspect.getsource(switch.HonSettingsSwitch)
+        self.assertIn("self._desc = description", source)
+        self.assertNotIn("self.entity_description", source)
+
+
 class AirPurifierSwitchSkipLoggingTest(unittest.IsolatedAsyncioTestCase):
     """A rejected toggle must say WHY.
 


### PR DESCRIPTION
Automated release PR for `v5.14.1`.

<!-- release-tag: v5.14.1 -->

## Summary by Sourcery

Fix Home Assistant air purifier switch entities failing to register due to missing device_class on their published descriptions and bump the integration version to v5.14.1.

Bug Fixes:
- Ensure HonAirPurifierSwitchDescription subclasses SwitchEntityDescription so Home Assistant can safely read device_class during entity registration.
- Align test stubs for SwitchEntity and SwitchEntityDescription with Home Assistant’s behavior so mismatched switch descriptions fail under test instead of only in real HA.

Enhancements:
- Add targeted tests to verify air purifier switch descriptions expose the fields Home Assistant reads at add time and that only published descriptions depend on HA bases.

Tests:
- Introduce new tests covering the Home Assistant add path for air purifier switches and the relationship between entity descriptions and HA switch base classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for air purifier switch entities with Home Assistant’s standard entity metadata.
  * Ensured switch device-class information is handled correctly when entities are added.
  * Preserved compatibility for existing legacy settings switches.

* **Tests**
  * Added coverage for entity registration, metadata handling, and device-class lookup.

* **Chores**
  * Updated the integration version to 5.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release updates the integration to v5.14.1 and fixes air-purifier switch registration by using Home Assistant's switch entity-description contract.
- Makes `HonAirPurifierSwitchDescription` inherit from `SwitchEntityDescription`.
- Improves the Home Assistant test stub to model add-time device-class resolution.
- Adds regression coverage for purifier toggles surviving entity registration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the registration fix matching Home Assistant's entity-description contract and no actionable regressions identified.

The purifier descriptions now expose the device-class field Home Assistant reads during entity registration while preserving existing construction, naming, identity, and command behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/switch.py | Correctly adopts Home Assistant's switch description base while preserving purifier switch keys, icons, translations, and dispatch behavior. |
| tests/conftest.py | Extends the switch stubs to reproduce Home Assistant's entity-description device-class lookup. |
| tests/test_air_purifier_entities.py | Adds focused regression tests for the previously failing add-time entity lookup. |
| custom_components/addhon/manifest.json | Updates the integration version from 5.14.0 to 5.14.1. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.14.1"](https://github.com/tis24dev/addhon/commit/54877a302ee17bc342bb2828ba044003a939363e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53675072)</sub>

<!-- /greptile_comment -->