### PR TITLE
Release v5.15.0

### DIFF
--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -68,6 +68,9 @@ from .const import (
     APPLIANCE_WASH_GROUP,
     APPLIANCE_WD,
     APPLIANCE_WM,
+    CONF_ENABLE_DEBUG,
+    CONF_ENABLE_EXPERIMENTAL,
+    CONF_ENABLE_MQTT_DEBUG,
     DOMAIN,
     PROGRAM_PARAM_NAMES,
 )
@@ -2566,10 +2569,24 @@ def _coordinator(hass: HomeAssistant, entry: ConfigEntry):
 def _last_error(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
     """The last classified setup/update error code, for issue triage.
 
-    Static code+reason (no device identity), pulled from the client. None when no
-    failure has been recorded (or the client is absent, e.g. a failed setup)."""
+    Static code+reason (no device identity), pulled from the client. None when the
+    client was asked and had recorded no failure; ``{"status": "client_absent"}``
+    when there was no client to ask at all (e.g. a failed setup)."""
     entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
     client = entry_data.get("client")
+    if client is None:
+        # A dump from a failed setup used to be indistinguishable from a healthy
+        # account that simply owns no appliances: both read `"last_error": null,
+        # "appliances": []`, and a real 5.9.3 report was triaged as the second when
+        # it was the first. `null` is now the answer of a client, not the absence of
+        # one. "No entry data" and "entry data without a client" are deliberately
+        # ONE state: async_setup_entry stores the bucket as a single literal that
+        # always carries the client (__init__.py:621) and pops it whole on a failed
+        # setup or unload (__init__.py:651, :662, :680), so a bucket without a
+        # client is not a state this integration can produce -- a second token would
+        # only send a triager hunting a distinction nothing writes. A closed-domain
+        # token like the fields below, so it needs no _redact either.
+        return {"status": "client_absent"}
     code = getattr(client, "last_error_code", None)
     if code is None:
         return None
@@ -2600,6 +2617,52 @@ def _last_error(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
             "can_resend": mfa.get("can_resend"),
         }
     return out
+
+
+# The option keys the Configure screen writes (config_flow.OptionsFlowHandler),
+# taken from the CONF_ constants so renaming one cannot leave a stale literal
+# here that quietly demotes a live toggle to `***`. CONF_AUTH_DIAGNOSTICS is
+# deliberately absent although it sits with them in const.py: the config flow
+# strips it before anything is validated or persisted, so it is not an option
+# key, and a build that ever left it in `entry.options` should be told so by the
+# mask rather than trusted.
+_KNOWN_OPTIONS = frozenset(
+    {CONF_ENABLE_DEBUG, CONF_ENABLE_EXPERIMENTAL, CONF_ENABLE_MQTT_DEBUG}
+)
+
+
+def _entry_options(options: Mapping) -> dict:
+    """Entry options with every key outside `_KNOWN_OPTIONS` stripped of its value.
+
+    Mask first, admit by name: today all three toggles are booleans and nothing
+    here can leak, but this block is copied out of storage unread, so the FOURTH
+    option ships whatever its author put in it -- a token, an endpoint, a user
+    string -- into every dump pasted into an issue. A whitelist is what makes
+    that a deliberate act instead of the default.
+
+    An unrecognised key keeps its NAME and loses only its VALUE: "this install
+    carries an option this build knows nothing about" is itself a finding, and
+    dropping the key would hide the very thing worth reporting. Sorted like the
+    other mappings in the dump, so two downloads of the same install differ only
+    where the install does.
+    """
+    return {
+        key: (options[key] if key in _KNOWN_OPTIONS else _REDACTED)
+        for key in sorted(options, key=str)
+    }
+
+
+def _last_poll(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
+    """The census the client recorded for its last completed poll cycle.
+
+    Passed through as the client built it (`hon_client._poll_census`), which is
+    where the leak-proof shape is enforced. None when no cycle has ever completed
+    -- no client, a setup that never got that far, or a first poll that aborted --
+    and `last_error` is what speaks for those.
+    """
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    census = getattr(entry_data.get("client"), "last_poll_census", None)
+    return dict(census) if isinstance(census, Mapping) else None
 
 
 async def async_get_config_entry_diagnostics(
@@ -2655,7 +2718,7 @@ async def async_get_config_entry_diagnostics(
                 "email": _redact_email(entry.data.get("email")),
                 "password": _REDACTED,
             },
-            "options": dict(entry.options),
+            "options": _entry_options(entry.options),
         },
         "last_error": _last_error(hass, entry),
         # Entry-wide, next to last_error rather than inside an appliance: a failed
@@ -2664,6 +2727,12 @@ async def async_get_config_entry_diagnostics(
         # primitives only (platform domains, counts, a status token), so like
         # last_error it is leak-proof by construction and skips _redact.
         "platforms": platforms,
+        # What separates "this account owns nothing" from "the cloud returned three
+        # and the poll dropped all three": both render as `"appliances": []` with a
+        # null last_error, and until now only the `Partial update` WARNING -- which
+        # no dump carries -- told them apart. Counts plus ADDHON catalog labels, so
+        # like the two keys above it is leak-proof by construction and skips _redact.
+        "last_poll": _last_poll(hass, entry),
         "appliances": appliances,
     }
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -2645,9 +2645,20 @@ def _entry_options(options: Mapping) -> dict:
     dropping the key would hide the very thing worth reporting. Sorted like the
     other mappings in the dump, so two downloads of the same install differ only
     where the install does.
+
+    Admitting a key admits a SHAPE with it. What makes these three safe to print
+    is not their names but the fact that the Configure screen coerces each to a
+    bool before storing it (config_flow.py: `bool(user_input.get(...))`), so a
+    string under `enable_debug` was not written by the form this whitelist
+    trusts, and nothing vouches for what it holds. It is masked like any
+    stranger, and the name still reports that the install carries it.
     """
     return {
-        key: (options[key] if key in _KNOWN_OPTIONS else _REDACTED)
+        key: (
+            options[key]
+            if key in _KNOWN_OPTIONS and isinstance(options[key], bool)
+            else _REDACTED
+        )
         for key in sorted(options, key=str)
     }
 

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -276,6 +276,34 @@ def _must_propagate(err: BaseException) -> bool:
     return _requires_reauth(err) or _is_retryable_server_error(err)
 
 
+def _poll_census(
+    returned: int, kept: int, failures: list[tuple[str, Exception]]
+) -> dict[str, Any]:
+    """Leak-proof account of ONE completed poll cycle, for the downloadable diagnostics.
+
+    A dump of a broken account reads `"appliances": []` whether the cloud returned
+    nothing or the poll dropped every appliance it was handed, and the only thing that
+    ever separated the two is the `Partial update: %d/%d` WARNING below, which no dump
+    carries. The two counts answer that; each drop then carries the ADDHON label of its
+    cause and NOTHING else -- the redacted names in `failures` belong to that WARNING,
+    and an exception message routinely carries a MAC, a nickname or a URL, so neither
+    is read here.
+
+    The label comes from the same picker the total-failure raise uses, so a census and
+    the `last_error` beside it in the dump can never name one failure two ways. `kept`
+    plus the drops normally account for `returned`; a shortfall is a finding of its own
+    (two appliances sharing an id collapse into a single snapshot entry).
+    """
+    dropped: list[dict[str, Any]] = []
+    for _name, err in failures:
+        # The name is dropped on the floor rather than forwarded: the picker never
+        # reads it, and passing "" keeps identity out of this call by construction
+        # instead of by trusting a helper never to grow a use for it.
+        code, _cause = _representative_failure([("", err)])
+        dropped.append({"code": code.label, "reason": code.reason_en})
+    return {"returned": returned, "kept": kept, "dropped": dropped}
+
+
 class HonClient:
     """Manages the connection to the Haier hOn APIs via the native client.
 
@@ -319,6 +347,11 @@ class HonClient:
         # phase names, rounded seconds, ok/error/timeout). This is the artefact that
         # makes a report like #76 diagnosable without a live probe.
         self.last_phase_ledger: list[dict] | None = None
+        # Census of the last COMPLETED poll cycle (see _poll_census): how many
+        # appliances the cloud returned, how many survived, one catalog label per
+        # drop. None until a cycle finishes, which is the third state the dump has
+        # to distinguish -- no poll ever ran.
+        self.last_poll_census: dict | None = None
         self._hon_instance = None
         self._api = None
         self._hon_loop: asyncio.AbstractEventLoop | None = None
@@ -620,6 +653,11 @@ class HonClient:
             self.last_error_phase = None
             self.last_mfa_summary = None
             self.last_phase_ledger = None
+            # Not part of that failure record: a census is a statement about ONE
+            # session's poll, and this attempt builds a new session. Carrying it over
+            # would let a dump answer "how did the last poll go" with a cycle that ran
+            # on a session this client has since thrown away.
+            self.last_poll_census = None
             try:
                 if self._hon_loop is None or not self._hon_loop.is_running():
                     self._start_hon_loop()
@@ -1168,6 +1206,17 @@ class HonClient:
 
             if retry_after_reauth:
                 continue
+
+            # Every appliance has been attempted, so THIS is the cycle the census
+            # describes -- including the total failure just below, which raises and
+            # would otherwise leave the dump with nothing but a stale snapshot to
+            # explain itself. Deliberately not recorded on the strict first-poll
+            # re-raise above: that one aborts mid-loop, and counting the appliances
+            # the loop never reached as survivors would be a false statement about
+            # exactly the dump this exists to explain.
+            self.last_poll_census = _poll_census(
+                len(appliances), len(data), failed_appliances
+            )
 
             if appliances and not data and failed_appliances:
                 # Every appliance failed this cycle: surface a failed update (the

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -13,5 +13,5 @@
     "yarl>=1.8",
     "typing-extensions>=4.8"
   ],
-  "version": "5.14.1"
+  "version": "5.15.0"
 }

--- a/tests/test_coordinator_resilience.py
+++ b/tests/test_coordinator_resilience.py
@@ -15,6 +15,7 @@ homeassistant package is not importable in the unit env).
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import types
 import unittest
@@ -285,6 +286,123 @@ class CoordinatorResilienceTest(unittest.TestCase):
         self.assertEqual(calls["reauth"], 1)       # reauth was attempted
         self.assertGreaterEqual(calls["update"], 2)  # and the poll retried
         self.assertIn("ac", data)                  # recovered after reauth
+
+
+class PollCensusTest(unittest.TestCase):
+    """The census the poll records for the downloadable diagnostics.
+
+    A real 5.9.3 field dump reads `"appliances": []` with a null `last_error` both
+    for an account that owns nothing and for a cycle that dropped every appliance
+    the cloud returned. The `Partial update: %d/%d` WARNING is the only place those
+    two are separated today, and a WARNING never reaches the file the reporter
+    attaches, so the two bugs arrive byte-identical.
+    """
+
+    def test_clean_poll_records_every_appliance_as_kept(self) -> None:
+        c = _client([FakeAppliance("g1"), FakeAppliance("g2")])
+        c._update_appliance_sync = lambda appliance: None
+        asyncio.run(c.async_get_appliances_data())
+        self.assertEqual(
+            {"returned": 2, "kept": 2, "dropped": []}, c.last_poll_census
+        )
+
+    def test_zero_appliances_records_a_census_not_a_silence(self) -> None:
+        # The whole point: "returned 0" must be a statement in the dump, not the
+        # absence of one, because the alternative reading of an empty dump is a poll
+        # that returned appliances and kept none.
+        c = _client([])
+        c._update_appliance_sync = lambda appliance: None
+        asyncio.run(c.async_get_appliances_data())
+        self.assertEqual(
+            {"returned": 0, "kept": 0, "dropped": []}, c.last_poll_census
+        )
+
+    def test_partial_failure_names_the_cause_of_each_drop(self) -> None:
+        good, bad = FakeAppliance("g1"), FakeAppliance("bad")
+        c = _client([good, bad])
+        c._first_poll_done = True  # steady state: the failed one is skipped
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError("decode error")  # -> DECODE_ERROR, non-retryable
+
+        c._update_appliance_sync = _update
+        asyncio.run(c.async_get_appliances_data())
+        census = c.last_poll_census
+        self.assertEqual(2, census["returned"])
+        self.assertEqual(1, census["kept"])
+        self.assertEqual(
+            [DECODE_ERROR.label], [drop["code"] for drop in census["dropped"]]
+        )
+
+    def test_total_failure_still_records_the_cycle_it_lost(self) -> None:
+        # The branch that raises is the one whose dump needs this most: the
+        # coordinator keeps its previous snapshot (or none at all on the first
+        # cycle), so without a census "returned 2, kept 0" is indistinguishable
+        # from "returned 0" -- two different bugs.
+        b1, b2 = FakeAppliance("b1"), FakeAppliance("b2")
+        c = _client([b1, b2])
+        c._first_poll_done = True
+        c._update_appliance_sync = lambda appliance: (_ for _ in ()).throw(
+            RuntimeError("decode error")
+        )
+        with self.assertRaises(HonCodedError):
+            asyncio.run(c.async_get_appliances_data())
+        census = c.last_poll_census
+        self.assertEqual(2, census["returned"])
+        self.assertEqual(0, census["kept"])
+        self.assertEqual(
+            [DECODE_ERROR.label, DECODE_ERROR.label],
+            [drop["code"] for drop in census["dropped"]],
+        )
+
+    def test_first_poll_abort_records_no_census(self) -> None:
+        # The strict first-poll branch re-raises from INSIDE the loop, so the
+        # appliances after the failing one were never attempted. A census counting
+        # them as survivors would be a false statement, and no census at all is the
+        # honest one: nothing completed.
+        bad, never_reached = FakeAppliance("bad"), FakeAppliance("g1")
+        c = _client([bad, never_reached])  # fresh client -> strict, and bad is first
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError("decode error")
+
+        c._update_appliance_sync = _update
+        with self.assertRaises(HonCodedError):
+            asyncio.run(c.async_get_appliances_data())
+        self.assertIsNone(c.last_poll_census)
+
+    def test_census_carries_no_identity_and_no_raw_exception_text(self) -> None:
+        # The redacted name belongs to the WARNING and nowhere else, and an exception
+        # message is not a closed domain: this one carries the nickname and the MAC,
+        # which is what a cloud 5xx body or a URL in a transport error looks like.
+        bad = FakeAppliance("AA:BB:CC:DD:EE:FF")
+        bad.nick_name = "Kitchen Washer"
+        c = _client([FakeAppliance("g1"), bad])
+        c._first_poll_done = True
+
+        def _update(appliance):
+            if appliance is bad:
+                raise RuntimeError(
+                    "decode error for Kitchen Washer at AA:BB:CC:DD:EE:FF"
+                )
+
+        c._update_appliance_sync = _update
+        asyncio.run(c.async_get_appliances_data())
+        blob = json.dumps(c.last_poll_census)
+        for leak in (
+            "Kitchen Washer",
+            "AA:BB:CC:DD:EE:FF",
+            "decode error for",
+            "***",  # not even the redacted name: the census has no name field
+        ):
+            self.assertNotIn(leak, blob, leak)
+        # Positive control: the drop IS reported, so the assertions above are not
+        # passing on an empty census.
+        self.assertEqual(
+            [DECODE_ERROR.label], [drop["code"] for drop in c.last_poll_census["dropped"]]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -191,7 +191,14 @@ _install_stubs()
 
 from custom_components.addhon import diagnostics  # noqa: E402
 from custom_components.addhon import debug_utils  # noqa: E402
+from custom_components.addhon import const  # noqa: E402
 from custom_components.addhon.const import DOMAIN  # noqa: E402
+from custom_components.addhon.const import (  # noqa: E402
+    CONF_AUTH_DIAGNOSTICS,
+    CONF_ENABLE_DEBUG,
+    CONF_ENABLE_EXPERIMENTAL,
+    CONF_ENABLE_MQTT_DEBUG,
+)
 
 
 def _run(coro):
@@ -750,6 +757,119 @@ class DiagnosticsRedactionTest(unittest.TestCase):
         self.assertNotIn("user@example.com", result["entry"]["title"] or "")
 
 
+def _dump_options(options: dict) -> dict:
+    """`entry.options` as the entry dump renders it."""
+    entry = FakeEntry()
+    entry.options = options
+    return _run(
+        diagnostics.async_get_config_entry_diagnostics(
+            FakeHass(_build_coordinator()), entry
+        )
+    )["entry"]["options"]
+
+
+class EntryOptionsRedactionTest(unittest.TestCase):
+    """`entry.options` reaches the dump straight out of storage, and the dump is
+    the file users paste into a GitHub issue. The three toggles that exist today
+    are booleans and leak nothing, so what is pinned here is what happens to the
+    FOURTH option: whoever adds it, whatever it ends up carrying."""
+
+    def test_the_known_toggles_keep_their_real_values(self):
+        self.assertEqual(
+            {
+                CONF_ENABLE_DEBUG: True,
+                CONF_ENABLE_EXPERIMENTAL: True,
+                CONF_ENABLE_MQTT_DEBUG: False,
+            },
+            _dump_options(
+                {
+                    CONF_ENABLE_DEBUG: True,
+                    CONF_ENABLE_MQTT_DEBUG: False,
+                    CONF_ENABLE_EXPERIMENTAL: True,
+                }
+            ),
+        )
+
+    def test_an_unknown_option_is_named_but_never_shown(self):
+        options = _dump_options(
+            {CONF_ENABLE_DEBUG: True, "api_endpoint": "https://bob:hunter2@hon.example"}
+        )
+        # The NAME survives on purpose: an option this build does not recognise is
+        # worth reporting, and a dropped key reports nothing.
+        self.assertIn("api_endpoint", options)
+        self.assertEqual("***", options["api_endpoint"])
+        self.assertNotIn("hunter2", json.dumps(options))
+        # positive control: the mask is keyed on the whitelist, not applied to the
+        # whole block, so the clauses above cannot pass by redacting everything.
+        self.assertEqual(True, options[CONF_ENABLE_DEBUG])
+
+    def test_the_sign_in_trace_flag_is_not_an_option(self):
+        """`CONF_AUTH_DIAGNOSTICS` sits beside the three toggles in const.py, which is
+        exactly why it is worth stating: the config flow strips it before anything is
+        persisted, so it never IS an option, and an entry that somehow carries one is
+        a stranger like any other."""
+        self.assertEqual(
+            {CONF_AUTH_DIAGNOSTICS: "***"},
+            _dump_options({CONF_AUTH_DIAGNOSTICS: True}),
+        )
+
+    def test_no_options_render_as_no_options(self):
+        self.assertEqual({}, _dump_options({}))
+
+    def test_the_keys_come_out_sorted(self):
+        # Same install, two downloads: an issue thread routinely carries both, and a
+        # storage-order mapping makes them diff on nothing that happened.
+        self.assertEqual(
+            ["alpha", CONF_ENABLE_DEBUG, "zulu"],
+            list(_dump_options({"zulu": 1, CONF_ENABLE_DEBUG: True, "alpha": 2})),
+        )
+
+
+def _options_flow_conf_names() -> set[str]:
+    """The `CONF_*` constants `OptionsFlowHandler` names inside its own body.
+
+    Parsed, never imported: config_flow reaches the transport auth chain (and
+    `yarl`, which the stubs in this file do not provide), and the module whose
+    next toggle this guard exists to catch is precisely the one it must not fail
+    to read. Scoped to the class because `CONF_AUTH_DIAGNOSTICS` is named
+    elsewhere in the same file by the credentials flow, which writes `entry.data`
+    and not `entry.options`.
+    """
+    source = (REPO_ROOT / "custom_components" / "addhon" / "config_flow.py").read_text(
+        encoding="utf-8"
+    )
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ClassDef) and node.name == "OptionsFlowHandler":
+            return {
+                child.id
+                for child in ast.walk(node)
+                if isinstance(child, ast.Name) and child.id.startswith("CONF_")
+            }
+    raise AssertionError(
+        "config_flow.OptionsFlowHandler was not found, so the option keys the "
+        "Configure screen writes could not be read. If the handler was renamed, "
+        "point this guard at the new name -- do not delete it."
+    )
+
+
+class EntryOptionsWhitelistGuardTest(unittest.TestCase):
+    """The behavioural tests above prove the mask works on the keys they name. This
+    ties the whitelist to the screen that fills `entry.options`, so an option added
+    to the Configure form later has to be ADMITTED here deliberately instead of
+    riding into every dump because nobody thought about it."""
+
+    def test_the_whitelist_is_exactly_what_the_options_screen_writes(self):
+        offered = {getattr(const, name) for name in _options_flow_conf_names()}
+        self.assertEqual(
+            offered,
+            set(diagnostics._KNOWN_OPTIONS),
+            "diagnostics._KNOWN_OPTIONS and the keys OptionsFlowHandler writes have "
+            "diverged. A new toggle must be added to _KNOWN_OPTIONS only once its "
+            "value is known to be safe to publish; otherwise leave it masked and "
+            "drop it from this comparison with a reason.",
+        )
+
+
 class DiagnosticsDeviceTest(unittest.TestCase):
     def test_device_diagnostics_returns_single_matching_appliance(self):
         coord = _build_coordinator()
@@ -1045,11 +1165,46 @@ class IdentityKeysDriftGuardTest(unittest.TestCase):
 class LastErrorDiagnosticsTest(unittest.TestCase):
     """#30: the config-entry diagnostics expose the last classified error code."""
 
-    def test_last_error_none_without_client(self) -> None:
-        # FakeHass stores only the coordinator -> no recorded error.
+    def test_last_error_says_so_when_there_is_no_client_to_ask(self) -> None:
+        # A 5.9.3 field dump read `"last_error": null, "appliances": []` and was
+        # triaged as an account owning no appliances; it was a failed setup, whose
+        # client never reached hass.data. `null` must not be the answer to a
+        # question nobody could ask.
         result = _run(diagnostics.async_get_config_entry_diagnostics(FakeHass(_build_coordinator()), FakeEntry()))
-        self.assertIn("last_error", result)
-        self.assertIsNone(result["last_error"])
+        self.assertEqual({"status": "client_absent"}, result["last_error"])
+        # And it must not be readable as a recorded failure: a consumer keying on
+        # `code` would otherwise report an error nobody classified.
+        self.assertNotIn("code", result["last_error"])
+
+    def test_last_error_stays_null_when_the_client_recorded_no_failure(self) -> None:
+        # The other half of the pair above: a client that WAS asked and had nothing
+        # keeps returning null, so the marker cannot be produced by simply owning no
+        # appliances. Both dumps carry an empty `appliances`, which is exactly the
+        # pair the field report could not tell apart.
+        class _Client:
+            last_error_code = None
+
+        hass = FakeHass(FakeCoordinator({}))
+        hass.data[DOMAIN]["e1"]["client"] = _Client()
+        healthy = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        failed_setup = _run(
+            diagnostics.async_get_config_entry_diagnostics(FakeHass(FakeCoordinator({})), FakeEntry())
+        )
+        self.assertIsNone(healthy["last_error"])
+        self.assertEqual([], healthy["appliances"])
+        self.assertEqual([], failed_setup["appliances"])
+        self.assertNotEqual(healthy["last_error"], failed_setup["last_error"])
+
+    def test_last_error_folds_missing_entry_data_into_the_same_marker(self) -> None:
+        # "No entry data for this entry" and "entry data without a client" are ONE
+        # state on purpose (diagnostics.py `_last_error`): __init__ writes the bucket
+        # with the client inside it and pops it whole, so the two cannot be reached
+        # separately, and a second token would be a distinction nothing writes. This
+        # pins the fold: an entry absent from hass.data reports the same marker as
+        # the client-less bucket above.
+        hass = FakeHass(_build_coordinator(), entry_id="other-entry")
+        result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        self.assertEqual({"status": "client_absent"}, result["last_error"])
 
     def test_last_error_reports_code_and_reason(self) -> None:
         from custom_components.addhon import error_codes as ec
@@ -1178,6 +1333,105 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
                     diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
                 )
                 self.assertNotIn("mfa", result["last_error"])
