### PR TITLE
Release v5.16.0

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -57,9 +57,10 @@ def _async_register_services(hass: HomeAssistant) -> None:
     realtime MQTT noise. The service is global to the domain, not per-entry, so it
     is idempotent: if already present it does nothing.
 
-    voluptuous is imported here (not at module level) so the import of __init__
-    does not depend on voluptuous: the test harness imports the package without
-    always providing its stub, while this function only runs in real HA.
+    voluptuous and homeassistant.helpers.service are imported here (not at module
+    level) so the import of __init__ does not depend on them: the test harness
+    imports the package without always providing their stubs, while this function
+    only runs in real HA.
     """
     mqtt_service_exists = hass.services.has_service(DOMAIN, SERVICE_SET_MQTT_LOG_LEVEL)
     log_service_exists = hass.services.has_service(DOMAIN, SERVICE_SET_LOG_LEVEL)
@@ -68,6 +69,8 @@ def _async_register_services(hass: HomeAssistant) -> None:
         return
 
     import voluptuous as vol
+
+    from homeassistant.helpers.service import async_register_admin_service
 
     # First registration (HA start/restart): silence the noise by default.
     # On a reload of a single entry the service stays registered, so a debug level
@@ -128,8 +131,15 @@ def _async_register_services(hass: HomeAssistant) -> None:
         {vol.Required(ATTR_LEVEL, default="debug"): vol.In(tuple(MQTT_LOG_LEVELS))}
     )
 
+    # Admin-only. Both handlers end in logging.getLogger().setLevel(), which is
+    # global to the Python process: not per config entry, not per user. Registered
+    # plainly, any authenticated non-admin could turn integration-wide debug
+    # logging on through the REST/WebSocket API. async_register_admin_service
+    # resolves call.context.user_id and raises Unauthorized for non-admins; calls
+    # with no user attached (automations, internal) keep working.
     if not mqtt_service_exists:
-        hass.services.async_register(
+        async_register_admin_service(
+            hass,
             DOMAIN,
             SERVICE_SET_MQTT_LOG_LEVEL,
             _handle_set_mqtt_log_level,
@@ -137,7 +147,8 @@ def _async_register_services(hass: HomeAssistant) -> None:
         )
 
     if not log_service_exists:
-        hass.services.async_register(
+        async_register_admin_service(
+            hass,
             DOMAIN,
             SERVICE_SET_LOG_LEVEL,
             _handle_set_log_level,

--- a/custom_components/addhon/config_flow.py
+++ b/custom_components/addhon/config_flow.py
@@ -14,6 +14,11 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .client.transport.auth import MFAChallengeRequired, MFACodeInvalid
 from .const import (
@@ -71,11 +76,17 @@ def _redact_email(email: str | None) -> str | None:
     return f"***@{domain}"
 
 
+# The Haier account password must never render as a plain text field: a bare
+# `str` shows it on screen while it is typed. One instance, reused by both the
+# user and the reauth schema (selectors are stateless).
+_PASSWORD_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+
+
 def _step_user_data_schema(auth_diagnostics: bool = False) -> vol.Schema:
     return vol.Schema(
         {
             vol.Required("email"): str,
-            vol.Required("password"): str,
+            vol.Required("password"): _PASSWORD_SELECTOR,
             vol.Optional(
                 CONF_AUTH_DIAGNOSTICS, default=auth_diagnostics
             ): bool,
@@ -86,7 +97,7 @@ def _step_user_data_schema(auth_diagnostics: bool = False) -> vol.Schema:
 def _step_reauth_data_schema(auth_diagnostics: bool = False) -> vol.Schema:
     return vol.Schema(
         {
-            vol.Required("password"): str,
+            vol.Required("password"): _PASSWORD_SELECTOR,
             vol.Optional(
                 CONF_AUTH_DIAGNOSTICS, default=auth_diagnostics
             ): bool,

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.15.0"
+  "version": "5.16.0"
 }

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -9,9 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tis24dev/addhOn/issues",
   "requirements": [
-    "awsiotsdk>=1.21.0",
-    "yarl>=1.8",
-    "typing-extensions>=4.8"
+    "awsiotsdk>=1.21.0"
   ],
   "version": "5.15.0"
 }

--- a/custom_components/addhon/strings.json
+++ b/custom_components/addhon/strings.json
@@ -1,0 +1,919 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Sign in with your hOn account",
+        "description": "Enter your Haier hOn app credentials. Same email and password you use on the mobile app.\n\n⚠️ This integration is unofficial and uses the hOn API without authorization from Haier.",
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "auth_diagnostics": "Collect sign-in diagnostics"
+        },
+        "data_description": {
+          "auth_diagnostics": "If sign-in fails, record detailed sanitized technical information in the Home Assistant log. Credentials, tokens, and personal data are not included."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate your hOn account",
+        "description": "The credentials for {email} are no longer valid. Enter the password again.",
+        "data": {
+          "password": "Password",
+          "auth_diagnostics": "Collect sign-in diagnostics"
+        },
+        "data_description": {
+          "auth_diagnostics": "If sign-in fails, record detailed sanitized technical information in the Home Assistant log. Credentials, tokens, and personal data are not included."
+        }
+      },
+      "2fa": {
+        "title": "Two-factor verification",
+        "description": "Your hOn account has two-factor authentication enabled. Enter the verification code we emailed to you. To get a new code, tick \"Resend code\" and submit.",
+        "data": {
+          "code": "Verification code",
+          "resend": "Resend code"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to hOn servers. Check your internet connection. ({error_code})",
+      "invalid_auth": "Invalid credentials. Check your email and password. ({error_code})",
+      "unknown": "Unexpected error. Check Home Assistant logs. ({error_code})",
+      "invalid_credentials": "Invalid email or password. ({error_code})",
+      "auth_introduce": "Could not start the hOn login. ({error_code})",
+      "auth_login": "Login rejected - check your email and password. ({error_code})",
+      "auth_get_token": "Could not retrieve the hOn session token. ({error_code})",
+      "auth_api_auth": "hOn rejected the API authorization. ({error_code})",
+      "mfa_required": "A verification code is required to finish signing in. ({error_code})",
+      "mfa_code_invalid": "The verification code is wrong or has expired. Enter it again or resend a new one. ({error_code})",
+      "mfa_send_failed": "Could not send the verification code. Wait a moment and tap Resend. ({error_code})",
+      "mfa_service_error": "The verification service had a temporary problem. Try the code again in a moment. ({error_code})",
+      "mfa_token_after_verify_failed": "Your code was accepted but sign-in could not finish. Please start the login again. ({error_code})",
+      "account_action_required": "Your password was accepted, but hOn is asking for an extra step on the account (for example a new password to set, or terms to accept). Sign in on the hOn website or app, complete the requested step, then try again here. ({error_code})",
+      "appliance_list_failed": "Could not fetch your appliance list. ({error_code})",
+      "network_timeout": "Timed out contacting the hOn servers. Check your internet connection. ({error_code})",
+      "auth_timeout": "Timed out while signing in to hOn. The servers are slow or your connection dropped. Try again. ({error_code})",
+      "refresh_timeout": "Timed out while refreshing the hOn session. Try again in a moment. ({error_code})",
+      "dns_failure": "Could not resolve the hOn servers (DNS). Check your network and DNS. ({error_code})",
+      "tls_failure": "TLS/certificate error contacting hOn. Check the system date/time and network. ({error_code})",
+      "connection_refused": "Could not connect to the hOn servers (refused, reset or unreachable). Check your network and firewall. ({error_code})",
+      "rate_limited": "Too many requests to hOn. Wait a few minutes and try again. ({error_code})",
+      "server_error": "The hOn servers returned an error. Try again later. ({error_code})",
+      "loop_timeout": "hOn setup timed out. Check your internet connection and try again. ({error_code})",
+      "decode_error": "Unreadable response from the hOn servers. Try again later. ({error_code})"
+    },
+    "abort": {
+      "already_configured": "This hOn account is already configured.",
+      "reauth_successful": "Re-authentication was successful.",
+      "reauth_account_mismatch": "The new credentials must belong to the same hOn account.",
+      "reauth_entry_not_found": "The configuration entry no longer exists. Please add the integration again.",
+      "mfa_no_challenge": "The two-factor session expired. Please start again."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "data": {
+          "enable_debug": "Enable debug logging",
+          "enable_mqtt_debug": "Enable MQTT realtime debug",
+          "enable_experimental": "Enable experimental entities"
+        },
+        "data_description": {
+          "enable_debug": "Raise this integration's log level to DEBUG (sign in, device discovery, polling, commands). Turn off to return to Home Assistant's configured level. MQTT realtime noise stays suppressed unless its own toggle is on.",
+          "enable_mqtt_debug": "Make the MQTT realtime channel very verbose. Normally keep this off; it only covers this integration's MQTT logger, not the underlying AWS IoT libraries (use Home Assistant's logger config for those).",
+          "enable_experimental": "Add entities whose meaning is based on incomplete evidence: they may be wrong, may be renamed, and may disappear again. They stay unavailable for any reading that has not been confirmed. Changing this reloads the integration."
+        }
+      }
+    }
+  },
+  "services": {
+    "refresh": {
+      "name": "Refresh now",
+      "description": "Force an immediate cloud poll for all configured hOn accounts. The automation-callable equivalent of the per-device \"Refresh now\" button: it asks every loaded coordinator to fetch fresh data right away, instead of waiting for the next scheduled poll. Takes no options and applies to the whole integration."
+    },
+    "set_log_level": {
+      "name": "Set diagnostic log level",
+      "description": "Change the log level of the Haier hOn integration and the native hOn client loggers used to diagnose login, device discovery, reauth and polling. Use \"debug\" when devices do not appear, then return to \"warning\" to reduce noise. Does not enable MQTT realtime noise: for that use the dedicated set_mqtt_log_level service.",
+      "fields": {
+        "level": {
+          "name": "Level",
+          "description": "Diagnostic log level to apply."
+        }
+      }
+    },
+    "set_mqtt_log_level": {
+      "name": "Set MQTT log level",
+      "description": "Change the log level of the hOn MQTT realtime channel. By default the reconnect-attempt noise is silenced (warning). Set \"debug\" to diagnose realtime push problems, then \"warning\" to silence it again. Not persistent: it returns to silenced after a Home Assistant restart.",
+      "fields": {
+        "level": {
+          "name": "Level",
+          "description": "Log level to apply to the hOn MQTT realtime channel."
+        }
+      }
+    }
+  },
+  "device": {
+    "diagnostics": {
+      "name": "addhOn diagnostics"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "state": {
+        "name": "Status",
+        "state": {
+          "idle": "Idle",
+          "selection": "Selection",
+          "running": "Running",
+          "paused": "Paused",
+          "delayed_start": "Delayed start",
+          "delayed_start_running": "Delayed start (running)",
+          "error": "Error",
+          "finished": "Finished",
+          "test": "Test",
+          "stopped": "Stopped",
+          "keep_fresh": "Keep fresh"
+        }
+      },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
+      "total_washes": {
+        "name": "Total cycles"
+      },
+      "total_water": {
+        "name": "Total water used"
+      },
+      "total_energy": {
+        "name": "Total energy used"
+      },
+      "current_energy": {
+        "name": "Current energy use"
+      },
+      "current_water": {
+        "name": "Current water use"
+      },
+      "program_name": {
+        "name": "Program"
+      },
+      "program_phase": {
+        "name": "Phase",
+        "state": {
+          "ready": "Ready",
+          "washing": "Washing",
+          "phase_skip": "Phase skip",
+          "rinsing": "Rinsing",
+          "drying": "Drying",
+          "steam": "Steam",
+          "spinning": "Spinning",
+          "weighing": "Weighing",
+          "rotation_start": "Rotation start",
+          "refresh": "Refresh"
+        }
+      },
+      "errors": {
+        "name": "Errors"
+      },
+      "delay_time": {
+        "name": "Start delay"
+      },
+      "loading_percentage": {
+        "name": "Average load"
+      },
+      "dry_level": {
+        "name": "Dry level"
+      },
+      "temp_level": {
+        "name": "Temperature level"
+      },
+      "spin_speed": {
+        "name": "Spin speed"
+      },
+      "wash_temperature": {
+        "name": "Wash temperature"
+      },
+      "dirty_level": {
+        "name": "Soil level"
+      },
+      "stain_type": {
+        "name": "Stain type",
+        "state": {
+          "none": "None",
+          "wine": "Wine",
+          "grass": "Grass",
+          "soil": "Soil",
+          "blood": "Blood",
+          "milk": "Milk",
+          "cooking_oil": "Cooking oil",
+          "tea": "Tea",
+          "coffee": "Coffee",
+          "chocolate": "Chocolate",
+          "lip_gloss": "Lip gloss",
+          "curry": "Curry",
+          "milk_tea": "Milk tea",
+          "chili_oil": "Chili oil",
+          "blue_ink": "Blue ink",
+          "color_pencil": "Color pencil",
+          "shoe_cream": "Shoe cream",
+          "oil_pastel": "Oil pastel",
+          "blueberry": "Blueberry",
+          "sweat": "Sweat",
+          "egg": "Egg",
+          "ketchup": "Ketchup",
+          "baby_food": "Baby food",
+          "soy_sauce": "Soy sauce",
+          "bean_paste": "Bean paste",
+          "chili_sauce": "Chili sauce",
+          "fruit": "Fruit"
+        }
+      },
+      "temp_indoor": {
+        "name": "Indoor temperature"
+      },
+      "temp_outdoor": {
+        "name": "Outdoor temperature"
+      },
+      "humidity_indoor": {
+        "name": "Indoor humidity"
+      },
+      "compressor_freq": {
+        "name": "Compressor frequency"
+      },
+      "ac_total_energy": {
+        "name": "Air conditioner total energy"
+      },
+      "pm25": {
+        "name": "PM2.5"
+      },
+      "co2": {
+        "name": "CO2"
+      },
+      "ch2o": {
+        "name": "Formaldehyde"
+      },
+      "pm10": {
+        "name": "PM10"
+      },
+      "voc": {
+        "name": "VOC"
+      },
+      "co": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "water_hardness": {
+        "name": "Water hardness"
+      },
+      "current_wash_cycle": {
+        "name": "Current cycle"
+      },
+      "remaining_rinses": {
+        "name": "Remaining rinses"
+      },
+      "detergent_level": {
+        "name": "Detergent dose"
+      },
+      "detergent_weight": {
+        "name": "Detergent dispensed"
+      },
+      "softener_weight": {
+        "name": "Softener dispensed"
+      },
+      "estimated_weight": {
+        "name": "Estimated weight"
+      },
+      "mean_water_consumption": {
+        "name": "Mean water consumption"
+      },
+      "program_duration": {
+        "name": "Program duration"
+      },
+      "temp_zone1": {
+        "name": "Zone 1 temperature"
+      },
+      "temp_zone2": {
+        "name": "Zone 2 temperature"
+      },
+      "temp_zone3": {
+        "name": "Zone 3 temperature"
+      },
+      "temp_zone4": {
+        "name": "Zone 4 temperature"
+      },
+      "temp_zone5": {
+        "name": "Zone 5 temperature"
+      },
+      "temp_upper": {
+        "name": "Upper zone temperature"
+      },
+      "temp_lower": {
+        "name": "Lower zone temperature"
+      },
+      "temp_ambient": {
+        "name": "Ambient temperature"
+      },
+      "humidity_ambient": {
+        "name": "Ambient humidity"
+      },
+      "humidity_zone1": {
+        "name": "Zone 1 humidity"
+      },
+      "humidity_zone2": {
+        "name": "Zone 2 humidity"
+      },
+      "temp_cavity": {
+        "name": "Oven temperature"
+      },
+      "probe_temp_1": {
+        "name": "Probe 1 temperature"
+      },
+      "probe_temp_2": {
+        "name": "Probe 2 temperature"
+      },
+      "salt_level": {
+        "name": "Salt level",
+        "state": {
+          "ok": "OK",
+          "low": "Low",
+          "critical": "Critical",
+          "empty": "Empty"
+        }
+      },
+      "rinse_aid_level": {
+        "name": "Rinse aid level",
+        "state": {
+          "ok": "OK",
+          "low": "Low",
+          "critical": "Critical",
+          "empty": "Empty"
+        }
+      },
+      "fan_speed": {
+        "name": "Fan speed"
+      },
+      "current_power": {
+        "name": "Power"
+      },
+      "descaling_cycles": {
+        "name": "Cycles to descaling"
+      },
+      "lifetime_cycles": {
+        "name": "Total cycles"
+      },
+      "water_temp": {
+        "name": "Water temperature"
+      },
+      "temp_inlet": {
+        "name": "Inlet temperature"
+      },
+      "temp_outlet": {
+        "name": "Outlet temperature"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "water_volume": {
+        "name": "Available water"
+      },
+      "heating_remaining": {
+        "name": "Time to target"
+      },
+      "battery": {
+        "name": "Battery"
+      },
+      "power_mode": {
+        "name": "Suction power",
+        "state": {
+          "auto": "Auto",
+          "turbo": "Turbo",
+          "quiet": "Quiet"
+        }
+      },
+      "last_work_area": {
+        "name": "Last cleaned area"
+      },
+      "total_work_area": {
+        "name": "Total cleaned area"
+      },
+      "machine_mode": {
+        "name": "Status",
+        "state": {
+          "idle": "Idle",
+          "selection": "Selection",
+          "running": "Running",
+          "paused": "Paused",
+          "delayed_start": "Delayed start",
+          "delayed_start_running": "Delayed start (running)",
+          "error": "Error",
+          "finished": "Finished",
+          "test": "Test",
+          "stopped": "Stopped",
+          "keep_fresh": "Keep fresh"
+        }
+      },
+      "vacuum_state": {
+        "name": "Status",
+        "state": {
+          "waiting": "Waiting",
+          "auto_cleaning": "Auto cleaning",
+          "spot_cleaning": "Spot cleaning",
+          "paused": "Paused",
+          "full_and_go": "Full & Go",
+          "cleaning_completed": "Cleaning completed",
+          "charging": "Charging"
+        }
+      },
+      "dryer_phase": {
+        "name": "Phase",
+        "state": {
+          "ready": "Ready",
+          "heating": "Heating",
+          "drying": "Drying",
+          "cooling": "Cooling",
+          "rotation": "Rotation"
+        }
+      },
+      "heater_phase": {
+        "name": "Phase",
+        "state": {
+          "ready": "Ready",
+          "heating": "Heating",
+          "holding": "Holding"
+        }
+      },
+      "filter_life": {
+        "name": "Filter life"
+      },
+      "filter_cleaning": {
+        "name": "Pre-filter life"
+      },
+      "total_work_time": {
+        "name": "Total work time"
+      },
+      "pollen_level": {
+        "name": "Pollen level"
+      },
+      "air_quality_label": {
+        "name": "Air quality rating (experimental)",
+        "state": {
+          "good": "Good"
+        }
+      },
+      "debug_status": {
+        "name": "Debug status",
+        "state": {
+          "off": "Off",
+          "integration": "Integration",
+          "mqtt": "MQTT realtime",
+          "full": "Integration + MQTT"
+        }
+      },
+      "integration_log_level": {
+        "name": "Integration log level"
+      },
+      "mqtt_log_level": {
+        "name": "MQTT log level"
+      },
+      "appliances_discovered": {
+        "name": "Appliances discovered"
+      },
+      "last_refresh": {
+        "name": "Last refresh"
+      }
+    },
+    "binary_sensor": {
+      "door_open": {
+        "name": "Door"
+      },
+      "door_lock": {
+        "name": "Door locked"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "drum_clean_needed": {
+        "name": "Drum clean needed"
+      },
+      "filter_clean_needed": {
+        "name": "Filter clean needed"
+      },
+      "dry_clean_needed": {
+        "name": "Condenser clean needed"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "remote_control": {
+        "name": "Remote control"
+      },
+      "preheat": {
+        "name": "Preheating"
+      },
+      "extra_dry": {
+        "name": "Extra dry"
+      },
+      "half_load": {
+        "name": "Half load"
+      },
+      "auto_open_door": {
+        "name": "Auto door open"
+      },
+      "eco_express": {
+        "name": "Eco express"
+      },
+      "night_wash": {
+        "name": "Night wash"
+      },
+      "steam": {
+        "name": "Steam"
+      },
+      "door_zone1": {
+        "name": "Zone 1 door"
+      },
+      "door2_zone1": {
+        "name": "Zone 1 door 2"
+      },
+      "door_zone2": {
+        "name": "Zone 2 door"
+      },
+      "door_zone3": {
+        "name": "Zone 3 door"
+      },
+      "door_cavity1": {
+        "name": "Cavity 1 door"
+      },
+      "door_cavity2": {
+        "name": "Cavity 2 door"
+      },
+      "ice_maker": {
+        "name": "Ice maker"
+      },
+      "ice_box_full": {
+        "name": "Ice box full"
+      },
+      "energy_saving": {
+        "name": "Energy saving"
+      },
+      "quick_cool": {
+        "name": "Super cool"
+      },
+      "quick_freeze": {
+        "name": "Super freeze"
+      },
+      "auto_set": {
+        "name": "Auto-set"
+      },
+      "holiday_mode": {
+        "name": "Holiday mode"
+      },
+      "filter_change": {
+        "name": "Filter change"
+      },
+      "ch2o_cleaning": {
+        "name": "Formaldehyde cleaning"
+      },
+      "light": {
+        "name": "Light"
+      },
+      "presence": {
+        "name": "Presence"
+      },
+      "pan_zone1": {
+        "name": "Zone 1 pan"
+      },
+      "pan_zone2": {
+        "name": "Zone 2 pan"
+      },
+      "pan_zone3": {
+        "name": "Zone 3 pan"
+      },
+      "pan_zone4": {
+        "name": "Zone 4 pan"
+      },
+      "pan_zone5": {
+        "name": "Zone 5 pan"
+      },
+      "pan_zone6": {
+        "name": "Zone 6 pan"
+      },
+      "indicator_light": {
+        "name": "Indicator light"
+      },
+      "eco_active": {
+        "name": "Eco active"
+      },
+      "problem": {
+        "name": "Problem"
+      },
+      "co_alarm": {
+        "name": "Carbon monoxide indication (experimental, not a certified detector)"
+      },
+      "update_ok": {
+        "name": "Update OK"
+      }
+    },
+    "switch": {
+      "sleep": {
+        "name": "Sleep mode"
+      },
+      "mute": {
+        "name": "Mute"
+      },
+      "eco": {
+        "name": "Eco"
+      },
+      "rapid": {
+        "name": "Rapid"
+      },
+      "health": {
+        "name": "Health"
+      },
+      "self_clean": {
+        "name": "Self-clean"
+      },
+      "self_clean_56": {
+        "name": "Self-clean 56°C"
+      },
+      "display": {
+        "name": "Display"
+      },
+      "light": {
+        "name": "Light"
+      },
+      "ten_degree_heating": {
+        "name": "10°C heating"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "touch_tone": {
+        "name": "Touch tone"
+      },
+      "human_sensing": {
+        "name": "Presence sensor"
+      },
+      "electric_heating": {
+        "name": "Electric heating"
+      },
+      "fresh_air": {
+        "name": "Fresh air"
+      },
+      "half_degree": {
+        "name": "Half degree"
+      },
+      "energy_saving": {
+        "name": "Energy saving"
+      },
+      "extra_rinse_1": {
+        "name": "Extra rinse 1"
+      },
+      "extra_rinse_2": {
+        "name": "Extra rinse 2"
+      },
+      "extra_rinse_3": {
+        "name": "Extra rinse 3"
+      },
+      "acquaplus": {
+        "name": "Acqua Plus"
+      },
+      "prewash": {
+        "name": "Prewash"
+      },
+      "hygiene": {
+        "name": "Extra hygiene"
+      },
+      "anticrease": {
+        "name": "Anti-crease"
+      },
+      "good_night": {
+        "name": "Good night"
+      },
+      "sterilization": {
+        "name": "Sterilization"
+      },
+      "tumbling": {
+        "name": "Tumbling"
+      },
+      "permanent_press": {
+        "name": "Keep fresh"
+      },
+      "anti_crease_time": {
+        "name": "Anti-crease time"
+      },
+      "pause": {
+        "name": "Pause"
+      },
+      "debug_logging": {
+        "name": "Debug logging"
+      },
+      "mqtt_realtime_debug": {
+        "name": "MQTT realtime debug"
+      }
+    },
+    "number": {
+      "target_temp_zone1": {
+        "name": "Zone 1 temperature"
+      },
+      "target_temp_zone2": {
+        "name": "Zone 2 temperature"
+      },
+      "target_temp_zone3": {
+        "name": "Zone 3 temperature"
+      },
+      "target_temp_zone4": {
+        "name": "Zone 4 temperature"
+      },
+      "target_temp_upper": {
+        "name": "Upper zone temperature"
+      },
+      "target_temp_lower": {
+        "name": "Lower zone temperature"
+      },
+      "target_temp": {
+        "name": "Temperature"
+      },
+      "target_temp_oven": {
+        "name": "Oven temperature"
+      },
+      "delay_time": {
+        "name": "Delayed start"
+      },
+      "aroma_time_on": {
+        "name": "Aroma on time (experimental)"
+      },
+      "aroma_time_off": {
+        "name": "Aroma off time (experimental)"
+      }
+    },
+    "select": {
+      "program": {
+        "name": "Program"
+      },
+      "aroma": {
+        "name": "Aroma",
+        "state": {
+          "off": "Off",
+          "soft": "Soft",
+          "mid": "Medium",
+          "h_biotics": "H-Biotics",
+          "custom": "Custom"
+        }
+      },
+      "panel_light": {
+        "name": "Panel light",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "high": "High"
+        }
+      },
+      "ref_program": {
+        "name": "Program",
+        "state": {
+          "off": "Off",
+          "holiday": "Holiday",
+          "super_cool": "Super cool",
+          "super_freeze": "Super freeze",
+          "auto_set": "Auto set",
+          "quick_cool": "Quick cool",
+          "zero_fresh": "Zero degrees",
+          "fruit_and_veg": "Fruit and veg",
+          "soft_freeze": "Soft freeze",
+          "iot_daily_use": "Daily use",
+          "iot_extra_cold": "Extra cold",
+          "iot_extra_cold_water": "Extra cold (water)",
+          "iot_extra_ice": "Extra ice",
+          "iot_high_efficiency": "High efficiency",
+          "iot_special_food_core": "Special food"
+        }
+      },
+      "spin_speed": {
+        "name": "Spin speed"
+      },
+      "wash_temp": {
+        "name": "Temperature"
+      },
+      "dry_level": {
+        "name": "Dry level",
+        "state": {
+          "extra_dry": "Extra dry",
+          "cupboard": "Cupboard dry",
+          "iron_dry": "Iron dry",
+          "hang_dry": "Hang dry",
+          "smart_dry": "Smart dry",
+          "wool_dry": "Wool dry",
+          "ready_to_wear": "Ready to wear"
+        }
+      },
+      "temp_level": {
+        "name": "Temperature level",
+        "state": {
+          "minimum": "Minimum",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High"
+        }
+      },
+      "dirty_level": {
+        "name": "Soil level",
+        "state": {
+          "little": "Light",
+          "normal": "Normal",
+          "very": "Heavy"
+        }
+      },
+      "steam_level": {
+        "name": "Steam level",
+        "state": {
+          "no_steam": "No steam",
+          "cotton": "Cotton",
+          "delicate": "Delicate",
+          "synthetic": "Synthetic"
+        }
+      },
+      "fan_direction_vertical": {
+        "name": "Vertical fan direction",
+        "state": {
+          "position_2": "Position 2",
+          "position_4": "Position 4",
+          "position_5": "Position 5",
+          "position_6": "Position 6",
+          "position_7": "Position 7",
+          "swing": "Swing"
+        }
+      },
+      "fan_direction_horizontal": {
+        "name": "Horizontal fan direction",
+        "state": {
+          "position_0": "Position 0",
+          "position_3": "Position 3",
+          "position_4": "Position 4",
+          "position_5": "Position 5",
+          "position_6": "Position 6",
+          "swing": "Swing"
+        }
+      }
+    },
+    "button": {
+      "start_program": {
+        "name": "Start program"
+      },
+      "stop_program": {
+        "name": "Stop program"
+      },
+      "force_refresh": {
+        "name": "Refresh now"
+      },
+      "reset_debug": {
+        "name": "Reset debug"
+      }
+    },
+    "fan": {
+      "purifier": {
+        "name": "Purifier"
+      }
+    }
+  },
+  "exceptions": {
+    "appliance_or_client_unavailable": {
+      "message": "The appliance or client is not available."
+    },
+    "aroma_custom_not_active": {
+      "message": "The aroma timings can only be changed while the custom aroma mode is running."
+    },
+    "command_error": {
+      "message": "Command failed: {error}"
+    },
+    "command_rejected": {
+      "message": "The hOn service did not accept the command."
+    },
+    "invalid_setpoint": {
+      "message": "Value {value} is not allowed (allowed: {allowed})."
+    },
+    "program_not_found": {
+      "message": "Program \"{program}\" was not found."
+    },
+    "program_not_supported": {
+      "message": "Program \"{program}\" is not supported by this device."
+    },
+    "purifier_not_running": {
+      "message": "The purifier must be confirmed running to change this."
+    },
+    "refresh_after_command_failed": {
+      "message": "Refresh after the command failed."
+    },
+    "refresh_after_command_failed_error": {
+      "message": "Refresh after the command failed: {error}"
+    },
+    "swing_not_supported": {
+      "message": "This device does not support vertical swing."
+    },
+    "swing_position_not_allowed": {
+      "message": "Swing position {position} is not allowed (allowed: {allowed})."
+    },
+    "speed_not_supported": {
+      "message": "This purifier runs in discrete modes and has no fan speed. Set a preset mode instead of a percentage."
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,7 +461,10 @@ def _install_selector_stubs() -> None:
         type(
             "TextSelectorConfig",
             (),
-            {"__init__": lambda self, type=None, **kwargs: setattr(self, "type", type)},
+            # Keyword-only, like the real TypedDict: config_flow builds it as
+            # TextSelectorConfig(type=...). A positional `type` parameter would
+            # shadow the builtin for no gain.
+            {"__init__": lambda self, **kwargs: setattr(self, "type", kwargs.get("type"))},
         ),
     )
     selector.TextSelector = getattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,7 +439,86 @@ def _ensure_yarl() -> None:
         sys.modules["yarl"] = yarl_stub
 
 
+def _install_selector_stubs() -> None:
+    """config_flow declares the password with a TextSelector in PASSWORD mode (a
+    bare `str` would render it as a plain text field, visible while typed). The CI
+    stub harness does not ship homeassistant.helpers.selector, so importing
+    config_flow -- and thus every config-flow test -- needs a minimal one. Real HA
+    symbols win when present, like the other stub installers here. The selector is
+    made callable because voluptuous invokes schema values as validators: a
+    non-callable would be compared for equality instead."""
+    helpers = _ensure_module("homeassistant.helpers")
+    selector = _ensure_module("homeassistant.helpers.selector")
+    helpers.selector = selector
+    selector.TextSelectorType = getattr(
+        selector,
+        "TextSelectorType",
+        type("TextSelectorType", (), {"PASSWORD": "password"}),
+    )
+    selector.TextSelectorConfig = getattr(
+        selector,
+        "TextSelectorConfig",
+        type(
+            "TextSelectorConfig",
+            (),
+            {"__init__": lambda self, type=None, **kwargs: setattr(self, "type", type)},
+        ),
+    )
+    selector.TextSelector = getattr(
+        selector,
+        "TextSelector",
+        type(
+            "TextSelector",
+            (),
+            {
+                "__init__": lambda self, config=None: setattr(self, "config", config),
+                "__call__": lambda self, value: value,
+            },
+        ),
+    )
+
+
+def _install_service_helper_stubs() -> None:
+    """_async_register_services registers the two log-level services through
+    homeassistant.helpers.service.async_register_admin_service (they flip
+    process-global logger levels, so they must be admin-only). The stub harness
+    does not ship that module, and `homeassistant.helpers` here is a plain
+    ModuleType rather than a package, so the `from ... import` only resolves if the
+    submodule is present in sys.modules. Mirrors the real helper: wrap the handler
+    in an admin check, then delegate to hass.services.async_register, which is what
+    the registration tests observe."""
+    exc = _ensure_module("homeassistant.exceptions")
+    exc.Unauthorized = getattr(
+        exc, "Unauthorized", type("Unauthorized", (Exception,), {})
+    )
+    helpers = _ensure_module("homeassistant.helpers")
+    service = _ensure_module("homeassistant.helpers.service")
+    helpers.service = service
+
+    if hasattr(service, "async_register_admin_service"):
+        return
+
+    def async_register_admin_service(
+        hass, domain, service_name, service_func, schema=None
+    ):
+        async def admin_handler(call):
+            # A call with no user attached (automation, internal) is trusted, same
+            # as in Home Assistant core.
+            user_id = getattr(getattr(call, "context", None), "user_id", None)
+            if user_id:
+                user = await hass.auth.async_get_user(user_id)
+                if user is None or not user.is_admin:
+                    raise exc.Unauthorized()
+            return await service_func(call)
+
+        hass.services.async_register(domain, service_name, admin_handler, schema=schema)
+
+    service.async_register_admin_service = async_register_admin_service
+
+
 _install_homeassistant_error()
 _install_shared_entity_stubs()
 _install_entity_platform_stubs()
+_install_selector_stubs()
+_install_service_helper_stubs()
 _ensure_yarl()

--- a/tests/test_config_flow_password_selector.py
+++ b/tests/test_config_flow_password_selector.py
@@ -28,19 +28,31 @@ class PasswordSelectorTest(unittest.TestCase):
     def setUp(self) -> None:
         self.tree = ast.parse(CONFIG_FLOW.read_text(encoding="utf-8"))
 
+    @staticmethod
+    def _is_required_password_key(key: ast.expr | None) -> bool:
+        """True for a ``vol.Required("password")`` schema key, and only that.
+
+        The marker call is matched too, not just its argument: accepting any call
+        with "password" as first argument would also accept a vol.Optional, or an
+        unrelated helper, and quietly weaken the guard.
+        """
+        return (
+            isinstance(key, ast.Call)
+            and isinstance(key.func, ast.Attribute)
+            and key.func.attr == "Required"
+            and bool(key.args)
+            and isinstance(key.args[0], ast.Constant)
+            and key.args[0].value == "password"
+        )
+
     def _password_schema_values(self) -> list[ast.expr]:
         """Every value bound to a ``vol.Required("password")`` schema key."""
         values: list[ast.expr] = []
         for node in ast.walk(self.tree):
             if not isinstance(node, ast.Dict):
                 continue
-            for key, value in zip(node.keys, node.values):
-                if (
-                    isinstance(key, ast.Call)
-                    and key.args
-                    and isinstance(key.args[0], ast.Constant)
-                    and key.args[0].value == "password"
-                ):
+            for key, value in zip(node.keys, node.values, strict=True):
+                if self._is_required_password_key(key):
                     values.append(value)
         return values
 
@@ -75,12 +87,35 @@ class PasswordSelectorTest(unittest.TestCase):
         ]
         self.assertEqual(len(assigned), 1, f"{SELECTOR_NAME} must be defined once")
 
-        attributes = {
-            f"{node.value.id}.{node.attr}"
-            for node in ast.walk(assigned[0])
-            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
-        }
-        self.assertIn("TextSelectorType.PASSWORD", attributes)
+        # Structure, not presence: TextSelectorType.PASSWORD appearing anywhere in
+        # the assignment would also be satisfied by a selector built the wrong way
+        # round, which is exactly the regression this guard exists to catch.
+        outer = assigned[0].value
+        self.assertTrue(
+            isinstance(outer, ast.Call)
+            and isinstance(outer.func, ast.Name)
+            and outer.func.id == "TextSelector",
+            f"{SELECTOR_NAME} must be a TextSelector(...) call",
+        )
+
+        self.assertTrue(outer.args, "TextSelector must be given a config")
+        config = outer.args[0]
+        self.assertTrue(
+            isinstance(config, ast.Call)
+            and isinstance(config.func, ast.Name)
+            and config.func.id == "TextSelectorConfig",
+            "TextSelector must wrap a TextSelectorConfig(...) call",
+        )
+
+        modes = [kw.value for kw in config.keywords if kw.arg == "type"]
+        self.assertEqual(len(modes), 1, "TextSelectorConfig needs one type= keyword")
+        self.assertTrue(
+            isinstance(modes[0], ast.Attribute)
+            and modes[0].attr == "PASSWORD"
+            and isinstance(modes[0].value, ast.Name)
+            and modes[0].value.id == "TextSelectorType",
+            "the config must ask for TextSelectorType.PASSWORD",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_config_flow_password_selector.py
+++ b/tests/test_config_flow_password_selector.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The Haier account password must never render as a plain text field.
+
+A bare ``vol.Required("password"): str`` renders as a normal text input, so the
+password stays visible on screen while it is typed. Both the user step and the
+reauth step must declare it through a ``TextSelector`` in ``PASSWORD`` mode.
+
+Checked at source level (AST), like the wiring guards in test_mqtt_log_level:
+that keeps the guard independent of whether the harness can build a real
+Home Assistant selector, and a plain substring match would still pass if the
+declaration drifted into an unrelated schema.
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_FLOW = ROOT / "custom_components" / "addhon" / "config_flow.py"
+
+SELECTOR_NAME = "_PASSWORD_SELECTOR"
+
+
+class PasswordSelectorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tree = ast.parse(CONFIG_FLOW.read_text(encoding="utf-8"))
+
+    def _password_schema_values(self) -> list[ast.expr]:
+        """Every value bound to a ``vol.Required("password")`` schema key."""
+        values: list[ast.expr] = []
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Call)
+                    and key.args
+                    and isinstance(key.args[0], ast.Constant)
+                    and key.args[0].value == "password"
+                ):
+                    values.append(value)
+        return values
+
+    def test_both_steps_declare_a_password_field(self) -> None:
+        # The user step and the reauth step: losing one would silently drop the
+        # guard for that flow.
+        self.assertEqual(len(self._password_schema_values()), 2)
+
+    def test_password_never_declared_as_bare_str(self) -> None:
+        for value in self._password_schema_values():
+            self.assertFalse(
+                isinstance(value, ast.Name) and value.id == "str",
+                "password declared as a bare str: it would render in clear",
+            )
+
+    def test_password_uses_the_shared_selector(self) -> None:
+        for value in self._password_schema_values():
+            self.assertTrue(
+                isinstance(value, ast.Name) and value.id == SELECTOR_NAME,
+                f"password must be declared with {SELECTOR_NAME}",
+            )
+
+    def test_selector_is_built_in_password_mode(self) -> None:
+        assigned = [
+            node
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == SELECTOR_NAME
+                for target in node.targets
+            )
+        ]
+        self.assertEqual(len(assigned), 1, f"{SELECTOR_NAME} must be defined once")
+
+        attributes = {
+            f"{node.value.id}.{node.attr}"
+            for node in ast.walk(assigned[0])
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+        }
+        self.assertIn("TextSelectorType.PASSWORD", attributes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mqtt_log_level.py
+++ b/tests/test_mqtt_log_level.py
@@ -17,6 +17,7 @@ async_setup_entry), matching test_coordinator_config_entry.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import logging
 import unittest
@@ -139,6 +140,60 @@ class WiringTest(unittest.TestCase):
         self.assertIn("SERVICE_SET_MQTT_LOG_LEVEL", src)
         self.assertIn("SERVICE_SET_LOG_LEVEL", src)
         self.assertIn("async_register", src)
+
+
+class AdminOnlyLogServicesTest(unittest.TestCase):
+    """Both log-level services end in logging.getLogger().setLevel(), which is
+    global to the Python process: not scoped to a config entry, not scoped to a
+    user. Registered with a plain hass.services.async_register they would be
+    callable by any authenticated non-admin through the REST/WebSocket API, so the
+    registration must keep going through async_register_admin_service.
+
+    Checked on the AST rather than on raw text: a substring match would still pass
+    if the constant drifted into a different call.
+    """
+
+    ADMIN_ONLY = {"SERVICE_SET_LOG_LEVEL", "SERVICE_SET_MQTT_LOG_LEVEL"}
+
+    def setUp(self) -> None:
+        self.tree = ast.parse(INIT.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _calls(tree: ast.AST, *, name: str = "", attr: str = "") -> list[ast.Call]:
+        found = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if name and isinstance(func, ast.Name) and func.id == name:
+                found.append(node)
+            elif attr and isinstance(func, ast.Attribute) and func.attr == attr:
+                found.append(node)
+        return found
+
+    def _service_names(self, call: ast.Call) -> set[str]:
+        names = {n.id for n in ast.walk(call) if isinstance(n, ast.Name)}
+        return names & self.ADMIN_ONLY
+
+    def test_log_services_are_registered_admin_only(self) -> None:
+        registered: set[str] = set()
+        for call in self._calls(self.tree, name="async_register_admin_service"):
+            registered |= self._service_names(call)
+        self.assertEqual(
+            registered,
+            self.ADMIN_ONLY,
+            "both log-level services must be registered via "
+            "async_register_admin_service",
+        )
+
+    def test_log_services_are_not_registered_plainly(self) -> None:
+        for call in self._calls(self.tree, attr="async_register"):
+            leaked = self._service_names(call)
+            self.assertFalse(
+                leaked,
+                f"{sorted(leaked)} registered without the admin gate: any "
+                "authenticated user could flip process-global log levels",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.16.0`.

<!-- release-tag: v5.16.0 -->

## Summary by Sourcery

Release version 5.16.0 with safer authentication fields, administrator-only logging controls, updated localization, and streamlined dependencies.

Bug Fixes:
- Protect configuration-flow passwords by rendering authentication and reauthentication fields as masked password inputs.
- Restrict process-wide log-level services to administrators.

Enhancements:
- Remove redundant runtime dependencies supplied by Home Assistant.
- Add the authoritative English localization catalog for configuration flows, services, entities, and exceptions.

Tests:
- Add regression coverage for password masking and administrator-only log-level service registration.

Chores:
- Bump the integration version to 5.16.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT and integration logging controls now require administrator access.
  * Password fields in setup and reauthentication flows are displayed as masked inputs.
  * Added complete English translations across configuration, authentication, options, services, diagnostics, entities, and error messages.
* **Bug Fixes**
  * Improved protection for logging controls against unauthorized access.
* **Improvements**
  * Updated the integration to version 5.16.0 and streamlined its runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release adds localized Home Assistant UI content, masks credentials during setup and reauthentication, restricts global logging controls to administrators, removes redundant dependency declarations, and updates the integration to version 5.16.0.
- Registers integration and MQTT log-level services through Home Assistant's administrator-only service helper while preserving internal and automation calls.
- Uses a password-mode text selector for setup and reauthentication credentials.
- Adds comprehensive English strings and regression coverage for the access-control and password-rendering changes.
- Removes redundant `yarl` and `typing-extensions` requirements.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/__init__.py | Routes both process-wide logging services through Home Assistant's administrator authorization helper while leaving refresh behavior unchanged. |
| custom_components/addhon/config_flow.py | Replaces plain password validators with a reusable password-mode selector in setup and reauthentication forms. |
| custom_components/addhon/manifest.json | Bumps the release version and removes dependencies already supplied by the Home Assistant runtime. |
| custom_components/addhon/strings.json | Adds English UI text for configuration, options, services, diagnostics, entities, states, and exceptions. |
| tests/test_config_flow_password_selector.py | Adds structural regression checks ensuring both credential forms use the password selector. |
| tests/test_mqtt_log_level.py | Adds coverage that both global log-level services use administrator-only registration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: tighten the password guard and dro..."](https://github.com/tis24dev/addhon/commit/ebccd74d69bca8c12d02e0762b35588f290ad13e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55524765)</sub>

<!-- /greptile_comment -->