+
+
+class LastPollCensusDiagnosticsTest(unittest.TestCase):
+    """The entry dump says whether the poll returned nothing or dropped everything.
+
+    A real 5.9.3 field dump reads `"data": {"entry": {...}, "last_error": null,
+    "appliances": []}` in full, and three states produce that exact file: an account
+    with no appliances, a poll that dropped every appliance the cloud returned, and a
+    setup that left no client at all. The `Partial update: %d/%d` WARNING separates
+    the first two on the user's machine and never reaches the file, so `last_poll`
+    carries the same fact into the dump: counts plus ADDHON catalog labels.
+    """
+
+    def _hass_with_census(self, census, coordinator=None):
+        class _Client:
+            last_poll_census = census
+
+        hass = FakeHass(coordinator if coordinator is not None else FakeCoordinator({}))
+        hass.data[DOMAIN]["e1"]["client"] = _Client()
+        return hass
+
+    def test_last_poll_is_null_when_no_cycle_completed(self) -> None:
+        # No client at all (the failed-setup state): the key is still there, so a
+        # reader never has to wonder whether this dump predates the census.
+        result = _run(
+            diagnostics.async_get_config_entry_diagnostics(
+                FakeHass(_build_coordinator()), FakeEntry()
+            )
+        )
+        self.assertIn("last_poll", result)
+        self.assertIsNone(result["last_poll"])
+
+    def test_an_empty_account_and_a_dropped_one_no_longer_look_alike(self) -> None:
+        empty = _run(
+            diagnostics.async_get_config_entry_diagnostics(
+                self._hass_with_census({"returned": 0, "kept": 0, "dropped": []}),
+                FakeEntry(),
+            )
+        )
+        dropped = _run(
+            diagnostics.async_get_config_entry_diagnostics(
+                self._hass_with_census(
+                    {
+                        "returned": 3,
+                        "kept": 0,
+                        "dropped": [
+                            {"code": "ADDHON-450", "reason": "hOn server error"},
+                            {"code": "ADDHON-450", "reason": "hOn server error"},
+                            {"code": "ADDHON-220", "reason": "Could not load appliance data"},
+                        ],
+                    }
+                ),
+                FakeEntry(),
+            )
+        )
+        # The two dumps still agree on everything the field report carried, which is
+        # the whole reason the census had to be added rather than inferred.
+        self.assertEqual([], empty["appliances"])
+        self.assertEqual([], dropped["appliances"])
+        self.assertIsNone(empty["last_error"])
+        self.assertIsNone(dropped["last_error"])
+        # ...and disagree where it counts.
+        self.assertEqual(0, empty["last_poll"]["returned"])
+        self.assertEqual([], empty["last_poll"]["dropped"])
+        self.assertEqual(3, dropped["last_poll"]["returned"])
+        self.assertEqual(0, dropped["last_poll"]["kept"])
+        self.assertEqual(
+            ["ADDHON-450", "ADDHON-450", "ADDHON-220"],
+            [drop["code"] for drop in dropped["last_poll"]["dropped"]],
+        )
+
+    def test_the_census_the_client_builds_survives_into_the_dump(self) -> None:
+        # Built by the WRITER (hon_client._poll_census) rather than hand-written, so
+        # this pins the whole path: the reader publishes what the poll recorded, and
+        # the two halves cannot drift into agreeing only in this file. The failure
+        # handed to it carries a nickname and a MAC, which is what a cloud error body
+        # or a transport URL looks like; `last_poll` skips `_redact` by design, so the
+        # leak check is run over the finished document.
+        from custom_components.addhon.hon_client import _poll_census
+
+        census = _poll_census(
+            3,
+            2,
+            [("***", RuntimeError("decode error for Kitchen Washer at AA:BB:CC:DD:EE:FF"))],
+        )
+        result = _run(
+            diagnostics.async_get_config_entry_diagnostics(
+                self._hass_with_census(census, _build_coordinator()), FakeEntry()
+            )
+        )
+        self.assertEqual(census, result["last_poll"])
+        self.assertEqual(3, result["last_poll"]["returned"])
+        self.assertEqual(2, result["last_poll"]["kept"])
+        self.assertEqual(
+            ["ADDHON-470"], [drop["code"] for drop in result["last_poll"]["dropped"]]
+        )
+        blob = json.dumps(result)  # also proves the block is serializable as it stands
+        for leak in ("Kitchen Washer", "AA:BB:CC:DD:EE:FF", "decode error for"):
+            self.assertNotIn(leak, blob, leak)
 
 
 # --- Task 10: air purifier coverage and passive future-capability capture -----

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -813,6 +813,19 @@ class EntryOptionsRedactionTest(unittest.TestCase):
             _dump_options({CONF_AUTH_DIAGNOSTICS: True}),
         )
 
+    def test_an_admitted_key_holding_a_non_boolean_is_masked_too(self):
+        # The whitelist admits a name, but what makes that name safe to print is
+        # the shape behind it: the Configure screen stores `bool(...)`, so a
+        # string here was written by something else and nothing vouches for it.
+        options = _dump_options(
+            {CONF_ENABLE_DEBUG: "https://bob:hunter2@hon.example", CONF_ENABLE_MQTT_DEBUG: True}
+        )
+        self.assertEqual("***", options[CONF_ENABLE_DEBUG])
+        self.assertNotIn("hunter2", json.dumps(options))
+        # positive control: the mask is keyed on the value's shape, not applied
+        # to every admitted key once one of them looks wrong.
+        self.assertEqual(True, options[CONF_ENABLE_MQTT_DEBUG])
+
     def test_no_options_render_as_no_options(self):
         self.assertEqual({}, _dump_options({}))
 

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -649,6 +649,16 @@ class SetupFailureRecordTest(unittest.TestCase):
         self.assertIsNone(client.last_error_code)
         self.assertIsNone(client.last_error_phase)
 
+    def test_a_fresh_attempt_never_shows_the_previous_session_poll_census(self) -> None:
+        # Cleared in the same block as the three above but for its own reason: the
+        # poll census describes ONE session's cycle, and this attempt builds a new
+        # session. Kept across, it would let a dump answer "how did the last poll go"
+        # with a cycle that ran on a session the client has since thrown away.
+        client = self._client(None)
+        client.last_poll_census = {"returned": 3, "kept": 3, "dropped": []}
+        client.setup_sync()
+        self.assertIsNone(client.last_poll_census)
+
 
 class _FallbackAppliance:
     """No update() attribute -> _do_update takes the load_* fallback path directly.


### PR DESCRIPTION
Automated release PR for `v5.15.0`.

<!-- release-tag: v5.15.0 -->

## Summary by Sourcery

Improve diagnostics for configuration entries and polling to better distinguish failure modes while keeping dumps leak-proof, and bump integration version to v5.15.0.

Enhancements:
- Expose a structured last_poll census in config-entry diagnostics to differentiate empty accounts, dropped polls, and never-completed cycles.
- Refine last_error reporting to use a client_absent status when no client is available instead of null, aligning diagnostics with actual setup state.
- Whitelist known options and mask unknown entry.options values while preserving their keys to avoid leaking arbitrary configuration data.
- Ensure poll census data is cleared on new client sessions so diagnostics always reflect the current session.

Tests:
- Add diagnostics tests covering entry.options masking, whitelist guarding against new options, and last_error behaviour for missing clients and entry data.
- Add tests for poll census recording in HonClient, including clean, partial, total, and aborted polls, plus leak checks on census content.
- Extend diagnostics tests to verify last_poll census exposure and privacy guarantees in the downloadable entry dump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe poll diagnostics showing appliance counts, retained items, and categorized failures.
  * Added the latest poll census to configuration diagnostics.
  * Improved error reporting by distinguishing unavailable clients from healthy accounts with no appliances.
  * Sensitive or unrecognized configuration values are now redacted.

* **Bug Fixes**
  * Prevented poll data from a previous session from appearing after a new setup.

* **Tests**
  * Added coverage for poll outcomes, error labeling, privacy safeguards, and diagnostic redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release improves privacy-safe configuration and polling diagnostics while updating the integration version to 5.15.0.
- Adds a structured census for the latest completed poll and clears it when a new client session begins.
- Distinguishes an absent client from a client with no recorded error.
- Preserves known boolean options while masking unknown or malformed option values.
- Expands diagnostics and polling tests for outcome reporting, lifecycle behavior, and data-leak prevention.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/addhon/diagnostics.py | Adds client-state and poll-census diagnostics plus allowlisted, shape-checked option serialization. |
| custom_components/addhon/hon_client.py | Records privacy-safe appliance outcome counts for completed polls and resets the census for new sessions. |
| custom_components/addhon/manifest.json | Updates the integration version from 5.14.1 to 5.15.0. |
| tests/test_coordinator_resilience.py | Covers clean, empty, partial, failed, and aborted poll census behavior and verifies sensitive details are excluded. |
| tests/test_diagnostics.py | Covers option masking, whitelist drift, absent-client reporting, census exposure, and diagnostic privacy. |
| tests/test_hon_client_realtime.py | Verifies that starting a new client session clears the previous session’s poll census. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(diagnostics): admit an option&#39;s shap..."](https://github.com/tis24dev/addhon/commit/8dd253e28786291835a7bcdb8e91734daf11498c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53686323)</sub>

<!-- /greptile_comment -->