### PR TITLE
Release v5.17.0

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -3,7 +3,8 @@
 
 import asyncio
 import logging
-from datetime import timedelta
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from typing import NoReturn
 
 from homeassistant.config_entries import ConfigEntry
@@ -293,6 +294,72 @@ async def _async_close_client(client) -> None:
         await client.async_close()
     except Exception as err:
         _LOGGER.warning("Error closing HonClient: %s", err)
+
+
+def _store_setup_failure(hass: HomeAssistant, entry: ConfigEntry, client) -> None:
+    """Leave behind WHY this setup failed, in place of the bucket it never filled.
+
+    Until this existed the two failure branches of async_setup_entry popped the entry
+    bucket whole, so a diagnostics download taken after a failed setup found no client
+    to ask and reported `{"status": "client_absent"}` -- true, and useless: it is the
+    same answer a dump gives while Home Assistant is still retrying, and it says
+    nothing about the classified code, the phase that burned the time, or the
+    appliance-list call. That is the state a reporter downloads a dump in most often,
+    and the artefacts built to explain it (the per-phase ledger of #76, the fetch
+    census) were unreachable in exactly that dump.
+
+    The bucket is REPLACED, never merged: whatever platforms and the coordinator were
+    handed must not survive a failed setup, and the record is the only key left. It is
+    overwritten by the next attempt (async_setup_entry stores the live bucket as one
+    literal) and removed by async_unload_entry / async_remove_entry, so the record
+    describes the LAST attempt and only while the entry has no working session.
+
+    Called BEFORE _async_close_client on both branches, because closing the client
+    nulls the session `last_appliance_fetch` reads through -- the census would be gone
+    by the time this ran after it. `last_setup_fetch` covers the other half: a failure
+    raised INSIDE setup_sync has already closed the session there, and that path
+    snapshots the census before it does (hon_client.py, the except of setup_sync).
+
+    Every value stored here is one this integration already emits in the dump through
+    `_last_error`: an ADDHON label, a phase token, the phase ledger, the census
+    primitives. No new class of value reaches hass.data, and diagnostics still
+    validates each one on the way out rather than trusting this record.
+    """
+    code = getattr(client, "last_error_code", None)
+    census = getattr(client, "last_appliance_fetch", None) or getattr(
+        client, "last_setup_fetch", None
+    )
+    fetch: dict | None = None
+    if isinstance(census, Mapping):
+        # The four counters live on the client, not in the census: they are what SETUP
+        # made of the list, while the census is what the CALL returned. Flattened into
+        # one mapping here so the reader in diagnostics has a single source for the
+        # block whether it is reading a live client or this record.
+        fetch = {
+            **dict(census),
+            "expanded": getattr(client, "setup_expanded", None),
+            "built": getattr(client, "appliance_count", None),
+            "skipped": getattr(client, "setup_drops", None),
+            "degraded": getattr(client, "degraded_census", None),
+        }
+    record = {
+        # The LABEL only, never the code object: diagnostics resolves the reason from
+        # the catalog at read time, so the text in the dump comes from error_codes.py
+        # in the running version and cannot be a string that rode in here.
+        "code": getattr(code, "label", None),
+        "phase": getattr(client, "last_error_phase", None),
+        "phase_ledger": getattr(client, "last_phase_ledger", None) or None,
+        "fetch": fetch,
+        "at": datetime.now(timezone.utc),
+    }
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"setup_failure": record}
+    _LOGGER.debug(
+        "Setup debug: recorded setup failure for entry=%s code=%s phase=%s fetch=%s",
+        entry.entry_id,
+        record["code"],
+        record["phase"],
+        (fetch or {}).get("outcome"),
+    )
 
 
 @callback
@@ -659,7 +726,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     await unload_platforms(entry, PLATFORMS)
                 except Exception as err:
                     _LOGGER.warning("Error unloading platforms after cancelled setup: %s", err)
-            hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        _store_setup_failure(hass, entry, hon_client)
         await _async_close_client(hon_client)
         raise
     except Exception:
@@ -670,7 +737,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     await unload_platforms(entry, PLATFORMS)
                 except Exception as err:
                     _LOGGER.warning("Error unloading platforms after failed setup: %s", err)
-            hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        _store_setup_failure(hass, entry, hon_client)
         await _async_close_client(hon_client)
         raise
 
@@ -702,3 +769,24 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     hass.services.async_remove(DOMAIN, service)
                     _LOGGER.debug("Unload debug: removed service %s", service)
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Drop the setup-failure record when the entry itself is deleted.
+
+    The only hook that can. An entry whose setup never succeeded is never unloaded --
+    Home Assistant calls async_unload_entry for LOADED entries -- so without this the
+    record written by _store_setup_failure would outlive the entry it describes for the
+    rest of the process, and `hass.data[DOMAIN]` would stay non-empty, which is what
+    async_unload_entry reads to decide whether the last entry just went away and the
+    global debug services can go with it.
+
+    No client to close here: a failed setup left none, and a loaded entry has already
+    been through async_unload_entry by the time Home Assistant removes it.
+    """
+    removed = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    _LOGGER.debug(
+        "Remove debug: entry=%s dropped_record=%s",
+        entry.entry_id,
+        removed is not None,
+    )

--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -324,7 +324,49 @@ def _store_setup_failure(hass: HomeAssistant, entry: ConfigEntry, client) -> Non
     `_last_error`: an ADDHON label, a phase token, the phase ledger, the census
     primitives. No new class of value reaches hass.data, and diagnostics still
     validates each one on the way out rather than trusting this record.
+
+    The reads are GUARDED, and the guard is not symmetry with `diagnostics._last_fetch`
+    -- it costs more here. `getattr(x, name, default)` swallows a MISSING attribute, not
+    an exception raised inside a property body, and `_setup_failure_record` reads four
+    HonClient properties that delegate to `_hon_instance` (`setup_drops` ends in
+    `dict(self._setup_drops)` on a session that setup may still be appending to from the
+    hOn loop thread -- `client/session.py:625-632`, and `_RaisingFetchClient` in the
+    diagnostics tests exists for exactly that). Unguarded, one such raise leaves this
+    helper propagating out of the `except` handler that called it, so
+    `_async_close_client` never runs and the dedicated loop thread and the owned
+    aiohttp session leak -- and in the CancelledError branch it would replace a
+    cancellation with an unrelated error. A dump that cannot say why setup failed is a
+    worse dump; a client nobody closed is a worse process.
+
+    On that path the bucket is still cleared and left EMPTY rather than filled with a
+    half-read record: `_last_error` then answers `client_absent`, which is exactly true
+    (there is no client, and nothing could be read about why).
     """
+    record: dict | None = None
+    try:
+        record = _setup_failure_record(client)
+    except Exception:  # noqa: BLE001 - a diagnostics record must never block teardown
+        _LOGGER.debug(
+            "Setup debug: could not record the setup failure for entry=%s",
+            entry.entry_id,
+            exc_info=True,
+        )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (
+        {"setup_failure": record} if record is not None else {}
+    )
+    _LOGGER.debug(
+        "Setup debug: recorded setup failure for entry=%s code=%s phase=%s fetch=%s",
+        entry.entry_id,
+        (record or {}).get("code"),
+        (record or {}).get("phase"),
+        ((record or {}).get("fetch") or {}).get("outcome"),
+    )
+
+
+def _setup_failure_record(client) -> dict:
+    """The record itself. Split from the guard above so that guard is the whole
+    degradation story: four property reads that may raise, none of them allowed to
+    keep a failed setup from closing its client."""
     code = getattr(client, "last_error_code", None)
     census = getattr(client, "last_appliance_fetch", None) or getattr(
         client, "last_setup_fetch", None
@@ -342,7 +384,7 @@ def _store_setup_failure(hass: HomeAssistant, entry: ConfigEntry, client) -> Non
             "skipped": getattr(client, "setup_drops", None),
             "degraded": getattr(client, "degraded_census", None),
         }
-    record = {
+    return {
         # The LABEL only, never the code object: diagnostics resolves the reason from
         # the catalog at read time, so the text in the dump comes from error_codes.py
         # in the running version and cannot be a string that rode in here.
@@ -352,14 +394,6 @@ def _store_setup_failure(hass: HomeAssistant, entry: ConfigEntry, client) -> Non
         "fetch": fetch,
         "at": datetime.now(timezone.utc),
     }
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"setup_failure": record}
-    _LOGGER.debug(
-        "Setup debug: recorded setup failure for entry=%s code=%s phase=%s fetch=%s",
-        entry.entry_id,
-        record["code"],
-        record["phase"],
-        (fetch or {}).get("outcome"),
-    )
 
 
 @callback

--- a/custom_components/addhon/client/session.py
+++ b/custom_components/addhon/client/session.py
@@ -43,6 +43,23 @@ from ..error_codes import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Reason -> token for an appliance the CLOUD returned and this setup never
+# appended. `construction_error` is deliberately NOT "build_error": there are TWO
+# `except self._APPLIANCE_BUILD_ERRORS` branches over the same tuple and only the
+# first one DROPS the appliance (:300, construction). The second (:333, load)
+# KEEPS it and falls through to the append at :377, so counting that branch here
+# would put the same appliance in both `built` and `skipped` and break the
+# reconciliation `setup_expanded` exists to give the reader.
+#
+# The ORDER is part of the contract, not cosmetic: tests/test_diagnostics.py reads
+# this tuple out of this file with `ast` (session.py imports aiohttp, which that
+# suite does not stub) and compares it element by element against
+# `diagnostics._FETCH_SKIP_REASONS` -- the allowlist the dump iterates INSTEAD of
+# the mapping it receives, so that no key chosen outside this module can reach a
+# public issue. A reason added here without its twin there is a reason the dump
+# silently refuses to print.
+SETUP_DROP_REASONS = ("not_a_dict", "bad_zone", "construction_error", "mac_empty")
+
 
 class NativeHon:
     """Native hOn session: OUR auth, transport and parser engine.
@@ -106,6 +123,37 @@ class NativeHon:
         # `needs_rehydration`, which makes the first coordinator refresh re-run
         # load_commands before any entity is created.
         self._retryable_partials: list[Any] = []
+        # Reason -> count for appliances the cloud returned and this setup dropped,
+        # and how many appliance OBJECTS the setup loop accounted for. Counted by
+        # the tokens declared above, so the census carries no identity BY
+        # CONSTRUCTION -- which is why it can reach a public dump where
+        # `_hydration_failures` (keyed f"{mac}#{zone}") and `_hydration_causes`
+        # (raw exceptions) never can.
+        #
+        # REBOUND, never mutated in place, and that is the whole reason `_count_drop`
+        # exists instead of a `+= 1` at each site. setup() runs on the dedicated hOn
+        # loop thread (hon_client.py:678-681; the runtime re-auth path re-runs
+        # _close_sync + setup_sync in an executor at hon_client.py:1069-1070) while a
+        # Download Diagnostics runs on Home Assistant's event loop and calls `dict()`
+        # on this mapping.
+        #
+        # The rebind is NOT what stops that reader tearing, and the earlier claim that
+        # it was does not survive measurement: `dict(d)` over str keys is a single C
+        # call that never yields the GIL, so it raised 0 times in 50_000 reads against
+        # a writer thread at setswitchinterval(1e-6) -- at four keys AND at a thousand.
+        # A Python-level `for` over the same dict raised 2658 times in 20_000. So the
+        # copy in `setup_drops` was already safe on CPython, and the guard that IS
+        # load-bearing is the one in `degraded_census`, which loops in Python (see its
+        # docstring, and the threaded test that pins it).
+        #
+        # The rebind is kept anyway, for two reasons that do not rest on an interpreter
+        # detail: it makes the snapshot atomic BY CONSTRUCTION rather than by grace of
+        # how CPython implements dict copying, and a reader that already took the
+        # mapping holds a value that cannot change under it afterwards. It costs a
+        # four-entry dict per dropped appliance.
+        # `_setup_expanded` is a plain int, so it is already atomic.
+        self._setup_drops: dict[str, int] = {}
+        self._setup_expanded = 0
 
     async def __aenter__(self) -> "NativeHon":
         return await self.create()
@@ -208,7 +256,35 @@ class NativeHon:
                 type(appliance_data).__name__,
             )
 
+    def _count_drop(self, reason: str) -> None:
+        """One more appliance the cloud sent and this setup did not append.
+
+        Rebinds instead of mutating, for the reason __init__ gives at length: the
+        snapshot a diagnostics reader takes is then atomic by construction and not by
+        grace of how CPython happens to implement `dict(d)`.
+
+        Cannot raise, and that is load-bearing rather than incidental: every call
+        site sits inside an `except` handler or beside the `return`/`continue` that
+        IS the per-appliance fault boundary (CR#2), so a raise here would escape
+        that boundary and abort the whole setup loop -- the exact failure the
+        boundary was added to stop. `reason` is always a literal of
+        SETUP_DROP_REASONS, `dict.get` has no failure mode on a str key, and the
+        rebind allocates a dict of at most four entries.
+        """
+        self._setup_drops = {
+            **self._setup_drops,
+            reason: self._setup_drops.get(reason, 0) + 1,
+        }
+
     async def _create_appliance(self, appliance_data: dict, zone: int = 0) -> None:
+        # Counted BEFORE anything below can fail, so the census describes ATTEMPTS
+        # and not successes: `built + sum(setup_drops.values()) == setup_expanded`
+        # only holds if every exit from this method is either an append or a
+        # _count_drop, and an exit that skipped the count would silently shrink the
+        # left-hand side. Objects, not cloud entries: setup() calls this zones + 1
+        # times for a multi-zone entry (:487-490), which is why a census keyed on
+        # the length of the cloud list could never reconcile.
+        self._setup_expanded += 1
         # Per-appliance fault boundary (CR#2 -- distinct from the steady-state
         # coordinator/polling resilience): a single malformed device must be
         # logged-and-skipped so the OTHER appliances still load and setup completes.
@@ -223,8 +299,20 @@ class NativeHon:
             mac_empty = appliance.mac_address == ""
         except self._APPLIANCE_BUILD_ERRORS as error:
             self._log_malformed(error, appliance_data)
+            # The DROPPING one of the two branches over this tuple: no usable object
+            # exists, so nothing is appended and this is the only record that the
+            # cloud sent one more appliance than the inventory shows.
+            self._count_drop("construction_error")
             return
         if mac_empty:
+            # THE reason this census exists. This is the only drop in this file that
+            # emits no log line at all, so an inventory thrown away here produces a
+            # diagnostics dump AND a home-assistant.log byte-identical to those of an
+            # account that genuinely owns no appliances -- "turn on debug and
+            # reload" cannot separate them, because there is nothing to turn on.
+            # Still nothing is LOGGED here: a mac is identity, and a count keyed by a
+            # token of this module is the half of the finding that is safe to publish.
+            self._count_drop("mac_empty")
             return
         if self._minimal:
             # Validation only: the appliance is built (so .appliances is populated and
@@ -337,6 +425,19 @@ class NativeHon:
         self._hydration_failures.clear()
         self._hydration_causes.clear()
         self._retryable_partials.clear()
+        # REBOUND, not cleared in place, unlike the three lines above. Two of those
+        # three hold objects nothing outside this session reads; the third,
+        # `_hydration_failures`, is reachable from another thread through
+        # `degraded_appliances` (:576) and `degraded_census` (:581), and both take an
+        # atomic `dict()` copy before touching it -- so a clear in place still cannot
+        # tear a reader mid-read. A Download Diagnostics on Home Assistant's loop
+        # copies the census below while this line runs on the hOn loop thread (see
+        # __init__). This also runs on the MFA resume path, where submit_mfa_code()
+        # re-enters setup() on the SAME session (:705): the appliances built before
+        # the challenge are dropped by the clear above, so a census that survived
+        # would count them twice.
+        self._setup_drops = {}
+        self._setup_expanded = 0
         self._setup_phase = "load_appliances"
         # The hierarchical scope is what makes a LAZY sign-in nested in this request name
         # itself ("load_appliances/auth/...") instead of borrowing this label -- the
@@ -360,6 +461,14 @@ class NativeHon:
                     ),
                     appliance,
                 )
+                # Counted as one expanded object as well as one drop. This entry
+                # never reaches _create_appliance, so nothing else will count it,
+                # and the reconciliation the reader performs --
+                # `built + sum(skipped) == expanded` -- is what tells them the
+                # census is complete rather than merely plausible. One unusable
+                # entry is exactly one appliance object that will never exist.
+                self._setup_expanded += 1
+                self._count_drop("not_a_dict")
                 continue
             # Zone parse is INSIDE the per-appliance boundary: a non-numeric "zone"
             # raises ValueError (or TypeError on a non-str/int), which must skip only
@@ -368,6 +477,12 @@ class NativeHon:
                 zones = int(appliance.get("zone", "0"))
             except (TypeError, ValueError) as error:
                 self._log_malformed(error, appliance)
+                # One object per unreadable entry, for the reason given just above:
+                # the zone is what decides HOW MANY objects the entry expands into,
+                # so an entry whose zone cannot be read is charged the one object it
+                # would have produced at minimum.
+                self._setup_expanded += 1
+                self._count_drop("bad_zone")
                 continue
             if zones > 1:
                 for zone in range(zones):
@@ -461,6 +576,114 @@ class NativeHon:
     def degraded_appliances(self) -> dict[str, Any]:
         """'mac#zone' -> code for appliances kept with partial data (diagnostics only)."""
         return dict(self._hydration_failures)
+
+    @property
+    def degraded_census(self) -> dict[str, int]:
+        """ADDHON label -> count of appliances this setup KEPT in a degraded state.
+
+        A different population from `setup_drops`, and the commoner one. Those
+        appliances do not exist at all; these exist with an empty `commands` map,
+        which `_record_partial` (:393-394) spells out as no
+        select/number/switch/button/climate/fan entities until a MANUAL reload. That
+        is the shape of the report "half my entities disappeared", and today the dump
+        shows the shortfall through `platforms.appliance_totals` without ever being
+        able to name a cause: instrumenting the rare silent drop and leaving the
+        common degradation invisible would have been the census backwards.
+
+        The KEYS of `_hydration_failures` are f"{mac}#{zone}" (:405) and never leave
+        this object. The reduction to labels happens HERE, on the session, so no
+        diagnostics reader is ever the thing that has to decide not to publish a MAC
+        -- the same trade `_poll_census` makes and defends at hon_client.py:298-301,
+        where the redacted name is dropped on the floor rather than forwarded.
+
+        `dict()` first and the loop over the COPY, which is not a style choice: a
+        Python-level `for` over `.values()` gives up the GIL between items, so a
+        `_record_partial` running on the hOn loop thread (hon_client.py:678-681; a
+        runtime re-auth re-runs setup in an executor at :1069-1070) while this runs
+        on Home Assistant's loop during a Download Diagnostics raises `RuntimeError:
+        dictionary changed size during iteration`. Measured on CPython 3.11 with a
+        writer thread and `setswitchinterval(1e-6)`: 5719 failures in 97726 reads for
+        the in-place loop, 0 for the copy, which finishes inside a single C call.
+        `_last_fetch` would catch that and render the whole block "unreadable",
+        which is precisely the block the download was for. `_record_partial` still
+        mutates in place (:405), unlike `_count_drop`, so the copy is the only thing
+        standing between the two threads.
+
+        getattr on `label` rather than an attribute read: every value put here today
+        is a catalog entry (:345 APPLIANCE_DATA_MALFORMED, :361 classify), and an
+        object that turns out not to be one stays out of the census entirely instead
+        of contributing a `None` key to a document that gets pasted into an issue.
+        """
+        out: dict[str, int] = {}
+        for code in dict(self._hydration_failures).values():
+            label = getattr(code, "label", None)
+            if isinstance(label, str):
+                out[label] = out.get(label, 0) + 1
+        return out
+
+    @property
+    def setup_drops(self) -> dict[str, int]:
+        """Reason -> count for appliances the cloud returned and setup dropped.
+
+        A copy, and the copy is why `_count_drop` rebinds: this runs on Home
+        Assistant's loop during a diagnostics download while setup() may be
+        appending on the hOn loop thread.
+        """
+        return dict(self._setup_drops)
+
+    @property
+    def setup_expanded(self) -> int:
+        """How many appliance OBJECTS this setup accounted for.
+
+        NOT the number of cloud entries. An entry with `zone > 1` is expanded into
+        zones + 1 objects (:487-490, pinned by tests/test_native_session.py:265-272
+        as [1, 2, 0]), so a census counted on the raw list length could never
+        reconcile against an inventory: `built > count` is a healthy reading for a
+        multi-zone fridge. An entry dropped before it can be expanded (:470-471, :484-485)
+        is charged one object, since it is one appliance that will never exist.
+
+        The invariant a maintainer reads this against:
+
+            built + sum(setup_drops.values()) == setup_expanded
+            setup_expanded >= len(the raw cloud list)
+
+        equal in the second line if and only if no entry had `zone > 1`.
+
+        The first line holds for every setup that ran to COMPLETION, and "completion"
+        is a real precondition rather than a formality, because this census is
+        readable WHILE the loop is running. A runtime re-auth re-runs _close_sync +
+        setup_sync in an executor (hon_client.py:1069-1070) with the config entry
+        still LOADED and the client still in `hass.data`, so a Download Diagnostics
+        taken in that window reads a half-finished loop: `count` is already published
+        (load_appliances returns before the first appliance is built) while
+        `expanded`, `built` and `skipped` are three separate reads of three moments of
+        the same loop. A shortfall therefore has TWO readings, and the block carries
+        no field that separates them:
+
+          * the setup is still running -- and the entry may well be up, which is
+            precisely why someone was able to download the dump;
+          * the loop was aborted inside an appliance, which only the auth rejection
+            at :359-360 and a cancellation can do, and in that state the config entry
+            did not come up at all.
+
+        Do not read a shortfall as the second without corroborating it against
+        `last_error`/`platforms` in the same document. Closing the gap properly means
+        publishing a completion marker beside the counters; that is a change to the
+        shape of an emitted block and is deliberately not made here.
+        """
+        return self._setup_expanded
+
+    @property
+    def last_appliance_fetch(self) -> dict | None:
+        """Census of the appliance-list fetch this session performed (diagnostics).
+
+        `self._api` here is the transport `HonApi` built in create() (:194), which owns
+        the census because it is the only object that sees both the HTTP status and the
+        raw body. getattr rather than an attribute read: `_api` is None until create()
+        runs, and a session double in a test is not required to grow a field just to be
+        asked a diagnostic question.
+        """
+        return getattr(self._api, "last_appliance_fetch", None)
 
     @property
     def auth_phase(self) -> str:

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -30,10 +30,10 @@ from typing import Any
 
 from . import device as _device
 from .connection import HonConnection
-from .parse import parse_appliance_list
+from .parse import parse_appliance_list, probe_appliance_list
 from .values import API_URL
 from ...debug_utils import redact_identity
-from ...error_codes import APPLIANCE_LIST_EMPTY
+from ...error_codes import APPLIANCE_LIST_EMPTY, classify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +59,18 @@ class HonApi:
 
     def __init__(self, connection: HonConnection) -> None:
         self._connection = connection
+        # Census of the last appliance-list fetch: closed-domain primitives only, read
+        # by NativeHon.last_appliance_fetch -> HonClient -> Download Diagnostics. There
+        # is one HonApi per session (built in NativeHon.create(), session.py:194) and it
+        # is rebuilt with the session, so this always describes THIS session and needs
+        # no clear anywhere: a census that outlived its session is how a dump ends up
+        # answering "what did the fetch do" with a call that ran on an object the client
+        # has already thrown away.
+        #
+        # That lifetime is the whole contract, and it BOUNDS what a dump can show: the
+        # census dies with the session, so a fetch whose failure also killed the session
+        # is not readable from a dump. See load_appliances' `except` branch below.
+        self.last_appliance_fetch: dict | None = None
 
     @property
     def auth(self) -> Any:
@@ -70,11 +82,62 @@ class HonApi:
         # (fix v2.7.1: the old GET commands/v1/appliance returns [] for every
         # account). The defensive extraction lives in parse.parse_appliance_list.
         device_id = self._connection.device.mobile_id or _device.MOBILE_ID
-        async with self._connection.post(
-            f"{API_URL}/unified-api/v1/view/appliance-list",
-            json={"deviceId": device_id},
-        ) as resp:
-            result = await resp.json(content_type=None)
+        status: int | None = None
+        try:
+            async with self._connection.post(
+                f"{API_URL}/unified-api/v1/view/appliance-list",
+                json={"deviceId": device_id},
+            ) as resp:
+                # getattr, not resp.status: a session double without the attribute must
+                # answer "unknown status", never abort a setup over a diagnostic field.
+                status = getattr(resp, "status", None)
+                result = await resp.json(content_type=None)
+        except Exception as error:
+            # connection.py:322-355 raises BEFORE a body exists on 429 (:335), on any
+            # >= 500 (:337) and on a non-JSON body -- a CDN or maintenance page (:355).
+            # Without this branch the session's own census would still read `None`
+            # after a call that demonstrably happened, so the record is written where
+            # the fetch is: on the api that made it. Only the catalog LABEL of the
+            # classified error is kept: it is a closed-domain token, unlike the
+            # exception message, which carries whatever the vendor put in the body.
+            #
+            # WHAT THIS DOES NOT DO, stated here because the obvious reading is wrong.
+            # It does not put `outcome: "raised"` into a diagnostics dump. This raise
+            # propagates out of setup() -> NativeHon.create()'s `except BaseException`
+            # -> close(), which nulls `self._api` (session.py:737-738), so the session
+            # stops reporting a census; HonClient.setup_sync then calls _close_sync()
+            # and async_setup_entry pops the whole entry bucket (__init__.py:662, :673).
+            # The dump for that entry reads `{"state": "client_absent"}`, and by design:
+            # the design note refuses to make a FAILED SETUP diagnosable in this change
+            # and inscribes the shape that will (a `setup_failure` record in
+            # hass.data), because doing it here would change the meaning of an existing
+            # key. Pinned end to end by
+            # tests/test_native_session.py::FetchCensusLifetimeTest so the limit is
+            # behaviour under test, not folklore. This census is the value that record
+            # will carry when it lands.
+            self.last_appliance_fetch = {
+                "at": datetime.now(timezone.utc),
+                "status": status,
+                "code": getattr(classify(error), "label", None),
+                "outcome": "raised",
+                "stopped_at": None,
+                "node_type": None,
+                "siblings": None,
+                "count": None,
+            }
+            raise
+        # Recorded BEFORE the parse, and independently of it. "The cloud sent an empty
+        # list" and "our walk stopped at modules.applianceList" both leave `appliances`
+        # empty and both read as `"appliances": []` in the diagnostics dump; the probe
+        # is the only thing that separates them there, because the WARNING below carries
+        # the real key names and a dump can never carry those. parse_appliance_list
+        # stays the single source of the returned list; the probe only describes the walk.
+        self.last_appliance_fetch = {
+            "at": datetime.now(timezone.utc),
+            "status": status,
+            "code": None,
+            **probe_appliance_list(result),
+        }
         appliances = parse_appliance_list(result)
         if not appliances:
             # Request/auth OK but 0 appliances: log the response structure to

--- a/custom_components/addhon/client/transport/parse.py
+++ b/custom_components/addhon/client/transport/parse.py
@@ -20,8 +20,12 @@ from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
-# Path in the POST /unified-api/v1/view/appliance-list response.
-_APPLIANCE_LIST_PATH = ("modules", "applianceList", "payload", "appliances")
+# Path in the POST /unified-api/v1/view/appliance-list response. PUBLIC (no leading
+# underscore) because two readers outside this function depend on it: `probe_appliance_list`
+# below walks the very same tuple, and `tests/test_diagnostics.py` pins
+# `diagnostics._FETCH_STOPS` against it so the token set the dump may print cannot drift
+# away from the path the parser actually walks.
+APPLIANCE_LIST_PATH = ("modules", "applianceList", "payload", "appliances")
 
 
 def parse_appliance_list(result: Any) -> list:
@@ -32,7 +36,7 @@ def parse_appliance_list(result: Any) -> list:
     -> `[]`. A non-list but *truthy* final value = schema drift: log + `[]`.
     """
     node: Any = result
-    for key in _APPLIANCE_LIST_PATH:
+    for key in APPLIANCE_LIST_PATH:
         if not isinstance(node, dict):
             return []
         node = node.get(key)
@@ -44,3 +48,67 @@ def parse_appliance_list(result: Any) -> list:
             type(node).__name__,
         )
     return []
+
+
+# Every type `json.loads` can produce. `type(x).__name__` on a foreign object is a
+# CLASS NAME, i.e. an arbitrary string chosen by whoever wrote that class, so the name
+# is MAPPED onto this set rather than copied: the value `probe_appliance_list` emits is
+# always a member of a literal written here, which is what lets the diagnostics dump
+# print it without a redaction pass (see the `_closed_token` argument in
+# diagnostics.py). A class named after a MAC address is exactly the accident this
+# closes.
+_NODE_TYPES = frozenset({"dict", "list", "str", "int", "float", "bool", "NoneType"})
+
+
+def _node_type(node: Any) -> str:
+    name = type(node).__name__
+    return name if name in _NODE_TYPES else "other"
+
+
+def probe_appliance_list(result: Any) -> dict:
+    """Where the appliance-list walk stopped, as closed-domain primitives.
+
+    Deliberately INDEPENDENT of `parse_appliance_list` rather than a refactor of it: a
+    probe that cannot influence what the parser returns is a structural property, not a
+    review promise. `parse_appliance_list` sits on the setup path of every config entry,
+    and the whole point of this function is to be shippable without touching it. The two
+    are pinned to agree by test (`tests/test_transport_parse.py`,
+    `test_probe_and_parse_agree_on_the_list`).
+
+    NO value and NO key name from the response is read into the result. Every string it
+    emits is an element of `APPLIANCE_LIST_PATH` or of `_NODE_TYPES`, both literals of
+    this file. That is what makes the output safe to publish in a diagnostics dump the
+    user pastes into a public issue, where a key name such as `"3C:71:BF:AA:BB:CC"`
+    would otherwise ride out on `stopped_at`.
+
+    `count` is None -- not 0 -- on every branch that never reached a list, so a `count`
+    of 0 in the dump means exactly one thing: the cloud sent an empty list. With 0 on
+    the failure branches the reader would be back to the ambiguity this function exists
+    to remove.
+
+    The try/except is not decoration. The input is `await resp.json(content_type=None)`
+    on a duck-typed response: in production aiohttp decodes with `json.loads` and none
+    of isinstance/`in`/len/`type().__name__` can raise, but a dict SUBCLASS overriding
+    `__contains__`/`__len__`/`__getitem__` satisfies `isinstance` and can. This runs
+    inside `NativeHon.setup()` (session.py:450), so "it cannot raise on a json.loads
+    output" is not the same claim as "it can never abort a setup" -- the guard makes the
+    second one true too, and gives the reserved "other" token its only producer.
+    """
+    try:
+        node: Any = result
+        for key in APPLIANCE_LIST_PATH:
+            if not isinstance(node, dict):
+                return {"outcome": "not_a_dict", "stopped_at": key,
+                        "node_type": _node_type(node), "siblings": None, "count": None}
+            if key not in node:
+                return {"outcome": "missing_key", "stopped_at": key,
+                        "node_type": "dict", "siblings": len(node), "count": None}
+            node = node[key]
+        if isinstance(node, list):
+            return {"outcome": "ok", "stopped_at": None,
+                    "node_type": "list", "siblings": None, "count": len(node)}
+        return {"outcome": "not_a_list", "stopped_at": None,
+                "node_type": _node_type(node), "siblings": None, "count": None}
+    except Exception:  # noqa: BLE001 - a probe must never abort a setup
+        return {"outcome": "other", "stopped_at": None,
+                "node_type": None, "siblings": None, "count": None}

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -2676,6 +2676,246 @@ def _last_poll(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
     return dict(census) if isinstance(census, Mapping) else None
 
 
+# The closed domains `last_fetch` may print. Duplicated from the transport rather
+# than imported: the Home Assistant layer does not import transport internals
+# anywhere else in this file, and a drift test pins each set against its source
+# (the same guarantee `_KNOWN_OPTIONS` and `_TO_REDACT` already carry, and for the
+# same reason -- the duplication is what makes the guard a test rather than an
+# import that would drag the transport package into every dump).
+_FETCH_STATES = frozenset({"recorded", "never_ran", "client_absent", "unreadable"})
+_FETCH_STOPS = frozenset({"modules", "applianceList", "payload", "appliances"})
+_FETCH_OUTCOMES = frozenset(
+    {"ok", "not_a_dict", "missing_key", "not_a_list", "raised", "other"}
+)
+_FETCH_NODE_TYPES = frozenset(
+    {"dict", "list", "str", "int", "float", "bool", "NoneType", "other"}
+)
+# The reasons a setup may drop an appliance the cloud returned. The counts arrive from
+# the session, which declares the same tokens as `SETUP_DROP_REASONS` and is pinned
+# against this tuple by a drift guard; a reason this build does not know is a reason
+# this build cannot vouch for, so it is dropped instead of printed.
+_FETCH_SKIP_REASONS = ("not_a_dict", "bad_zone", "construction_error", "mac_empty")
+# Only to refuse a foreign object: a count is an int and an int cannot carry identity,
+# so this is hygiene, not privacy.
+_FETCH_MAX_INT = 1_000_000
+# Ten years either way. `_age_seconds` returns a NEGATIVE number when the clocks
+# disagree (documented at its definition) and that finding must survive the bound.
+_FETCH_MAX_AGE_S = 315_360_000
+# A catalog label cannot be enumerated here without duplicating error_codes.py, so it
+# is bounded by SHAPE instead: seven fixed characters and three digits, validated on
+# the way OUT. `last_poll.dropped` already emits `code.label` unvalidated; this is the
+# same value under a tighter contract, not a new class of value.
+_ADDHON_LABEL_RE = re.compile(r"ADDHON-[0-9]{3}")
+_FETCH_MAX_LABEL_ROWS = 20
+
+
+def _closed_token(value, allowed: frozenset) -> str | None:
+    """A token of `allowed`, or "other". NEVER an object chosen by the writer.
+
+    `type(value) is str`, NOT isinstance -- the same refusal `_bounded_int` makes just
+    below, for a stronger reason. isinstance admits SUBCLASSES; a str subclass is free
+    to override `__eq__`/`__hash__` so that it compares equal to "ok" while its actual
+    characters are "3C:71:BF:AA:BB:CC", and Home Assistant's JSON encoder writes the
+    characters. With `type(value) is str` the comparison is `str.__eq__` on a plain
+    str, so the object returned is a plain str whose characters ARE the literal's --
+    which is what makes "the output is a literal of this module" a fact rather than a
+    hope.
+
+    An unrecognised value renders as "other" rather than None so the dump still reports
+    that the writer produced something this reader does not know: the same "keep the
+    finding, lose the value" rule `_entry_options` applies to an option key.
+    """
+    if value is None:
+        return None
+    return value if type(value) is str and value in allowed else "other"
+
+
+def _bounded_int(value, low: int, high: int) -> int | None:
+    """An int inside [low, high], else None. `bool` is refused on purpose:
+    isinstance(True, int) is True and would render this field as `true`."""
+    return value if type(value) is int and low <= value <= high else None
+
+
+def _label_token(value) -> str | None:
+    """An ADDHON catalog label, or None. Shape-validated on the way out, so the
+    emitted string is provably "ADDHON-" plus three digits and nothing else."""
+    if type(value) is not str or not _ADDHON_LABEL_RE.fullmatch(value):
+        return None
+    return value
+
+
+def _skip_census(raw) -> dict:
+    """Reason -> count, over the ALLOWLIST and never over the mapping received.
+
+    Iterating the received mapping would put a key CHOSEN BY THE WRITER into the
+    document, which is precisely the door `_redact` cannot close: it masks by key NAME
+    (:375-392), so a key it has never heard of is a key it publishes.
+
+    Four keys at most, by construction. No `truncated` twin is needed and none is
+    admitted: the problem `attributes_last_update` solves that way (:1940-1952) does
+    not exist when no key of the map is chosen by the cloud.
+    """
+    raw = raw if isinstance(raw, Mapping) else {}
+    out: dict = {}
+    for reason in _FETCH_SKIP_REASONS:
+        counted = _bounded_int(raw.get(reason), 0, _FETCH_MAX_INT)
+        if counted:
+            out[reason] = counted
+    return out
+
+
+def _degraded_census(raw) -> dict:
+    """ADDHON label -> count, both halves validated on the way out.
+
+    Unlike `_skip_census` the keys cannot come from an allowlist without duplicating
+    error_codes.py here, so they are bounded by SHAPE: `_label_token` emits only
+    "ADDHON-" plus three digits, and a row count caps the map. A key that is not a
+    label is dropped whole -- keys and values move together or not at all.
+
+    This is the ONLY place in the block that iterates a mapping it received instead of
+    an allowlist. It is admitted because the key is validated for shape BEFORE it is
+    written, not because the writer is trusted: the session that fills this map keys it
+    by `f"{mac}#{zone}"` in its own bookkeeping, so a build that ever handed those keys
+    over directly would publish a MAC per degraded appliance.
+    """
+    raw = raw if isinstance(raw, Mapping) else {}
+    out: dict = {}
+    for key, value in raw.items():
+        if len(out) >= _FETCH_MAX_LABEL_ROWS:
+            break
+        label = _label_token(key)
+        counted = _bounded_int(value, 0, _FETCH_MAX_INT)
+        if label is not None and counted:
+            out[label] = counted
+    return out
+
+
+# The keys of a block that has nothing to report. Written once so a `never_ran` and a
+# `recorded` block can never disagree about which keys exist: the key set of a
+# top-level block has to be stable for a field-by-field diff between two downloads of
+# the same issue to mean anything.
+#
+# A FACTORY, not a module constant, and the two mutable values are why. `{**CONST}` is
+# a SHALLOW copy, so a constant would hand every `never_ran`/`client_absent`/
+# `unreadable` block ever produced by this process the same two dict objects -- aliased
+# to the constant itself. Nothing mutates the returned document today (Home Assistant
+# json-serialises it and `_redact` never reaches this block), so that was latent rather
+# than live; but the claim this block makes is that every value in it is a literal of
+# this module BY CONSTRUCTION, and an alias makes that claim depend on no future caller
+# ever writing into the dict it was handed. A census that grew a `truncated` twin, a
+# post-pass that annotated the block, or a test helper would then have written into
+# EVERY later dump of EVERY config entry in the process. Building them per call costs
+# two empty dicts per download and removes the premise. Pinned by
+# test_the_key_set_is_the_same_in_every_state.
+def _fetch_empty() -> dict:
+    return {
+        "at": None, "age_s": None, "status": None, "code": None, "outcome": None,
+        "stopped_at": None, "node_type": None, "siblings": None, "count": None,
+        "expanded": None, "built": None, "skipped": {}, "degraded": {},
+    }
+
+
+def _last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime) -> dict:
+    """What the ONE appliance-list HTTP call returned, and what setup made of it.
+
+    NEVER None. `last_poll` beside this is a per-cycle recount of a list built once at
+    setup (the poll reads `HonClient.async_get_appliances`, which returns the cached
+    inventory `NativeHon.setup()` filled); this block is the call itself, and it is the
+    only place in the dump where "the cloud sent nothing" and "we could not read what
+    the cloud sent" stop looking alike. A `null` block would fold those into the
+    absence of a session -- the ambiguity `_last_error` was rewritten to remove
+    (:2582-2588).
+
+    NOT in that list, though `outcome: "raised"` is in `_FETCH_OUTCOMES` and the
+    transport writes it: "the call never reached a body". That census dies with the
+    session the raise tore down, and the entry bucket is popped with it, so the block
+    reads `client_absent`. The reader's domain still carries the token because the
+    writer produces it and a reader that printed "other" for its own main field would
+    be worse; the state becomes reachable here when a failed setup gets a record of
+    its own. See `HonApi.load_appliances`.
+
+    Leak-proof by construction on the strongest terms in the file: every KEY is a
+    literal written above, and every VALUE is either an int this function range-checks,
+    an instant `_stamp_text` validates against `_ISO_RE`, a token `_closed_token` looks
+    up in a frozenset written above, or a label `_label_token` shape-checks. Not one
+    string from the cloud, from the session or from the client is copied into the
+    document -- so `_redact` is not merely skipped here, it would have nothing to do.
+
+    Deliberate divergence from `_last_poll` next door, which passes the census through
+    as `dict(census)` and rests entirely on its writer. This one does not trust its
+    writer, because the census arrives through a `getattr` on `_hon_instance`, which in
+    a test or in the presence of a session double can be any object at all.
+    """
+    try:
+        return _build_last_fetch(hass, entry, now=now)
+    except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+        _LOGGER.debug("Diagnostics debug: last_fetch not computable", exc_info=True)
+        return {"state": "unreadable", **_fetch_empty()}
+
+
+def _build_last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime) -> dict:
+    """The block itself. Split from `_last_fetch` so the guard above is the whole
+    degradation story: eight `.get` calls on a mapping this function declares untrusted
+    and five `getattr` reads of properties that may raise, all of them inside a
+    convenience field, and none of them allowed to take the download down."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    client = entry_data.get("client")
+    if client is None:
+        # Same two-into-one state `_last_error` documents at :2582-2588: a bucket
+        # without a client is not a state this integration can produce.
+        return {"state": "client_absent", **_fetch_empty()}
+    raw = getattr(client, "last_appliance_fetch", None)
+    if not isinstance(raw, Mapping):
+        # A live client whose session was closed, or one between _close_sync and the
+        # end of setup_sync on a runtime re-auth. `null` would be true too, but silent.
+        return {"state": "never_ran", **_fetch_empty()}
+    moment = _as_utc(raw.get("at"), assume_naive_utc=False)
+    return {
+        "state": "recorded",
+        # Both halves hang off ONE `moment`, so an instant `_as_utc` refuses -- a naive
+        # datetime (:1259-1260), a string that merely looks like one, any foreign
+        # object -- blanks BOTH. That is the coupling that matters: it is what stops a
+        # value this reader could not validate from being half-published.
+        #
+        # It is NOT a claim that the two always move together, and the two ways they
+        # part are both readings worth keeping rather than defects to suppress:
+        #   * `at` alone, `age_s` null -- the age fell outside +/-10 years. The usual
+        #     cause is the reporter's own clock (a host that stamped the fetch before
+        #     NTP corrected it reads `1970-01-01T00:00:11+00:00`, `age_s: null`).
+        #     Blanking `at` too would delete that finding, which is the one thing in
+        #     the block that explains why every other age in the dump looks absurd.
+        #   * `age_s` alone, `at` null -- `_stamp_text` refused to render an instant
+        #     `_as_utc` accepted, which takes a `datetime` SUBCLASS whose `isoformat`
+        #     returns something that is not an ISO stamp. The refusal is the point (an
+        #     unvalidated string is exactly what must not reach the file) and the age
+        #     survives it because it is computed, not echoed.
+        # Neither half is unreadable on its own: `generated_at` is in the same document,
+        # so a reader recovers whichever is missing by subtraction. Both cases are
+        # pinned in test_at_and_age_move_together.
+        "at": _stamp_text(moment),
+        "age_s": (
+            _bounded_int(_age_seconds(moment, now), -_FETCH_MAX_AGE_S, _FETCH_MAX_AGE_S)
+            if moment is not None
+            else None
+        ),
+        "status": _bounded_int(raw.get("status"), 100, 599),
+        "code": _label_token(raw.get("code")),
+        "outcome": _closed_token(raw.get("outcome"), _FETCH_OUTCOMES),
+        "stopped_at": _closed_token(raw.get("stopped_at"), _FETCH_STOPS),
+        "node_type": _closed_token(raw.get("node_type"), _FETCH_NODE_TYPES),
+        "siblings": _bounded_int(raw.get("siblings"), 0, _FETCH_MAX_INT),
+        "count": _bounded_int(raw.get("count"), 0, _FETCH_MAX_INT),
+        "expanded": _bounded_int(
+            getattr(client, "setup_expanded", None), 0, _FETCH_MAX_INT
+        ),
+        "built": _bounded_int(
+            getattr(client, "appliance_count", None), 0, _FETCH_MAX_INT
+        ),
+        "skipped": _skip_census(getattr(client, "setup_drops", None)),
+        "degraded": _degraded_census(getattr(client, "degraded_census", None)),
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
@@ -2744,6 +2984,17 @@ async def async_get_config_entry_diagnostics(
         # no dump carries -- told them apart. Counts plus ADDHON catalog labels, so
         # like the two keys above it is leak-proof by construction and skips _redact.
         "last_poll": _last_poll(hass, entry),
+        # The ONE HTTP call the whole inventory rests on, which happens once per
+        # session at setup and is therefore invisible to the poll above: `last_poll`
+        # recounts a list built long before it. This is what separates "the cloud sent
+        # an empty list" from "our walk could not reach the list" -- two states that
+        # both render as `"appliances": []` with a null `last_error`, and that until
+        # now no dump could tell apart. The third of that family, "the call never
+        # reached a body", is written by the transport but is NOT readable here: it
+        # dies with the session the raise tore down (see `_last_fetch`). Closed-domain
+        # tokens, range-checked ints and a validated instant, so like `last_poll` it is
+        # leak-proof by construction and skips _redact.
+        "last_fetch": _last_fetch(hass, entry, now=now),
         "appliances": appliances,
     }
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -2566,6 +2566,74 @@ def _coordinator(hass: HomeAssistant, entry: ConfigEntry):
     return entry_data.get("coordinator")
 
 
+# A setup phase as the client records it: flat ("authenticate", "mfa_challenge") or
+# hierarchical ("load_appliances/auth"). Shape-validated rather than enumerated, because
+# the vocabulary is assembled at raise time from the segment a phase() context was opened
+# with (client/phase.py) and a frozenset here would have to be kept in step with every
+# new context in the transport. Lower-case words and slashes only, and short: whatever a
+# future caller puts in `last_error_phase`, what this file publishes is that shape.
+_PHASE_RE = re.compile(r"[a-z_]+(?:/[a-z_]+)*")
+_PHASE_MAX_LEN = 64
+
+
+def _phase_token(value) -> str | None:
+    """A phase name, or None. The `type(...) is not str` is the guard `_closed_token`
+    documents: a str SUBCLASS passes `isinstance` and re-implements `__str__`, so the
+    string that reaches the file need not be the one the regex matched."""
+    if type(value) is not str or len(value) > _PHASE_MAX_LEN:
+        return None
+    return value if _PHASE_RE.fullmatch(value) else None
+
+
+def _reason_for_label(label: str | None) -> str | None:
+    """The catalog reason for an ADDHON label, resolved HERE and never echoed.
+
+    `_last_error`'s live branch reads `code.reason_en` off the code object the client
+    holds, which is an `error_codes` singleton -- the text is this module's, not the
+    cloud's. The failure-record branch has no such object: it has a string that has been
+    through hass.data. Resolving the reason from the catalog instead of storing it keeps
+    the two branches on the same footing, and means a record written by an older version
+    of this integration cannot put a stale (or foreign) sentence in the document.
+    """
+    if label is None:
+        return None
+    from . import error_codes
+
+    for code in error_codes.all_codes():
+        if code.label == label:
+            return code.reason_en
+    return None
+
+
+def _setup_failed(failure: Mapping) -> dict:
+    """`last_error` for an entry whose setup failed, from the record __init__ left.
+
+    Same leak-proof argument as the live branch below, one notch stricter because the
+    values arrive through a mapping rather than off a code object: the label is
+    shape-checked (`_label_token`), the reason is looked up in the catalog rather than
+    read from the record, the phase is shape-checked, and the instant goes through the
+    same `_as_utc` + `_stamp_text` pair every other stamp in this file uses.
+
+    `phase_ledger` is passed through exactly as the live branch passes it (:2620): a
+    list of {phase, seconds, outcome} rows built by our own phase tracker, in this
+    process, out of the same objects. It is guarded to a list so a foreign value cannot
+    make the key a shape no reader expects, but its rows are not rebuilt -- doing that
+    here and not there would claim a difference in trust that does not exist.
+    """
+    label = _label_token(failure.get("code"))
+    out: dict = {
+        "status": "setup_failed",
+        "code": label,
+        "reason": _reason_for_label(label),
+        "phase": _phase_token(failure.get("phase")),
+        "at": _stamp_text(_as_utc(failure.get("at"), assume_naive_utc=False)),
+    }
+    ledger = failure.get("phase_ledger")
+    if isinstance(ledger, list) and ledger:
+        out["phase_ledger"] = ledger
+    return out
+
+
 def _last_error(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
     """The last classified setup/update error code, for issue triage.
 
@@ -2579,13 +2647,19 @@ def _last_error(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
         # account that simply owns no appliances: both read `"last_error": null,
         # "appliances": []`, and a real 5.9.3 report was triaged as the second when
         # it was the first. `null` is now the answer of a client, not the absence of
-        # one. "No entry data" and "entry data without a client" are deliberately
-        # ONE state: async_setup_entry stores the bucket as a single literal that
-        # always carries the client (__init__.py:621) and pops it whole on a failed
-        # setup or unload (__init__.py:651, :662, :680), so a bucket without a
-        # client is not a state this integration can produce -- a second token would
-        # only send a triager hunting a distinction nothing writes. A closed-domain
-        # token like the fields below, so it needs no _redact either.
+        # one.
+        #
+        # A bucket without a client IS a state this integration produces, and only
+        # one thing produces it: `_store_setup_failure` replacing the bucket on a
+        # failed setup (__init__.py). When that record is there it is a strictly
+        # better answer than the marker below -- it carries the classified code, the
+        # phase, the ledger -- so it is preferred. `client_absent` keeps its meaning
+        # for everything else: an entry absent from hass.data, and a bucket a future
+        # caller builds without either key.
+        failure = entry_data.get("setup_failure")
+        if isinstance(failure, Mapping):
+            return _setup_failed(failure)
+        # A closed-domain token like the fields below, so it needs no _redact either.
         return {"status": "client_absent"}
     code = getattr(client, "last_error_code", None)
     if code is None:
@@ -2826,13 +2900,13 @@ def _last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime) -> di
     absence of a session -- the ambiguity `_last_error` was rewritten to remove
     (:2582-2588).
 
-    NOT in that list, though `outcome: "raised"` is in `_FETCH_OUTCOMES` and the
-    transport writes it: "the call never reached a body". That census dies with the
-    session the raise tore down, and the entry bucket is popped with it, so the block
-    reads `client_absent`. The reader's domain still carries the token because the
-    writer produces it and a reader that printed "other" for its own main field would
-    be worse; the state becomes reachable here when a failed setup gets a record of
-    its own. See `HonApi.load_appliances`.
+    IN that list since the failed setup got a record of its own: `outcome: "raised"`,
+    "the call never reached a body". The census still dies with the session the raise
+    tore down -- `setup_sync` snapshots it into `last_setup_fetch` one line before
+    `_close_sync`, and `_store_setup_failure` copies that into the entry bucket in
+    place of the coordinator and client the setup never handed over. A dump taken
+    after a failed setup therefore reads the block, not `client_absent`. See
+    `HonApi.load_appliances` for the writer.
 
     Leak-proof by construction on the strongest terms in the file: every KEY is a
     literal written above, and every VALUE is either an int this function range-checks,
@@ -2861,14 +2935,46 @@ def _build_last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime)
     entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
     client = entry_data.get("client")
     if client is None:
-        # Same two-into-one state `_last_error` documents at :2582-2588: a bucket
-        # without a client is not a state this integration can produce.
+        # No client, but possibly a record of why there is none. `_store_setup_failure`
+        # flattens the census and the four counters into one mapping precisely so this
+        # branch reads the same block builder the live branch does -- and it is what
+        # finally makes `outcome: "raised"` reachable in a dump. The census of a setup
+        # that died before the response had a body used to be torn down with the
+        # session that raised, which is why the docstring above listed that state as
+        # written-but-unobservable.
+        failure = entry_data.get("setup_failure")
+        recorded = failure.get("fetch") if isinstance(failure, Mapping) else None
+        if isinstance(recorded, Mapping):
+            return _fetch_block(recorded, recorded, now=now)
         return {"state": "client_absent", **_fetch_empty()}
     raw = getattr(client, "last_appliance_fetch", None)
     if not isinstance(raw, Mapping):
         # A live client whose session was closed, or one between _close_sync and the
         # end of setup_sync on a runtime re-auth. `null` would be true too, but silent.
         return {"state": "never_ran", **_fetch_empty()}
+    return _fetch_block(
+        raw,
+        # The counters are what SETUP made of the list; `raw` is what the CALL
+        # returned. Two sources on the live path, one flattened mapping on the record
+        # path, and one block builder for both.
+        {
+            "expanded": getattr(client, "setup_expanded", None),
+            "built": getattr(client, "appliance_count", None),
+            "skipped": getattr(client, "setup_drops", None),
+            "degraded": getattr(client, "degraded_census", None),
+        },
+        now=now,
+    )
+
+
+def _fetch_block(raw: Mapping, counters: Mapping, *, now: datetime) -> dict:
+    """The `recorded` block, from a census mapping and a counter mapping.
+
+    Every value is validated HERE rather than at either call site, so the block a live
+    client produces and the block a setup-failure record produces are the same document
+    under the same guarantees -- and the record, which has been through hass.data and is
+    therefore the less trusted of the two, cannot be the one that got the shorter check.
+    """
     moment = _as_utc(raw.get("at"), assume_naive_utc=False)
     return {
         "state": "recorded",
@@ -2905,14 +3011,10 @@ def _build_last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime)
         "node_type": _closed_token(raw.get("node_type"), _FETCH_NODE_TYPES),
         "siblings": _bounded_int(raw.get("siblings"), 0, _FETCH_MAX_INT),
         "count": _bounded_int(raw.get("count"), 0, _FETCH_MAX_INT),
-        "expanded": _bounded_int(
-            getattr(client, "setup_expanded", None), 0, _FETCH_MAX_INT
-        ),
-        "built": _bounded_int(
-            getattr(client, "appliance_count", None), 0, _FETCH_MAX_INT
-        ),
-        "skipped": _skip_census(getattr(client, "setup_drops", None)),
-        "degraded": _degraded_census(getattr(client, "degraded_census", None)),
+        "expanded": _bounded_int(counters.get("expanded"), 0, _FETCH_MAX_INT),
+        "built": _bounded_int(counters.get("built"), 0, _FETCH_MAX_INT),
+        "skipped": _skip_census(counters.get("skipped")),
+        "degraded": _degraded_census(counters.get("degraded")),
     }
 
 

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -836,6 +836,89 @@ class HonClient:
             _LOGGER.error("Error fetching appliances: %s", err)
             raise RuntimeError(f"Error fetching appliances: {err}") from err
 
+    @property
+    def last_appliance_fetch(self) -> dict | None:
+        """The live session's appliance-list fetch census, or None if there is none.
+
+        Read LIVE off the session rather than mirrored into a field of this client. A
+        mirror would need a clear beside the ones at the top of setup_sync and a second
+        write on the MFA-resume path, and forgetting either is how a census ends up
+        describing a session the client has already thrown away. Reading through
+        `_hon_instance` cannot drift: `_close_sync` nulls it under the lifecycle lock,
+        so the answer is either this session's census or None.
+
+        getattr, not an attribute read: `_hon_instance` is None before the first setup
+        and after a close, and a session double is free not to carry the field.
+        """
+        return getattr(self._hon_instance, "last_appliance_fetch", None)
+
+    @property
+    def appliance_count(self) -> int | None:
+        """How many appliances the live session actually built (None: no session).
+
+        The same number as `last_poll.returned` whenever both describe the same
+        session -- that one is a recount of this list at the end of a poll cycle
+        (`_poll_census`, written at :1300) -- but the two have INDEPENDENT
+        resets, and the window where that matters is a SUCCESSFUL runtime re-auth:
+        `last_poll_census` is nulled at the top of every setup_sync (:660) and
+        rewritten only when a whole cycle closes, so between the end of setup_sync
+        and the end of the first poll `last_poll` is null and this is the only
+        number in the dump that says how many appliances the setup built. That
+        window is exactly when someone downloads a dump saying "I reloaded and my
+        entities are gone".
+
+        isinstance before len(): `_hon_instance` can be a session double, and a
+        length taken off an arbitrary object is how a convenience field in a dump
+        learns to raise.
+        """
+        appliances = getattr(self._hon_instance, "appliances", None)
+        return len(appliances) if isinstance(appliances, list) else None
+
+    @property
+    def setup_expanded(self) -> int | None:
+        """How many appliance objects the live session's setup accounted for.
+
+        Read off the session for the reason `last_appliance_fetch` above gives at
+        length: a copy kept on this client would need a clear that someone will
+        eventually forget, and would then describe a session already discarded.
+        With `built` beside it the reader can check
+        `built + sum(skipped.values()) == expanded` and know the census accounts
+        for every appliance the cloud sent.
+        """
+        return getattr(self._hon_instance, "setup_expanded", None)
+
+    @property
+    def setup_drops(self) -> dict[str, int] | None:
+        """Reason -> count for the appliances the live setup dropped, or None.
+
+        The session already reduced this to tokens it declares itself
+        (`client/session.py:SETUP_DROP_REASONS`), so no identity crosses this
+        boundary and the diagnostics reader still filters it against its own
+        allowlist rather than trusting the mapping it receives.
+        """
+        return getattr(self._hon_instance, "setup_drops", None)
+
+    @property
+    def degraded_census(self) -> dict[str, int] | None:
+        """ADDHON label -> count for the appliances the live setup KEPT broken.
+
+        The other half of the account beside `setup_drops`, and the half that
+        answers the commoner report: `setup_drops` counts appliances that never
+        became entities at all, this counts the ones that exist with an empty
+        `commands` map and therefore lost their select/number/switch/button/
+        climate/fan entities until a manual reload (`client/session.py:393-394`).
+        Read together they say whether a shrunken entity list is missing devices or
+        missing capabilities, which nothing in the dump could distinguish before.
+
+        Deliberately NOT `degraded_appliances`, which is the same information keyed
+        by f"{mac}#{zone}". The session publishes the reduced form itself
+        (`client/session.py:581`) so a plaintext MAC is never handed across this
+        boundary for a reader to remember not to write down; the diagnostics reader
+        then still shape-checks every label it receives (`_degraded_census`) instead
+        of trusting the mapping, for the same reason `setup_drops` is filtered above.
+        """
+        return getattr(self._hon_instance, "degraded_census", None)
+
     def _needs_rehydration(self, appliance) -> bool:
         """Did setup append this appliance without its commands, for a retryable reason?
 

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -347,6 +347,19 @@ class HonClient:
         # phase names, rounded seconds, ok/error/timeout). This is the artefact that
         # makes a report like #76 diagnosable without a live probe.
         self.last_phase_ledger: list[dict] | None = None
+        # The appliance-list census as it stood when setup_sync FAILED, snapshotted
+        # before _close_sync tears the session down. Part of the failure record with
+        # the three fields above, and cleared with them.
+        #
+        # This is deliberately the mirror `last_appliance_fetch` (:840) argues against,
+        # and the argument does not reach it: what that property refuses is a mirror of
+        # a LIVE census, which drifts because the session keeps writing after the copy.
+        # This one is written once, on the path that has just decided there will be no
+        # more writes, and is read by __init__ into a hass.data record that is never
+        # updated afterwards. Without it the census of a setup that raised inside
+        # load_appliances dies with the session, and `outcome: "raised"` -- the state
+        # that says "the call never reached a body" -- stays unreachable in a dump.
+        self.last_setup_fetch: dict | None = None
         # Census of the last COMPLETED poll cycle (see _poll_census): how many
         # appliances the cloud returned, how many survived, one catalog label per
         # drop. None until a cycle finishes, which is the third state the dump has
@@ -653,6 +666,7 @@ class HonClient:
             self.last_error_phase = None
             self.last_mfa_summary = None
             self.last_phase_ledger = None
+            self.last_setup_fetch = None
             # Not part of that failure record: a census is a statement about ONE
             # session's poll, and this attempt builds a new session. Carrying it over
             # would let a dump answer "how did the last poll go" with a cycle that ran
@@ -732,6 +746,11 @@ class HonClient:
                     self.last_error_phase or "setup",
                     classify_failure_reason(err),
                 )
+                # BEFORE _close_sync, which nulls _hon_instance and with it the only
+                # reader of the census (`last_appliance_fetch`). This is the whole
+                # reason the failure record can say "the POST never reached a body":
+                # after the next line that fact exists nowhere else in the process.
+                self.last_setup_fetch = self.last_appliance_fetch
                 self._close_sync()
                 raise
 

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.16.0"
+  "version": "5.17.0"
 }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6827,6 +6827,34 @@ class SetupFailureRecordTest(unittest.TestCase):
             "ok", hass.data[DOMAIN]["e1"]["setup_failure"]["fetch"]["outcome"]
         )
 
+    def test_a_raising_property_does_not_keep_the_setup_from_closing(self) -> None:
+        # `getattr(x, name, default)` swallows a MISSING attribute, never an exception
+        # raised INSIDE a property body -- and `setup_drops` ends in
+        # `dict(self._setup_drops)` on a session setup may still be appending to from
+        # the hOn loop thread (client/session.py:625-632, the same hazard
+        # `_RaisingFetchClient` above stands in for). Unguarded, that raise propagates
+        # out of the `except` handler in async_setup_entry, `_async_close_client` never
+        # runs, and the dedicated loop thread and the aiohttp session leak.
+        init = _addhon_init()
+
+        class Hostile(_FailedClient):
+            @property
+            def setup_drops(self):
+                raise RuntimeError("session torn down on the hOn loop thread")
+
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"]["client"] = object()
+        init._store_setup_failure(hass, FakeEntry(), Hostile())
+        # No raise -- and the bucket is still CLEARED, because a coordinator or a
+        # client that outlived a failed setup is the one outcome worse than a missing
+        # record. Empty, not half-filled: `last_error` then answers `client_absent`,
+        # which is exactly true.
+        self.assertEqual({}, hass.data[DOMAIN]["e1"])
+        result = _run(
+            diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+        )
+        self.assertEqual({"status": "client_absent"}, result["last_error"])
+
     def test_removing_the_entry_drops_the_record(self) -> None:
         # The only hook that can: an entry whose setup never succeeded is never
         # unloaded, so without async_remove_entry the record outlives the entry and
@@ -6866,15 +6894,18 @@ class SetupFailureRecordTest(unittest.TestCase):
             # first, and an assertion built on it passes whichever way the two are
             # written. Verified by mutation: swapping the two statements leaves a
             # walk-order assertion green and fails this one.
-            lines = {
-                node.func.id: node.lineno
-                for node in ast.walk(handler)
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-                and node.func.id in ("_store_setup_failure", "_async_close_client")
-            }
+            lines: dict[str, list[int]] = {"_store_setup_failure": [], "_async_close_client": []}
+            for node in ast.walk(handler):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                    if node.func.id in lines:
+                        lines[node.func.id].append(node.lineno)
+            # max/min, not a single lineno each: ast.walk is breadth first, so a name
+            # appearing twice in one handler would resolve to whichever the traversal
+            # yielded last. This asserts the strongest reading -- EVERY record build
+            # precedes EVERY close -- and cannot be satisfied by traversal luck.
             self.assertLess(
-                lines["_store_setup_failure"],
-                lines["_async_close_client"],
+                max(lines["_store_setup_failure"]),
+                min(lines["_async_close_client"]),
                 "the record must be built while the session is still there",
             )
             # And the pop it replaced must be gone: a pop after the write would delete

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -940,6 +940,68 @@ _CUSTOM_ENTITY_ATTRS: dict[str, frozenset[str]] = {
 }
 
 
+def _session_drop_reasons() -> tuple | None:
+    """The `SETUP_DROP_REASONS` tuple `client/session.py` declares, or None.
+
+    Parsed, never imported, the same idiom `_options_flow_conf_names` above applies to
+    config_flow and for the same kind of reason: session.py imports `aiohttp` at module
+    level and the stubs in this file do not provide it, so the module whose next drop
+    reason this guard exists to catch is precisely the one it must not fail to read.
+
+    None when the constant is not declared yet: the setup census that fills these
+    counts lands in a later commit, and this guard arms itself the moment it does
+    rather than being written from memory afterwards.
+    """
+    source = (
+        REPO_ROOT / "custom_components" / "addhon" / "client" / "session.py"
+    ).read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if "SETUP_DROP_REASONS" in names and isinstance(node.value, ast.Tuple):
+            return tuple(
+                element.value
+                for element in node.value.elts
+                if isinstance(element, ast.Constant)
+            )
+    return None
+
+
+def _probe_outcome_tokens() -> set[str]:
+    """Every string `probe_appliance_list` can put under "outcome", read from its body.
+
+    Read with `ast` rather than by calling the probe over a table of responses: a table
+    proves that the tokens it triggers are known, never that no OTHER token exists in
+    the function. This guard is about the tokens nobody thought to trigger.
+    """
+    source = (
+        REPO_ROOT
+        / "custom_components"
+        / "addhon"
+        / "client"
+        / "transport"
+        / "parse.py"
+    ).read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.FunctionDef) and node.name == "probe_appliance_list":
+            return {
+                value.value
+                for mapping in ast.walk(node)
+                if isinstance(mapping, ast.Dict)
+                for key, value in zip(mapping.keys, mapping.values)
+                if isinstance(key, ast.Constant)
+                and key.value == "outcome"
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            }
+    raise AssertionError(
+        "parse.probe_appliance_list was not found, so the outcome tokens it can "
+        "produce could not be read. If it was renamed, point this guard at the new "
+        "name -- do not delete it."
+    )
+
+
 class DiagnosticsDriftGuardTest(unittest.TestCase):
     def test_custom_mapped_attrs_are_not_reported_unmapped(self):
         """The behavioural half of the pin above: the EFFECT the comment there claims,
@@ -966,6 +1028,52 @@ class DiagnosticsDriftGuardTest(unittest.TestCase):
                 self.assertNotIn(
                     attr, cov["attributes_unmapped"], f"{app_type}.{attr}"
                 )
+
+    def test_stop_tokens_track_the_parser_path(self):
+        """`stopped_at` may only name a segment the parser actually walks.
+
+        The token set is duplicated in diagnostics.py rather than imported (the HA
+        layer imports no transport internals anywhere else in this file), and this is
+        what makes the duplication safe: a level added to or renamed in the response
+        path has to be reflected here, or the dump would answer "other" for the very
+        level it was added to report.
+        """
+        from custom_components.addhon.client.transport import parse
+
+        self.assertEqual(set(parse.APPLIANCE_LIST_PATH), set(diagnostics._FETCH_STOPS))
+
+    def test_node_type_tokens_track_the_probe(self):
+        # "other" exists only on the reader side: the probe emits it too, but the
+        # reader must also be able to say it about a token the probe never wrote.
+        from custom_components.addhon.client.transport import parse
+
+        self.assertEqual(
+            set(parse._NODE_TYPES) | {"other"}, set(diagnostics._FETCH_NODE_TYPES)
+        )
+
+    def test_skip_reason_tokens_track_the_session(self):
+        # An ASSERT, not a skip. The hatch this replaces was written while the setup
+        # census was still a separate commit, so `None` meant "not landed yet"; the
+        # constant has landed, and from here `None` can only mean the one thing this
+        # guard exists to catch -- session.py stopped declaring SETUP_DROP_REASONS in
+        # a form the parser recognises. A skip would report success for exactly that.
+        # Same standard as `_probe_outcome_tokens` beside it, which raises.
+        declared = _session_drop_reasons()
+        self.assertIsNotNone(
+            declared,
+            "client/session.py no longer declares SETUP_DROP_REASONS as a tuple "
+            "literal: point this guard at the new form -- do not delete it.",
+        )
+        self.assertEqual(declared, diagnostics._FETCH_SKIP_REASONS)
+
+    def test_fetch_outcomes_track_the_writers(self):
+        # Two writers fill `outcome`: the probe, and the except branch of
+        # load_appliances, which is the only producer of "raised". The reader's domain
+        # must be exactly their union -- a token missing here is printed as "other",
+        # which is the one reading the block cannot afford for its main field.
+        self.assertEqual(
+            _probe_outcome_tokens() | {"raised"}, set(diagnostics._FETCH_OUTCOMES)
+        )
 
     def test_ac_climate_params_pinned(self):
         self.assertEqual(
@@ -1445,6 +1553,535 @@ class LastPollCensusDiagnosticsTest(unittest.TestCase):
         blob = json.dumps(result)  # also proves the block is serializable as it stands
         for leak in ("Kitchen Washer", "AA:BB:CC:DD:EE:FF", "decode error for"):
             self.assertNotIn(leak, blob, leak)
+
+
+class _FetchClient:
+    """The client double `_build_last_fetch` reads.
+
+    It carries only the five names the block asks for, and every one of them is
+    optional: the reader reaches them through `getattr(..., None)` precisely because a
+    client between two sessions, or a double in a test, is not obliged to have them.
+    """
+
+    def __init__(self, census=None, **attrs) -> None:
+        self.last_appliance_fetch = census
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+
+class _RaisingFetchClient:
+    """A client whose `setup_drops` raises, the way a property reading a session
+    being torn down on the hOn loop thread can."""
+
+    last_appliance_fetch = {"outcome": "ok", "count": 0}
+
+    @property
+    def setup_drops(self):
+        raise RuntimeError("session torn down mid-dump")
+
+
+class LastFetchDiagnosticsTest(unittest.TestCase):
+    """The dump names the level at which the appliance-list walk stopped.
+
+    The field case: the cloud answered with `result` keys ['executionTime', 'modules',
+    'success'] and `modules` keys ['applianceList'], the hOn app showed two appliances
+    for the account, and the dump read `"appliances": []` with `"last_error": null`.
+    That file is compatible with six different states, and the maintainer could not
+    answer the only question that matters -- whose bug it is -- from it. `last_fetch`
+    is what separates them, and every value in it is a token of a frozenset written in
+    diagnostics.py, a range-checked int, a shape-checked catalog label or an instant
+    `_stamp_text` validated: never a string chosen by the cloud.
+    """
+
+    def _dump(self, client=None, coordinator=None):
+        hass = FakeHass(coordinator if coordinator is not None else FakeCoordinator({}))
+        if client is not None:
+            hass.data[DOMAIN]["e1"]["client"] = client
+        return _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+
+    def _fetch(self, census=None, **attrs):
+        return self._dump(_FetchClient(census, **attrs))["last_fetch"]
+
+    def test_last_fetch_is_never_null(self) -> None:
+        # `null` is the reading this block exists to abolish: it is what a dump says
+        # today for "no session", "no fetch" and "a fetch this reader could not read"
+        # alike. Every harness in this file must produce a dict with a state token.
+        dumps = [
+            self._dump(),
+            self._dump(_FetchClient()),
+            self._dump(_FetchClient({"outcome": "ok", "count": 0})),
+            self._dump(_FetchClient("not-a-mapping")),
+            self._dump(_RaisingFetchClient()),
+            _entry_diag()[0],
+        ]
+        for result in dumps:
+            with self.subTest(state=result["last_fetch"].get("state")):
+                self.assertIsInstance(result["last_fetch"], dict)
+                self.assertIn(result["last_fetch"]["state"], diagnostics._FETCH_STATES)
+
+    def test_no_client_reads_client_absent(self) -> None:
+        # The whole suite runs on a bucket holding only {"coordinator": ...}, which is
+        # the failed-setup state: there is no client to ask, and saying so is a
+        # different statement from "the client was asked and had nothing".
+        fetch = self._dump()["last_fetch"]
+        self.assertEqual("client_absent", fetch["state"])
+        for key, value in fetch.items():
+            if key == "state":
+                continue
+            with self.subTest(key=key):
+                self.assertEqual({} if key in ("skipped", "degraded") else None, value)
+
+    def test_a_client_without_a_census_reads_never_ran(self) -> None:
+        fetch = self._fetch(None)
+        self.assertEqual("never_ran", fetch["state"])
+        self.assertIsNone(fetch["outcome"])
+
+    def test_the_key_set_is_the_same_in_every_state(self) -> None:
+        # A field-by-field diff between two downloads of the same issue is only
+        # meaningful if the key set is stable: a block that drops keys when it has
+        # nothing to say turns "this got worse" into "this file is shaped differently".
+        blocks = {
+            "recorded": self._fetch({"outcome": "ok", "count": 0}),
+            "never_ran": self._fetch(None),
+            "client_absent": self._dump()["last_fetch"],
+            "unreadable": self._dump(_RaisingFetchClient())["last_fetch"],
+        }
+        for state, block in blocks.items():
+            with self.subTest(state=state):
+                self.assertEqual(state, block["state"])
+        key_sets = {frozenset(block) for block in blocks.values()}
+        self.assertEqual(1, len(key_sets), key_sets)
+        self.assertEqual(set(diagnostics._FETCH_STATES), set(blocks))
+        # The empty halves are built PER CALL, not spread from a module constant.
+        # `{**CONST}` is a shallow copy, so a constant would hand every block in the
+        # process the same two dicts -- aliased to the constant itself -- and one
+        # in-place write anywhere downstream would then appear in every later dump of
+        # every config entry. The key set is what the constant existed to stabilise,
+        # and it is asserted above, so nothing is lost by unsharing the values.
+        for left, right in (("never_ran", "client_absent"), ("client_absent", "unreadable")):
+            for key in ("skipped", "degraded"):
+                with self.subTest(pair=(left, right), key=key):
+                    self.assertIsNot(blocks[left][key], blocks[right][key])
+        blocks["never_ran"]["skipped"]["written_by_a_downstream_caller"] = 1
+        self.assertEqual({}, self._fetch(None)["skipped"])
+
+    def test_an_empty_payload_and_a_schema_drift_no_longer_look_alike(self) -> None:
+        # THE acceptance test. Both dumps carry `"appliances": []` and a null
+        # `last_error` -- the exact file the field report arrived as -- and until now
+        # nothing else in the document differed at all.
+        empty = self._fetch({"status": 200, "outcome": "ok", "count": 0})
+        drift = self._fetch(
+            {
+                "status": 200,
+                "outcome": "missing_key",
+                "stopped_at": "payload",
+                "node_type": "dict",
+                "siblings": 2,
+                "count": None,
+            }
+        )
+        self.assertNotEqual(empty, drift)
+        # The cloud answered, and it answered with nothing: the bug is not ours.
+        self.assertEqual("ok", empty["outcome"])
+        self.assertEqual(0, empty["count"])
+        # The cloud answered with something our walk could not follow, and the block
+        # says at which level to look.
+        self.assertEqual("missing_key", drift["outcome"])
+        self.assertEqual("payload", drift["stopped_at"])
+        self.assertEqual(2, drift["siblings"])
+        self.assertIsNone(drift["count"])
+
+    def test_the_census_the_probe_builds_survives_into_the_dump(self) -> None:
+        # Built by the WRITER rather than hand-written, so this pins the whole path:
+        # every key `probe_appliance_list` emits is a key this reader looks up, and a
+        # rename on either side would silently turn the block's main field into
+        # `null` while both halves kept their own tests green.
+        from custom_components.addhon.client.transport.parse import probe_appliance_list
+
+        # The envelope the field report actually carried: `result` keys
+        # ['executionTime', 'modules', 'success'], `modules` keys ['applianceList'].
+        # What sat under `applianceList` is exactly what no dump could say, which is
+        # why the walk has to report the level it stopped at.
+        drifted = {
+            "executionTime": 1.2,
+            "modules": {"applianceList": {"AA:BB:CC:DD:EE:FF": 1}},
+            "success": True,
+        }
+        empty = {"modules": {"applianceList": {"payload": {"appliances": []}}}}
+        blocks = [
+            self._fetch(
+                {"at": FROZEN, "status": 200, "code": None, **probe_appliance_list(body)}
+            )
+            for body in (drifted, empty)
+        ]
+        self.assertNotEqual(blocks[0], blocks[1])
+        self.assertEqual("missing_key", blocks[0]["outcome"])
+        self.assertEqual("payload", blocks[0]["stopped_at"])
+        self.assertEqual(1, blocks[0]["siblings"])
+        self.assertIsNone(blocks[0]["count"])
+        self.assertEqual("ok", blocks[1]["outcome"])
+        self.assertEqual(0, blocks[1]["count"])
+        # The sibling key beside the level we stopped at was chosen by the cloud.
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(blocks))
+
+    def test_a_dropped_inventory_is_not_an_empty_account(self) -> None:
+        # State (D): the cloud sent two appliances and this setup dropped both at the
+        # empty-MAC guard, which is the one drop in session.py that does not even log.
+        fetch = self._fetch(
+            {"status": 200, "outcome": "ok", "count": 2},
+            setup_expanded=2,
+            appliance_count=0,
+            setup_drops={"mac_empty": 2},
+        )
+        self.assertEqual(2, fetch["count"])
+        self.assertEqual(2, fetch["expanded"])
+        self.assertEqual(0, fetch["built"])
+        self.assertEqual({"mac_empty": 2}, fetch["skipped"])
+
+    def test_a_moved_endpoint_is_visible_as_a_status(self) -> None:
+        # State (C): a 4xx with a JSON body is delivered as a success by
+        # connection.py, so without the status it is indistinguishable from drift.
+        fetch = self._fetch(
+            {"status": 404, "outcome": "missing_key", "stopped_at": "modules"}
+        )
+        self.assertEqual(404, fetch["status"])
+        self.assertEqual("modules", fetch["stopped_at"])
+
+    def test_a_raised_fetch_is_visible_as_an_outcome(self) -> None:
+        # State (E): the POST never reached a body. Recorded on the error path, which
+        # is the half a census written after the call could never carry.
+        fetch = self._fetch(
+            {"status": None, "code": "ADDHON-470", "outcome": "raised"}
+        )
+        self.assertEqual("recorded", fetch["state"])
+        self.assertEqual("raised", fetch["outcome"])
+        self.assertEqual("ADDHON-470", fetch["code"])
+        self.assertIsNone(fetch["status"])
+
+    def test_a_zoned_account_reconciles(self) -> None:
+        # State (H): one cloud entry with `zone: 2` is expanded into three appliance
+        # objects, so `expanded > count` is a SANE reading and the block must be able
+        # to show it rather than look like an inconsistency.
+        fetch = self._fetch(
+            {"status": 200, "outcome": "ok", "count": 1},
+            setup_expanded=3,
+            appliance_count=3,
+        )
+        self.assertEqual(1, fetch["count"])
+        self.assertEqual(3, fetch["expanded"])
+        self.assertEqual(3, fetch["built"])
+
+    def test_unknown_tokens_collapse_to_other(self) -> None:
+        # The leak test on the reader side. Every token field is looked up in a
+        # frozenset written in diagnostics.py; a value from anywhere else is reported
+        # as "other", which keeps the finding ("the writer said something this build
+        # does not know") and loses the value.
+        fetch = self._fetch(
+            {
+                "outcome": "3C:71:BF:AA:BB:CC",
+                "stopped_at": "user@example.com",
+                "node_type": "Kitchen Washer",
+            }
+        )
+        self.assertEqual("other", fetch["outcome"])
+        self.assertEqual("other", fetch["stopped_at"])
+        self.assertEqual("other", fetch["node_type"])
+        blob = json.dumps(self._dump(_FetchClient({
+            "outcome": "3C:71:BF:AA:BB:CC",
+            "stopped_at": "user@example.com",
+            "node_type": "Kitchen Washer",
+        })))
+        for leak in ("3C:71:BF:AA:BB:CC", "user@example.com", "Kitchen Washer"):
+            self.assertNotIn(leak, blob, leak)
+
+    def test_a_str_subclass_token_cannot_smuggle_text(self) -> None:
+        # `isinstance` admits subclasses, and a str subclass may define __eq__/__hash__
+        # so that it IS "ok" for every membership test while its characters are a MAC.
+        # `_closed_token` compares with `type(value) is str` for exactly this, and the
+        # JSON encoder writes characters, not equality classes.
+        class Tok(str):
+            def __eq__(self, other):
+                return other == "ok" or str.__eq__(self, other)
+
+            def __ne__(self, other):
+                return not self.__eq__(other)
+
+            def __hash__(self):
+                return hash("ok")
+
+        smuggler = Tok("AA:BB:CC:DD:EE:FF")
+        # The premise of the test: this object passes the membership test the naive
+        # implementation would have used.
+        self.assertIn(smuggler, diagnostics._FETCH_OUTCOMES)
+        result = self._dump(_FetchClient({"outcome": smuggler}))
+        self.assertEqual("other", result["last_fetch"]["outcome"])
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(result))
+
+    def test_an_unknown_code_label_is_dropped(self) -> None:
+        # A catalog label cannot be enumerated here without duplicating error_codes.py,
+        # so it is bounded by shape. Anything that is not "ADDHON-" plus exactly three
+        # digits is not a label this build can vouch for.
+        for junk in ("not-a-label", "ADDHON-99", "ADDHON-4700"):
+            with self.subTest(code=junk):
+                self.assertIsNone(self._fetch({"code": junk})["code"])
+
+    def test_unknown_skip_reasons_are_not_copied(self) -> None:
+        # `_skip_census` iterates the ALLOWLIST, never the mapping it received: a key
+        # chosen by the writer is a key `_redact` would publish, because `_redact`
+        # masks by key name and has never heard of this one.
+        fetch = self._fetch(
+            {"outcome": "ok", "count": 2},
+            setup_drops={"AA:BB:CC:DD:EE:FF": 1, "mac_empty": 2},
+        )
+        self.assertEqual({"mac_empty": 2}, fetch["skipped"])
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(fetch))
+
+    def test_unknown_degraded_keys_are_not_copied(self) -> None:
+        # The session keys its degradation ledger by f"{mac}#{zone}"; the reduction to
+        # labels happens on the session side, and this is the second wall: a key that
+        # is not a label is dropped whole, value included.
+        fetch = self._fetch(
+            {"outcome": "ok", "count": 2},
+            degraded_census={"AA:BB:CC#0": 3, "ADDHON-230": 2},
+        )
+        self.assertEqual({"ADDHON-230": 2}, fetch["degraded"])
+        self.assertNotIn("AA:BB:CC#0", json.dumps(fetch))
+
+    def test_a_skip_count_that_is_not_a_count_is_dropped(self) -> None:
+        # The two tests above put their hostile string in the KEY, which the allowlist
+        # refuses without ever looking at the value. This is the other half: a KNOWN
+        # key whose VALUE is text. `_skip_census` runs `_bounded_int` on it for
+        # exactly this reason -- the census arrives through a `getattr` on
+        # `_hon_instance`, which in a test, or beside a session double, is any object
+        # at all -- and without this the check is invisible to the suite and the next
+        # simplification writes `out[reason] = raw.get(reason)`.
+        fetch = self._fetch(
+            {"outcome": "ok", "count": 2},
+            setup_drops={"mac_empty": "AA:BB:CC:DD:EE:FF"},
+        )
+        self.assertEqual({}, fetch["skipped"])
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(fetch))
+        # A bool is refused too: isinstance(True, int) is True, and `"mac_empty": true`
+        # is a reader's problem forever.
+        boolean = self._fetch({"outcome": "ok"}, setup_drops={"mac_empty": True})
+        self.assertEqual({}, boolean["skipped"])
+
+    def test_a_degraded_count_that_is_not_a_count_drops_the_whole_row(self) -> None:
+        # Keys and values move together or not at all: a valid label with a text count
+        # takes the label out with it, rather than publishing the label beside a
+        # value this reader could not vouch for.
+        fetch = self._fetch(
+            {"outcome": "ok", "count": 2},
+            degraded_census={"ADDHON-230": "AA:BB:CC:DD:EE:FF"},
+        )
+        self.assertEqual({}, fetch["degraded"])
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(fetch))
+
+    def test_the_three_setup_counters_are_range_checked_like_the_others(self) -> None:
+        # `count` and `status` have junk-value tests; `siblings`, `expanded` and
+        # `built` had none, so their `_bounded_int` calls could be deleted with the
+        # suite green -- and three of the block's fourteen fields would then publish
+        # whatever the writer returned. Same table, same three refusals.
+        self.assertIsNone(self._fetch({"outcome": "ok", "siblings": True})["siblings"])
+        self.assertIsNone(self._fetch({"outcome": "ok", "siblings": "2"})["siblings"])
+        self.assertIsNone(self._fetch({"outcome": "ok", "siblings": -1})["siblings"])
+        for junk in ("3", True, -1, diagnostics._FETCH_MAX_INT + 1):
+            with self.subTest(junk=junk):
+                self.assertIsNone(
+                    self._fetch({"outcome": "ok"}, setup_expanded=junk)["expanded"]
+                )
+                self.assertIsNone(
+                    self._fetch({"outcome": "ok"}, appliance_count=junk)["built"]
+                )
+        # ...and a legitimate value still passes, so the assertions above are not
+        # passing merely because the fields are always null.
+        healthy = self._fetch({"outcome": "ok"}, setup_expanded=3, appliance_count=2)
+        self.assertEqual(3, healthy["expanded"])
+        self.assertEqual(2, healthy["built"])
+
+    def test_a_huge_degraded_map_is_capped(self) -> None:
+        # 20 as a LITERAL, not as `diagnostics._FETCH_MAX_LABEL_ROWS`: an expected
+        # value borrowed from the code under test pins the existence of a cap and
+        # never its value, so widening the constant to 1000 would leave this green
+        # while the block grew fifty times. The input is 100 valid labels, so the
+        # answer is exact and the number a reviewer wants to see is in the test.
+        census = {f"ADDHON-{200 + i}": 1 for i in range(100)}
+        fetch = self._fetch({"outcome": "ok", "count": 1}, degraded_census=census)
+        self.assertEqual(20, len(fetch["degraded"]))
+        self.assertEqual(20, diagnostics._FETCH_MAX_LABEL_ROWS)
+
+    def test_out_of_range_status_is_refused(self) -> None:
+        # `True` is in the list on purpose: isinstance(True, int) is True, and a
+        # `"status": true` in the document would be a reader's problem forever.
+        for junk in (99, 600, "200", True):
+            with self.subTest(status=junk):
+                self.assertIsNone(self._fetch({"status": junk})["status"])
+
+    def test_a_boolean_count_is_not_an_int(self) -> None:
+        self.assertIsNone(self._fetch({"outcome": "ok", "count": True})["count"])
+
+    def test_a_string_instant_is_never_echoed(self) -> None:
+        # `_stamp_text` promises its output was built by datetime.isoformat. A cloud
+        # string that merely looks like an instant would break that promise while
+        # looking identical in the file.
+        fetch = self._fetch({"at": "2026-08-21T04:11:07"})
+        self.assertIsNone(fetch["at"])
+        self.assertIsNone(fetch["age_s"])
+        self.assertNotIn("2026-08-21T04:11:07", json.dumps(fetch))
+
+    def test_a_naive_instant_yields_neither_a_stamp_nor_an_age(self) -> None:
+        # `_as_utc(..., assume_naive_utc=False)` returns None for a naive datetime, so
+        # both halves blank together. The writer always stamps
+        # `datetime.now(timezone.utc)`, so a naive value can only come from a foreign
+        # object, and refusing it is the right answer.
+        fetch = self._fetch({"at": datetime(2026, 8, 21, 4, 11, 7)})
+        self.assertIsNone(fetch["at"])
+        self.assertIsNone(fetch["age_s"])
+
+    def test_at_and_age_move_together(self) -> None:
+        # Both halves hang off ONE `moment`, so an instant `_as_utc` refuses blanks
+        # BOTH: that is the coupling that matters, because it is what stops a value
+        # this reader could not validate from being half-published.
+        with _FrozenClock(FROZEN):
+            for at in (
+                FROZEN - timedelta(seconds=30),
+                datetime(2026, 8, 21, 4, 11, 7),
+                "2026-08-21T04:11:07",
+                object(),
+            ):
+                with self.subTest(at=type(at).__name__):
+                    fetch = self._fetch({"at": at})
+                    self.assertEqual(fetch["at"] is None, fetch["age_s"] is None)
+
+    def test_an_out_of_range_age_keeps_the_instant_that_explains_it(self) -> None:
+        # The FIRST of the two ways the halves part, and the reason the coupling is
+        # not stated as an invariant. A host that stamped the fetch before NTP
+        # corrected its clock -- Home Assistant on a Pi with no RTC, a container
+        # started before sync -- writes an instant `_as_utc` accepts and `_stamp_text`
+        # renders, whose age then falls outside +/-10 years and is refused.
+        #
+        # `at` MUST survive that: it is the only field in the document that explains
+        # why every other age in the same dump looks absurd. Blanking it to satisfy a
+        # tidier-sounding invariant would delete the finding.
+        before_ntp = datetime(1970, 1, 1, 0, 0, 11, tzinfo=timezone.utc)
+        with _FrozenClock(FROZEN):
+            skewed = self._fetch({"outcome": "ok", "count": 0, "at": before_ntp})
+        self.assertEqual("1970-01-01T00:00:11+00:00", skewed["at"])
+        self.assertEqual(before_ntp.isoformat(), skewed["at"])
+        self.assertIsNone(skewed["age_s"])
+
+    def test_a_hostile_isoformat_loses_the_stamp_and_keeps_the_age(self) -> None:
+        # The SECOND way they part, and the test that pins `at` to `_stamp_text`
+        # rather than to `datetime.isoformat`. `_as_utc` accepts a datetime SUBCLASS
+        # (it is a datetime), `_age_seconds` computes a real age from it, and
+        # `_stamp_text` is the only thing standing between an overridden
+        # `isoformat()` and the file: it re-validates the rendered text against
+        # `_ISO_RE` and a 40-character cap.
+        #
+        # Every other test in this class is satisfied by a bare `moment.isoformat()`
+        # -- the string cases never reach the render at all, because `_as_utc`
+        # refused them first -- so without this one the validator is dead weight as
+        # far as the suite can tell, and the next simplification deletes it.
+        class _HostileStamp(datetime):
+            def isoformat(self, *args, **kwargs):
+                return "AA:BB:CC:DD:EE:FF"
+
+        moment = _HostileStamp(2026, 8, 13, 7, 9, 10, tzinfo=timezone.utc)
+        with _FrozenClock(FROZEN):
+            result = self._dump(_FetchClient({"outcome": "ok", "count": 0, "at": moment}))
+        fetch = result["last_fetch"]
+        self.assertIsNone(fetch["at"])
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(result))
+        # The age survives because it is COMPUTED, not echoed, and `generated_at` in
+        # the same document lets a reader place it.
+        self.assertEqual(30, fetch["age_s"])
+
+    def test_an_absurd_age_is_refused(self) -> None:
+        with _FrozenClock(FROZEN):
+            ancient = self._fetch({"at": FROZEN - timedelta(days=365 * 50)})
+            recent = self._fetch({"at": FROZEN - timedelta(days=365 * 5)})
+            ahead = self._fetch({"at": FROZEN + timedelta(days=365 * 5)})
+        self.assertIsNone(ancient["age_s"])
+        self.assertGreater(recent["age_s"], 0)
+        self.assertLessEqual(recent["age_s"], diagnostics._FETCH_MAX_AGE_S)
+        # A NEGATIVE age is a finding, not nonsense: it says the reporter's clock and
+        # the one that stamped the fetch disagree. The bound must not erase it.
+        self.assertLess(ahead["age_s"], 0)
+
+    def test_last_fetch_does_not_read_the_clock_again(self) -> None:
+        # `now` is passed in, like every other age in the document, so the whole dump
+        # still describes one instant.
+        moment = FROZEN - timedelta(seconds=51_840)
+        with _FrozenClock(FROZEN) as clock:
+            fetch = self._fetch({"at": moment})
+        self.assertEqual(1, clock.calls)
+        self.assertEqual(moment.isoformat(), fetch["at"])
+        self.assertEqual(51_840, fetch["age_s"])
+
+    def test_last_fetch_sits_between_last_poll_and_appliances(self) -> None:
+        # The placement IS the content of the change: the two blocks answer the same
+        # family of question ("what did the cloud give us") and a reader who found
+        # `last_poll` must fall over this one without being told it exists.
+        result = self._dump(_FetchClient({"outcome": "ok", "count": 0}))
+        self.assertEqual(["last_poll", "last_fetch", "appliances"], list(result)[-3:])
+        # And it did not take over the first key, which `generated_at` owns.
+        self.assertEqual("generated_at", next(iter(result)))
+
+    def test_a_populated_fetch_block_carries_no_identity(self) -> None:
+        # The end-to-end leak check, over the FINISHED document rather than the block:
+        # `last_fetch` skips `_redact` by design, exactly like `last_poll` beside it,
+        # so what protects it has to be visible here.
+        census = {
+            "at": FROZEN,
+            "status": 200,
+            "code": "decode error for Kitchen Washer at AA:BB:CC:DD:EE:FF",
+            "outcome": "ok",
+            "stopped_at": "PLAINTEXT-SERIAL",
+            "node_type": "user@example.com",
+            "count": 2,
+        }
+        with _FrozenClock(FROZEN):
+            result = self._dump(
+                _FetchClient(
+                    census,
+                    setup_expanded=2,
+                    appliance_count=0,
+                    setup_drops={"AA:BB:CC:DD:EE:FF": 1, "mac_empty": 2},
+                    degraded_census={"AA:BB:CC:DD:EE:FF#0": 1, "ADDHON-230": 2},
+                ),
+                _build_coordinator(),
+            )
+        blob = json.dumps(result)
+        for leak in (
+            "Kitchen Washer",
+            "AA:BB:CC:DD:EE:FF",
+            "PLAINTEXT-SERIAL",
+            "user@example.com",
+            "decode error for",
+        ):
+            self.assertNotIn(leak, blob, leak)
+        # ...and the block still said everything it was asked to say.
+        self.assertEqual(2, result["last_fetch"]["count"])
+        self.assertEqual({"mac_empty": 2}, result["last_fetch"]["skipped"])
+        self.assertEqual({"ADDHON-230": 2}, result["last_fetch"]["degraded"])
+
+    def test_a_foreign_client_object_yields_never_ran(self) -> None:
+        # Everything that is not a Mapping is the same state: nothing was recorded on
+        # this client. The reader does not try to interpret it further.
+        for census in ("x", [], None, 3):
+            with self.subTest(census=census):
+                self.assertEqual("never_ran", self._fetch(census)["state"])
+
+    def test_a_raising_client_property_degrades_the_block_not_the_dump(self) -> None:
+        # setup() runs on the dedicated hOn loop thread while a Download Diagnostics
+        # runs on HA's event loop, so any accessor here can raise on a session being
+        # torn down. A convenience field must never take the whole download with it --
+        # the download is the artefact the whole exercise exists to make producible.
+        result = self._dump(_RaisingFetchClient(), _build_coordinator())
+        self.assertEqual("unreadable", result["last_fetch"]["state"])
+        self.assertEqual(2, len(result["appliances"]))
+        self.assertIn("generated_at", result)
+        self.assertIn("platforms", result)
 
 
 # --- Task 10: air purifier coverage and passive future-capability capture -----

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1290,7 +1290,9 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
         # A 5.9.3 field dump read `"last_error": null, "appliances": []` and was
         # triaged as an account owning no appliances; it was a failed setup, whose
         # client never reached hass.data. `null` must not be the answer to a
-        # question nobody could ask.
+        # question nobody could ask. A failed setup now leaves a record and reads
+        # `setup_failed` instead; this marker covers what is left, an entry with no
+        # session and nothing said about why.
         result = _run(diagnostics.async_get_config_entry_diagnostics(FakeHass(_build_coordinator()), FakeEntry()))
         self.assertEqual({"status": "client_absent"}, result["last_error"])
         # And it must not be readable as a recorded failure: a consumer keying on
@@ -1317,12 +1319,14 @@ class LastErrorDiagnosticsTest(unittest.TestCase):
         self.assertNotEqual(healthy["last_error"], failed_setup["last_error"])
 
     def test_last_error_folds_missing_entry_data_into_the_same_marker(self) -> None:
-        # "No entry data for this entry" and "entry data without a client" are ONE
-        # state on purpose (diagnostics.py `_last_error`): __init__ writes the bucket
-        # with the client inside it and pops it whole, so the two cannot be reached
-        # separately, and a second token would be a distinction nothing writes. This
-        # pins the fold: an entry absent from hass.data reports the same marker as
-        # the client-less bucket above.
+        # "No entry data for this entry" and "a bucket with neither a client nor a
+        # failure record" are ONE state on purpose (diagnostics.py `_last_error`).
+        # They were once the same for a stronger reason -- nothing could produce the
+        # second -- and `_store_setup_failure` has since made a client-less bucket a
+        # real state, but a client-less bucket with NOTHING in it still is not, and
+        # inventing a token for it would send a triager hunting a distinction nothing
+        # writes. This pins the fold: an entry absent from hass.data reports the same
+        # marker as the record-less bucket above.
         hass = FakeHass(_build_coordinator(), entry_id="other-entry")
         result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
         self.assertEqual({"status": "client_absent"}, result["last_error"])
@@ -1620,9 +1624,11 @@ class LastFetchDiagnosticsTest(unittest.TestCase):
                 self.assertIn(result["last_fetch"]["state"], diagnostics._FETCH_STATES)
 
     def test_no_client_reads_client_absent(self) -> None:
-        # The whole suite runs on a bucket holding only {"coordinator": ...}, which is
-        # the failed-setup state: there is no client to ask, and saying so is a
-        # different statement from "the client was asked and had nothing".
+        # The whole suite runs on a bucket holding only {"coordinator": ...}: no
+        # client to ask, and no record of a failure either. Saying so is a different
+        # statement from "the client was asked and had nothing" -- and, since
+        # `_store_setup_failure` exists, a different one from "the setup failed, and
+        # here is what the call returned before it did" (SetupFailureRecordTest).
         fetch = self._dump()["last_fetch"]
         self.assertEqual("client_absent", fetch["state"])
         for key, value in fetch.items():
@@ -6702,6 +6708,340 @@ class TheNestedParametersContainerIsAlwaysAPlainDictTest(unittest.TestCase):
                     type(landed) is dict or not isinstance(landed, Mapping),
                     f"a {type(landed).__name__} reached the dead fallback",
                 )
+
+
+class _FailedCode:
+    """The `error_codes` singleton `HonClient.last_error_code` holds after a failure."""
+
+    label = "ADDHON-400"
+    reason_en = "Validation failed"
+
+
+class _FailedClient:
+    """A client as `_store_setup_failure` finds it: the session already gone (so the
+    live census reads None) and the snapshot `setup_sync` took in its place."""
+
+    last_error_code = _FailedCode
+    last_error_phase = "load_appliances/auth"
+    last_phase_ledger = [{"phase": "auth", "seconds": 2.1, "outcome": "error"}]
+    last_appliance_fetch = None
+    last_setup_fetch = {"outcome": "raised", "code": "ADDHON-470", "status": None}
+    setup_expanded = 0
+    appliance_count = 0
+    setup_drops = {}
+    degraded_census = {}
+
+
+def _addhon_init():
+    """The integration package, which owns the writer half of the record."""
+    return importlib.import_module("custom_components.addhon")
+
+
+class SetupFailureRecordTest(unittest.TestCase):
+    """A dump taken after a FAILED setup says why it failed.
+
+    Until the record existed both failure branches of `async_setup_entry` popped the
+    entry bucket whole, so `last_error` read `{"status": "client_absent"}` -- the same
+    answer a dump gives while Home Assistant is still retrying -- and `last_fetch` read
+    `client_absent` too. Everything built to explain a failed setup (the per-phase
+    ledger of #76, the appliance-list census) was unreachable in the one dump a
+    reporter can produce for it.
+    """
+
+    def _hass_with_record(self, record):
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"] = {"setup_failure": record}
+        return hass
+
+    def _dump_record(self, record):
+        return _run(
+            diagnostics.async_get_config_entry_diagnostics(
+                self._hass_with_record(record), FakeEntry()
+            )
+        )
+
+    def _record(self, **over):
+        record = {
+            "code": "ADDHON-400",
+            "phase": "load_appliances/auth",
+            "phase_ledger": [{"phase": "auth", "seconds": 2.1, "outcome": "error"}],
+            "fetch": None,
+            "at": datetime(2026, 8, 24, 9, 0, 0, tzinfo=timezone.utc),
+        }
+        record.update(over)
+        return record
+
+    # -- the writer -------------------------------------------------------------
+
+    def test_a_failed_setup_replaces_the_bucket_instead_of_popping_it(self) -> None:
+        # REPLACES, not merges: a coordinator and a client the setup could not finish
+        # handing over must not survive it. The record is the only key left.
+        init = _addhon_init()
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"]["client"] = _FailedClient()
+        init._store_setup_failure(hass, FakeEntry(), _FailedClient())
+        bucket = hass.data[DOMAIN]["e1"]
+        self.assertEqual({"setup_failure"}, set(bucket))
+        self.assertEqual("ADDHON-400", bucket["setup_failure"]["code"])
+        self.assertEqual("load_appliances/auth", bucket["setup_failure"]["phase"])
+
+    def test_the_record_stores_the_label_and_never_the_code_object(self) -> None:
+        # The reason is resolved from the catalog at READ time, so the sentence in the
+        # dump comes from error_codes.py in the running version. A record that carried
+        # the object (or its text) would put a value from another process's catalog --
+        # or from whatever a future writer decides to store -- into the document.
+        init = _addhon_init()
+        hass = FakeHass(_build_coordinator())
+        init._store_setup_failure(hass, FakeEntry(), _FailedClient())
+        record = hass.data[DOMAIN]["e1"]["setup_failure"]
+        self.assertEqual("ADDHON-400", record["code"])
+        self.assertNotIn("reason", record)
+        self.assertIsInstance(record["at"], datetime)
+        self.assertIsNotNone(record["at"].tzinfo)
+
+    def test_the_record_falls_back_to_the_snapshot_when_the_session_is_gone(self) -> None:
+        # THE reason `last_setup_fetch` exists. A failure raised inside setup_sync has
+        # already closed the session there, so the live property reads None and the
+        # census of the call would be gone -- with it, the only evidence of a POST that
+        # never reached a body.
+        init = _addhon_init()
+        hass = FakeHass(_build_coordinator())
+        init._store_setup_failure(hass, FakeEntry(), _FailedClient())
+        fetch = hass.data[DOMAIN]["e1"]["setup_failure"]["fetch"]
+        self.assertEqual("raised", fetch["outcome"])
+        self.assertEqual("ADDHON-470", fetch["code"])
+        # The four counters are flattened in beside it, so the reader has one source.
+        for key in ("expanded", "built", "skipped", "degraded"):
+            self.assertIn(key, fetch)
+
+    def test_a_live_census_wins_over_the_snapshot(self) -> None:
+        # A setup that failed AFTER the client came up (the first coordinator refresh
+        # raising ConfigEntryNotReady) still has its session: the live census describes
+        # the same call and is the fresher of the two.
+        init = _addhon_init()
+        client = _FailedClient()
+        client.last_appliance_fetch = {"outcome": "ok", "count": 2}
+        hass = FakeHass(_build_coordinator())
+        init._store_setup_failure(hass, FakeEntry(), client)
+        self.assertEqual(
+            "ok", hass.data[DOMAIN]["e1"]["setup_failure"]["fetch"]["outcome"]
+        )
+
+    def test_removing_the_entry_drops_the_record(self) -> None:
+        # The only hook that can: an entry whose setup never succeeded is never
+        # unloaded, so without async_remove_entry the record outlives the entry and
+        # keeps hass.data[DOMAIN] non-empty -- which is what async_unload_entry reads
+        # to decide the global debug services can go.
+        init = _addhon_init()
+        hass = self._hass_with_record(self._record())
+        _run(init.async_remove_entry(hass, FakeEntry()))
+        self.assertNotIn("e1", hass.data[DOMAIN])
+
+    def test_both_failure_branches_record_before_closing_the_client(self) -> None:
+        # Source-level, because async_setup_entry is not behaviourally testable in this
+        # harness (it runs the executor login, the first refresh and the platform
+        # forwarding). Order is the whole point: _async_close_client nulls the session
+        # `last_appliance_fetch` reads through, so a record built after it would have
+        # lost the live census in exactly the case that has one.
+        source = (
+            Path(diagnostics.__file__).resolve().parent / "__init__.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        setup = next(
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_setup_entry"
+        )
+        handlers = [h for h in ast.walk(setup) if isinstance(h, ast.ExceptHandler)]
+        recording = [
+            h for h in handlers
+            if any(
+                isinstance(call.func, ast.Name) and call.func.id == "_store_setup_failure"
+                for call in ast.walk(h) if isinstance(call, ast.Call)
+            )
+        ]
+        self.assertEqual(2, len(recording), "both failure branches must record")
+        for handler in recording:
+            # By LINE, not by the order ast.walk happens to yield: walk is breadth
+            # first, so an index into its output says nothing about which call runs
+            # first, and an assertion built on it passes whichever way the two are
+            # written. Verified by mutation: swapping the two statements leaves a
+            # walk-order assertion green and fails this one.
+            lines = {
+                node.func.id: node.lineno
+                for node in ast.walk(handler)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id in ("_store_setup_failure", "_async_close_client")
+            }
+            self.assertLess(
+                lines["_store_setup_failure"],
+                lines["_async_close_client"],
+                "the record must be built while the session is still there",
+            )
+            # And the pop it replaced must be gone: a pop after the write would delete
+            # the record, a pop before it would be dead code that reads as a live rule.
+            self.assertNotIn(
+                "pop",
+                [
+                    node.func.attr
+                    for node in ast.walk(handler)
+                    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                ],
+            )
+
+    # -- the reader -------------------------------------------------------------
+
+    def test_last_error_reports_the_failure_instead_of_client_absent(self) -> None:
+        result = self._dump_record(self._record())["last_error"]
+        self.assertEqual("setup_failed", result["status"])
+        self.assertEqual("ADDHON-400", result["code"])
+        self.assertEqual("2026-08-24T09:00:00+00:00", result["at"])
+        self.assertEqual(
+            [{"phase": "auth", "seconds": 2.1, "outcome": "error"}],
+            result["phase_ledger"],
+        )
+
+    def test_the_reason_is_looked_up_and_never_read_from_the_record(self) -> None:
+        # The record is written by us, but it has been through hass.data: a writer in a
+        # future version (or a test double, or an older record left by an install that
+        # has since been upgraded) is not a source this file publishes text from.
+        from custom_components.addhon import error_codes as ec
+
+        result = self._dump_record(
+            self._record(reason="3C:71:BF:AA:BB:CC belongs to user@example.com")
+        )["last_error"]
+        self.assertEqual(ec.NETWORK_TIMEOUT.reason_en, result["reason"])
+        self.assertNotIn("3C:71", json.dumps(result))
+
+    def test_an_unknown_label_reports_no_reason_rather_than_a_guess(self) -> None:
+        # 998 is registered by nothing (999 IS: it is UNKNOWN), so this is a label
+        # whose shape passes and whose meaning this version does not have -- a record
+        # written by a newer install, read after a downgrade.
+        result = self._dump_record(self._record(code="ADDHON-998"))["last_error"]
+        self.assertEqual("ADDHON-998", result["code"])
+        self.assertIsNone(result["reason"])
+
+    def test_a_hostile_label_and_a_hostile_phase_are_refused(self) -> None:
+        result = self._dump_record(
+            self._record(code="3C:71:BF:AA:BB:CC", phase="user@example.com")
+        )["last_error"]
+        self.assertIsNone(result["code"])
+        self.assertIsNone(result["reason"])
+        self.assertIsNone(result["phase"])
+        self.assertNotIn("3C:71", json.dumps(result))
+        self.assertNotIn("example.com", json.dumps(result))
+
+    def test_a_str_subclass_cannot_smuggle_text_through_the_phase(self) -> None:
+        # The B1 guard, on the field this change adds: `isinstance` admits a str
+        # SUBCLASS, which can match the regex and still render something else.
+        class Sneaky(str):
+            def __str__(self) -> str:  # pragma: no cover - only reached if the guard fails
+                return "3C:71:BF:AA:BB:CC"
+
+        result = self._dump_record(self._record(phase=Sneaky("authenticate")))["last_error"]
+        self.assertIsNone(result["phase"])
+
+    def test_a_naive_stamp_is_refused(self) -> None:
+        result = self._dump_record(
+            self._record(at=datetime(2026, 8, 24, 9, 0, 0))
+        )["last_error"]
+        self.assertIsNone(result["at"])
+
+    def test_a_foreign_ledger_shape_is_dropped_not_published(self) -> None:
+        result = self._dump_record(self._record(phase_ledger="user@example.com"))["last_error"]
+        self.assertNotIn("phase_ledger", result)
+
+    def test_last_fetch_reads_the_recorded_census(self) -> None:
+        # THE acceptance test of this change, and the state the previous one wrote but
+        # could not show: a POST that never reached a body. The census used to die with
+        # the session the raise tore down.
+        block = self._dump_record(
+            self._record(
+                fetch={
+                    "outcome": "raised",
+                    "code": "ADDHON-470",
+                    "status": None,
+                    "expanded": 0,
+                    "built": 0,
+                    "skipped": {},
+                    "degraded": {},
+                }
+            )
+        )["last_fetch"]
+        self.assertEqual("recorded", block["state"])
+        self.assertEqual("raised", block["outcome"])
+        self.assertEqual("ADDHON-470", block["code"])
+
+    def test_the_counters_of_a_failed_setup_survive_it(self) -> None:
+        # The inventory arrived, setup dropped all of it, and then setup failed. Before
+        # the record this dump was indistinguishable from an account owning nothing.
+        block = self._dump_record(
+            self._record(
+                fetch={
+                    "outcome": "ok",
+                    "count": 2,
+                    "status": 200,
+                    "expanded": 2,
+                    "built": 0,
+                    "skipped": {"mac_empty": 2},
+                    "degraded": {},
+                }
+            )
+        )["last_fetch"]
+        self.assertEqual((2, 2, 0), (block["count"], block["expanded"], block["built"]))
+        self.assertEqual({"mac_empty": 2}, block["skipped"])
+
+    def test_a_record_without_a_census_still_reads_client_absent(self) -> None:
+        # The failure happened before the call, so there is nothing to say about it.
+        # `last_error` speaks for that dump; this block must not invent a census.
+        block = self._dump_record(self._record())["last_fetch"]
+        self.assertEqual("client_absent", block["state"])
+        self.assertIsNone(block["outcome"])
+
+    def test_the_recorded_block_keeps_the_key_set(self) -> None:
+        # Same rule as the four states above it: a field-by-field diff between two
+        # downloads of the same issue is only meaningful if the key set is stable.
+        from_record = self._dump_record(
+            self._record(fetch={"outcome": "ok", "count": 0})
+        )["last_fetch"]
+        hass = FakeHass(_build_coordinator())
+        hass.data[DOMAIN]["e1"]["client"] = _FetchClient({"outcome": "ok", "count": 0})
+        from_client = _run(
+            diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+        )["last_fetch"]
+        self.assertEqual(set(from_client), set(from_record))
+        self.assertEqual("recorded", from_record["state"])
+
+    def test_the_record_is_validated_like_a_live_client_not_trusted(self) -> None:
+        # The record has been through hass.data, so it is the LESS trusted of the two
+        # sources -- it must not be the one that gets the shorter check. Every hostile
+        # value below is refused by the same guard the live path uses.
+        block = self._dump_record(
+            self._record(
+                fetch={
+                    "outcome": "user@example.com",
+                    "stopped_at": "3C:71:BF:AA:BB:CC",
+                    "node_type": "Kitchen_Washer_3C71BFAABBCC",
+                    "code": "not-a-label",
+                    "status": 99999,
+                    "count": -1,
+                    "skipped": {"3C:71:BF:AA:BB:CC": 1},
+                    "degraded": {"user@example.com": 1},
+                }
+            )
+        )["last_fetch"]
+        # Two refusals, deliberately different. A token this reader does not know
+        # renders as "other" -- the finding survives, the value does not (_closed_token)
+        # -- while a label, a status and a count that fail their check go to null.
+        for key in ("outcome", "stopped_at", "node_type"):
+            with self.subTest(key=key):
+                self.assertEqual("other", block[key])
+        for key in ("code", "status", "count"):
+            with self.subTest(key=key):
+                self.assertIsNone(block[key])
+        self.assertEqual({}, block["skipped"])
+        self.assertEqual({}, block["degraded"])
+        self.assertNotIn("3C:71", json.dumps(block))
+        self.assertNotIn("example.com", json.dumps(block))
 
 
 if __name__ == "__main__":

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -1189,5 +1189,77 @@ class RealtimeWiringSourceGuard(unittest.TestCase):
         self.assertIn("def build_realtime_snapshot", src)
 
 
+class LastFetchAccessorTest(unittest.TestCase):
+    """`HonClient.last_appliance_fetch` reads the LIVE session, never a mirror.
+
+    The census belongs to the transport api of the session that performed the fetch
+    (`NativeHon.last_appliance_fetch` -> `HonApi.last_appliance_fetch`). Mirroring it
+    into a field of the client would need a clear in setup_sync and a second write on
+    the MFA-resume path; forgetting either is how a dump ends up describing a session
+    the client has already thrown away, which is worse than reporting nothing.
+
+    `appliance_count`, `setup_expanded`, `setup_drops` and `degraded_census` beside
+    it are the setup census and are asserted here for the same reason and in the
+    same three shapes: they read through the same `_hon_instance` and inherit the
+    lifetime pinned by the last test of this class.
+    """
+
+    def test_the_accessors_are_none_without_a_session(self) -> None:
+        client = HonClient(email="e@x", password="p")  # no _hon_instance yet
+        self.assertIsNone(client._hon_instance)
+        self.assertIsNone(client.last_appliance_fetch)
+        # None, never 0 or {}: "this client has no session" and "the setup built
+        # nothing" are two different findings, and the dump renders them as two
+        # different states (`client_absent` against `expanded: 0`).
+        self.assertIsNone(client.appliance_count)
+        self.assertIsNone(client.setup_expanded)
+        self.assertIsNone(client.setup_drops)
+        self.assertIsNone(client.degraded_census)
+
+    def test_the_accessors_read_the_live_session(self) -> None:
+        census = {"status": 200, "outcome": "ok", "count": 2}
+        drops = {"mac_empty": 2}
+        degraded = {"ADDHON-230": 1}
+        client = HonClient(email="e@x", password="p")
+        client._hon_instance = types.SimpleNamespace(
+            last_appliance_fetch=census,
+            appliances=[],
+            setup_expanded=2,
+            setup_drops=drops,
+            degraded_census=degraded,
+        )
+        self.assertIs(census, client.last_appliance_fetch)
+        self.assertIs(drops, client.setup_drops)
+        self.assertIs(degraded, client.degraded_census)
+        self.assertEqual(2, client.setup_expanded)
+        # State (D) of the design's table, read end to end off one session: the
+        # cloud sent two appliances (census count), setup expanded two objects,
+        # built none of them, and named the reason. That reading is the entire
+        # purpose of these four accessors existing on the same object.
+        self.assertEqual(0, client.appliance_count)
+
+    def test_a_closed_session_stops_reporting_a_fetch(self) -> None:
+        # The lifetime claim of the accessor's docstring, stated as behaviour: after
+        # _close_sync the client holds no session, so it cannot answer with the census
+        # of the one it just discarded. A mirrored field would still answer.
+        client = HonClient(email="e@x", password="p")
+        client._start_hon_loop()
+        session = FakeSession([])
+        session.last_appliance_fetch = {"status": 200, "outcome": "ok", "count": 2}
+        client._hon_instance = session
+        session.setup_expanded = 2
+        session.setup_drops = {"mac_empty": 2}
+        session.degraded_census = {"ADDHON-230": 1}
+        self.assertEqual(2, client.last_appliance_fetch["count"])
+        self.assertEqual(0, client.appliance_count)
+        client._close_sync()
+        self.assertIsNone(client._hon_instance)
+        self.assertIsNone(client.last_appliance_fetch)
+        self.assertIsNone(client.appliance_count)
+        self.assertIsNone(client.setup_expanded)
+        self.assertIsNone(client.setup_drops)
+        self.assertIsNone(client.degraded_census)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -15,6 +15,7 @@ import asyncio
 import sys
 import threading
 import time
+import ast
 import types
 import unittest
 from pathlib import Path
@@ -1259,6 +1260,77 @@ class LastFetchAccessorTest(unittest.TestCase):
         self.assertIsNone(client.setup_expanded)
         self.assertIsNone(client.setup_drops)
         self.assertIsNone(client.degraded_census)
+
+
+class SetupFetchSnapshotTest(unittest.TestCase):
+    """`last_setup_fetch`: the one census the live accessor above cannot keep.
+
+    The accessor's argument against mirroring holds for a LIVE census, which drifts
+    because the session keeps writing after the copy. This field is written on the path
+    that has just decided there will be no more writes -- the except of setup_sync, one
+    line before `_close_sync` -- and read once, by `__init__._store_setup_failure`, into
+    a record that is never updated. Without it the census of a setup that raised inside
+    load_appliances dies with the session, and `outcome: "raised"` stays a state the
+    transport writes and no dump can show.
+    """
+
+    def test_a_fresh_client_has_no_snapshot(self) -> None:
+        client = HonClient(email="e@x", password="p")
+        self.assertIsNone(client.last_setup_fetch)
+
+    def test_the_snapshot_survives_the_close_the_accessor_does_not(self) -> None:
+        # The two halves of the same instant, side by side: after _close_sync the live
+        # accessor answers None (it has no session to ask) while the snapshot still
+        # carries what the call returned. That difference is the whole feature.
+        client = HonClient(email="e@x", password="p")
+        client._start_hon_loop()
+        session = FakeSession([])
+        session.last_appliance_fetch = {"outcome": "raised", "code": "ADDHON-470"}
+        client._hon_instance = session
+        client.last_setup_fetch = client.last_appliance_fetch
+        client._close_sync()
+        self.assertIsNone(client.last_appliance_fetch)
+        self.assertEqual("raised", client.last_setup_fetch["outcome"])
+
+    def test_setup_sync_snapshots_before_it_closes_and_clears_on_a_retry(self) -> None:
+        # Source-level: setup_sync runs a real login in an executor and is not
+        # behaviourally reachable here. Two orderings matter and both are asserted by
+        # LINE, because ast.walk is breadth first and an index into it would pass
+        # whichever way the statements are written.
+        #
+        # 1. the snapshot is taken BEFORE _close_sync, which nulls the session the
+        #    accessor reads through -- after it, there is nothing left to snapshot;
+        # 2. it is CLEARED at the top of setup_sync with the rest of the failure
+        #    record, so a retry that succeeds cannot leave a dump describing the
+        #    census of an attempt this client has already thrown away.
+        source = Path(HonClient.__module__.replace(".", "/") + ".py")
+        if not source.exists():  # pragma: no cover - import layout guard
+            source = Path(__file__).resolve().parents[1] / "custom_components" / "addhon" / "hon_client.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        setup = next(
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "setup_sync"
+        )
+        writes = [
+            node.lineno
+            for node in ast.walk(setup)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Attribute) and t.attr == "last_setup_fetch"
+                for t in node.targets
+            )
+        ]
+        closes = [
+            node.lineno
+            for node in ast.walk(setup)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_close_sync"
+        ]
+        self.assertEqual(2, len(writes), "one clear at the top, one snapshot on failure")
+        self.assertTrue(closes, "setup_sync must still close the session it failed on")
+        self.assertLess(writes[0], min(closes), "the clear precedes every close")
+        self.assertLess(writes[1], max(closes), "the snapshot precedes the close it feeds")
 
 
 if __name__ == "__main__":

--- a/tests/test_hon_client_realtime.py
+++ b/tests/test_hon_client_realtime.py
@@ -1311,7 +1311,13 @@ class SetupFetchSnapshotTest(unittest.TestCase):
             node for node in ast.walk(tree)
             if isinstance(node, ast.FunctionDef) and node.name == "setup_sync"
         )
-        writes = [
+        # SORTED, because ast.walk is breadth first: its output is traversal order,
+        # not line order, and the clear and the snapshot sit at different depths. They
+        # happen to come out in line order today, so indexing the raw list would pass
+        # -- until an edit moved either statement and silently swapped the pair being
+        # asserted. (Reported by a reviewer on PR #86; the same trap this file's twin
+        # in test_diagnostics.py already avoids.)
+        writes = sorted(
             node.lineno
             for node in ast.walk(setup)
             if isinstance(node, ast.Assign)
@@ -1319,14 +1325,14 @@ class SetupFetchSnapshotTest(unittest.TestCase):
                 isinstance(t, ast.Attribute) and t.attr == "last_setup_fetch"
                 for t in node.targets
             )
-        ]
-        closes = [
+        )
+        closes = sorted(
             node.lineno
             for node in ast.walk(setup)
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "_close_sync"
-        ]
+        )
         self.assertEqual(2, len(writes), "one clear at the top, one snapshot on failure")
         self.assertTrue(closes, "setup_sync must still close the session it failed on")
         self.assertLess(writes[0], min(closes), "the clear precedes every close")

--- a/tests/test_native_session.py
+++ b/tests/test_native_session.py
@@ -15,7 +15,9 @@ awscrt. aiohttp/yarl/homeassistant are stubbed.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -1103,6 +1105,564 @@ class NativeSessionSetupTest(unittest.TestCase):
             self.assertIn(member, dir(nh))
         # appliances is readable right away (empty list), api is not (not created)
         self.assertEqual(nh.appliances, [])
+
+
+class SetupDropCensusTest(unittest.TestCase):
+    """`setup_drops` / `setup_expanded`: the appliances the cloud sent and we did not.
+
+    The class of failure this pins is the one no log can describe: an account whose
+    inventory arrives and is thrown away renders in the diagnostics dump, and in
+    home-assistant.log, exactly like an account that owns nothing -- and for the empty
+    mac (session.py:293-302) that is literal, since that branch writes no log line at
+    all. The census is the only artefact that can separate them, so its arithmetic has
+    to be pinned rather than assumed:
+
+        len(appliances) + sum(setup_drops.values()) == setup_expanded
+
+    Every test below is a term of that sum. `test_a_load_failure_is_NOT_counted_as_a_
+    drop` is the one that keeps it honest from the other side: the second
+    `except self._APPLIANCE_BUILD_ERRORS` KEEPS its appliance, and counting it would
+    put the same object on both sides of the equation.
+
+    The last two tests belong to `degraded_census`, the census of what that same
+    branch KEEPS. It is here rather than in a class of its own because the two
+    populations are defined by contrast -- an appliance is in exactly one of them,
+    and `test_a_load_failure_is_NOT_counted_as_a_drop` is the hinge between the two.
+    """
+
+    def _patch(self, obj, name, value):
+        real = getattr(obj, name)
+        setattr(obj, name, value)
+        self.addCleanup(lambda: setattr(obj, name, real))
+
+    def _nh_with_api(self, harness, **kw):
+        nh = NativeHon("u@x", "p", **kw)
+        nh._api = harness.api  # bypass connection creation, drive setup() directly
+        return nh
+
+    def test_a_silent_mac_drop_is_counted(self) -> None:
+        # The root cause the whole census exists for: the appliance arrived, was built,
+        # and was dropped for an empty mac WITHOUT a log line. assertNoLogs is part of
+        # the assertion, not tidiness -- it states the premise ("the log cannot answer
+        # this") that makes the counter worth its lines.
+        data = [{"macAddress": "", "applianceTypeName": "GHOST"}]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertNoLogs(session_mod._LOGGER, level="DEBUG"):
+            _run(nh.setup())
+        self.assertEqual([], nh.appliances)
+        self.assertEqual({"mac_empty": 1}, nh.setup_drops)
+        self.assertEqual(1, nh.setup_expanded)
+
+    def test_a_non_dict_element_is_counted(self) -> None:
+        # Dropped in setup() BEFORE _create_appliance is reached, so this is also the
+        # test that the expansion counter is charged for an entry that never expands:
+        # without that, an inventory of schema-drift entries would report expanded == 0
+        # with a non-empty census and the reconciliation would fail on healthy data.
+        good = {"macAddress": "B", "applianceTypeName": "WM"}
+        h = _Harness(self, [good])
+        h.install()
+
+        async def mixed_load_appliances():
+            h.events.append("load_appliances")
+            return ["AA:BB:CC:DD:EE:FF", dict(good)]
+
+        h.api.load_appliances = mixed_load_appliances
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        self.assertEqual({"not_a_dict": 1}, nh.setup_drops)
+        self.assertEqual(2, nh.setup_expanded)
+        self.assertEqual(["B"], [a.mac_address for a in nh.appliances])
+
+    def test_an_unparseable_zone_is_counted(self) -> None:
+        data = [{"macAddress": "BAD", "applianceTypeName": "AC", "zone": "abc"}]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        self.assertEqual({"bad_zone": 1}, nh.setup_drops)
+        self.assertEqual(1, nh.setup_expanded)
+        self.assertEqual([], nh.appliances)
+
+    def test_a_construction_error_is_counted(self) -> None:
+        # factory.create_appliance raising leaves no usable object, so this branch
+        # returns without appending: it is a DROP and the census must say so.
+        data = [{"macAddress": "BAD", "applianceTypeName": "REF"}]
+        h = _Harness(self, data)
+
+        def raising_create_appliance(api, data, zone=0):
+            raise KeyError("malformed attributes in constructor")
+
+        async def fake_make_mqtt(hon):
+            h.events.append("mqtt")
+            return FakeMqtt(h)
+
+        self._patch(factory, "create_appliance", raising_create_appliance)
+        self._patch(NativeHon, "_make_mqtt", fake_make_mqtt)
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        self.assertEqual({"construction_error": 1}, nh.setup_drops)
+        self.assertEqual(1, nh.setup_expanded)
+        self.assertEqual([], nh.appliances)
+
+    def test_a_load_failure_is_NOT_counted_as_a_drop(self) -> None:
+        # The trap this class exists to disarm. There are TWO
+        # `except self._APPLIANCE_BUILD_ERRORS` branches over the SAME tuple: the first
+        # (construction) drops, the second (load) KEEPS the appliance and falls through
+        # to the append. Counting the second would put one object in both `built` and
+        # `skipped`, and the invariant would then be broken by the most ordinary event
+        # in this file -- an appliance whose commands failed to load, which ships every
+        # day as a degraded entry. Without this test that breakage is silent.
+        data = [{"macAddress": "A", "applianceTypeName": "REF"}]
+        h = _Harness(self, data, fail_macs={"A"})
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        self.assertEqual({}, nh.setup_drops)
+        self.assertEqual(1, len(nh.appliances))
+        self.assertEqual(1, nh.setup_expanded)
+        # It is degraded, not absent: the OTHER census (C3) is the one that owns it.
+        self.assertEqual(1, len(nh.degraded_appliances))
+
+    def test_two_appliances_dropped_leave_an_empty_inventory_and_a_full_census(
+        self,
+    ) -> None:
+        # State (D) of the design's decision table: the cloud sent an inventory and we
+        # threw all of it away. Today this dump is byte-identical to an empty account;
+        # the three numbers below are what tell them apart.
+        data = [
+            {"macAddress": "", "applianceTypeName": "REF"},
+            {"macAddress": "", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        _run(nh.setup())
+        self.assertEqual([], nh.appliances)
+        self.assertEqual({"mac_empty": 2}, nh.setup_drops)
+        self.assertEqual(2, nh.setup_expanded)
+
+    def test_a_zoned_entry_expands_the_census_not_the_count(self) -> None:
+        # Blocker B3: ONE cloud entry with zone=2 becomes THREE appliance objects
+        # (zone 1, zone 2, base), so a census counted on the length of the cloud list
+        # could never reconcile -- `built > count` is a HEALTHY reading for a
+        # multi-zone fridge, not a bug. `expanded` is the term that makes the sum work.
+        data = [{"macAddress": "Z", "applianceTypeName": "AC", "zone": "2"}]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        _run(nh.setup())
+        self.assertEqual(3, len(nh.appliances))
+        self.assertEqual(3, nh.setup_expanded)
+        self.assertEqual({}, nh.setup_drops)
+        # One cloud entry, three objects: the gap the raw count cannot explain.
+        self.assertEqual(1, len(data))
+
+    def test_a_dropped_zoned_entry_is_counted_per_object(self) -> None:
+        # The same expansion on the failing side: the drop is charged once per OBJECT,
+        # never once per entry, or the sum stops closing exactly when the account is
+        # both zoned and broken.
+        data = [{"macAddress": "", "applianceTypeName": "AC", "zone": "2"}]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        _run(nh.setup())
+        self.assertEqual([], nh.appliances)
+        self.assertEqual({"mac_empty": 3}, nh.setup_drops)
+        self.assertEqual(3, nh.setup_expanded)
+
+    def test_the_census_invariant_holds(self) -> None:
+        # The whole point, on a table that mixes every branch at once: healthy, zoned,
+        # silently dropped, schema drift, unreadable zone. This is the arithmetic a
+        # maintainer performs on the dump to decide whether the census accounts for
+        # everything the cloud sent, so it is asserted rather than left to the reader.
+        good = {"macAddress": "A", "applianceTypeName": "REF"}
+        zoned = {"macAddress": "Z", "applianceTypeName": "AC", "zone": "2"}
+        headless = {"macAddress": "", "applianceTypeName": "GHOST"}
+        unreadable = {"macAddress": "B", "applianceTypeName": "WM", "zone": "abc"}
+        entries = [dict(good), dict(zoned), dict(headless), "x", dict(unreadable)]
+        h = _Harness(self, [good])
+        h.install()
+
+        async def mixed_load_appliances():
+            h.events.append("load_appliances")
+            return [dict(e) if isinstance(e, dict) else e for e in entries]
+
+        h.api.load_appliances = mixed_load_appliances
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        self.assertEqual(
+            nh.setup_expanded, len(nh.appliances) + sum(nh.setup_drops.values())
+        )
+        # Stated again as literals, so a change that keeps the sum balanced by moving
+        # an appliance from one side to the other still fails here.
+        self.assertEqual(7, nh.setup_expanded)
+        self.assertEqual(4, len(nh.appliances))
+        self.assertEqual(
+            {"mac_empty": 1, "not_a_dict": 1, "bad_zone": 1}, nh.setup_drops
+        )
+        # The second half of the declared invariant: one object per cloud entry at
+        # minimum, more only where an entry was expanded into zones.
+        self.assertGreaterEqual(nh.setup_expanded, len(entries))
+
+    def test_setup_drops_are_cleared_on_a_new_setup(self) -> None:
+        # setup() is re-entered on the SAME session when a mid-setup MFA challenge is
+        # resumed, so a census that survived would describe two setups at once and the
+        # invariant would fail against a single inventory. Rebound, not cleared in
+        # place: a diagnostics download reads this map from another thread.
+        data = [{"macAddress": "", "applianceTypeName": "GHOST"}]
+        h = _Harness(self, data)
+        h.install()
+        nh = self._nh_with_api(h)
+        _run(nh.setup())
+        self.assertEqual({"mac_empty": 1}, nh.setup_drops)
+        # The PRIVATE object, not `nh.setup_drops`. The property returns
+        # `dict(self._setup_drops)` -- already a detached copy -- so an assertion on
+        # what it returned survives a `.clear()` just as happily as a rebind and
+        # cannot distinguish the two. This is the only assertion in the change that
+        # claims to pin the rebind, so it has to hold the object the writer touches.
+        before = nh._setup_drops
+        data[:] = [{"macAddress": "A", "applianceTypeName": "REF"}]
+        _run(nh.setup())
+        self.assertEqual({}, nh.setup_drops)
+        self.assertEqual(1, nh.setup_expanded)
+        self.assertEqual(1, len(nh.appliances))
+        # The reset REBOUND rather than mutating: a reader on Home Assistant's loop
+        # that took the mapping mid-download still holds a complete census of the
+        # setup it was reading, not an emptied one.
+        self.assertIsNot(before, nh._setup_drops)
+        self.assertEqual({"mac_empty": 1}, before)
+
+    def test_count_drop_rebinds_instead_of_mutating(self) -> None:
+        # The other half of the same discipline, and the half no other test reaches:
+        # `_count_drop` is called once per dropped appliance while a Download
+        # Diagnostics may already hold the mapping. A `self._setup_drops[reason] += 1`
+        # would pass every behavioural test in this class -- the counts are identical
+        # -- and would silently change what a concurrent reader sees.
+        nh = NativeHon("u@x", "p")
+        held = nh._setup_drops
+        nh._count_drop("mac_empty")
+        self.assertIsNot(held, nh._setup_drops)
+        self.assertEqual({}, held)
+        self.assertEqual({"mac_empty": 1}, nh.setup_drops)
+        # And again on a non-empty census, because a rebind that only happened on the
+        # first drop would still lose the property from the second one on.
+        held = nh._setup_drops
+        nh._count_drop("mac_empty")
+        self.assertIsNot(held, nh._setup_drops)
+        self.assertEqual({"mac_empty": 1}, held)
+        self.assertEqual({"mac_empty": 2}, nh.setup_drops)
+
+    def test_setup_drop_reasons_are_exhaustive(self) -> None:
+        # A fifth way out of the loop must arrive with a token, or the dump will drop
+        # its count on the floor: diagnostics.py iterates SETUP_DROP_REASONS instead of
+        # the mapping it receives, precisely so a key it does not know cannot reach a
+        # public issue. That safety has a cost -- an uncounted reason is invisible --
+        # and this test is what makes the cost visible at the moment it is incurred.
+        observed: set = set()
+        for entries, patch_factory in (
+            ([{"macAddress": "", "applianceTypeName": "GHOST"}], False),
+            (["not-a-dict"], False),
+            ([{"macAddress": "B", "applianceTypeName": "WM", "zone": "abc"}], False),
+            ([{"macAddress": "C", "applianceTypeName": "REF"}], True),
+        ):
+            h = _Harness(self, [])
+            h.install()
+            if patch_factory:
+                def raising_create_appliance(api, data, zone=0):
+                    raise KeyError("constructor boom")
+
+                self._patch(factory, "create_appliance", raising_create_appliance)
+
+            async def load_appliances(captured=entries):
+                return [dict(e) if isinstance(e, dict) else e for e in captured]
+
+            h.api.load_appliances = load_appliances
+            nh = self._nh_with_api(h)
+            _run(nh.setup())
+            observed |= set(nh.setup_drops)
+        self.assertEqual(set(session_mod.SETUP_DROP_REASONS), observed)
+
+    def test_degraded_census_counts_labels_never_macs(self) -> None:
+        # The commoner half of the report this whole block exists for: nothing was
+        # dropped, both appliances shipped, and both shipped WITHOUT commands -- so
+        # the user sees two devices and none of their select/number/switch/button/
+        # climate/fan entities (session.py:378-380). The raw bookkeeping that knows
+        # this is keyed by identity, so the two assertions below are one statement:
+        # the session holds "AA:BB:CC:DD:EE:FF#0" and publishes "ADDHON-230".
+        data = [
+            {"macAddress": "AA:BB:CC:DD:EE:FF", "applianceTypeName": "REF"},
+            {"macAddress": "11:22:33:44:55:66", "applianceTypeName": "WM"},
+        ]
+        h = _Harness(self, data, fail_macs={a["macAddress"] for a in data})
+        h.install()
+        nh = self._nh_with_api(h)
+        with self.assertLogs(session_mod._LOGGER, level="ERROR"):
+            _run(nh.setup())
+        # Kept, not dropped: the other census must stay empty or the same appliance
+        # would be counted as both absent and present.
+        self.assertEqual(2, len(nh.appliances))
+        self.assertEqual({}, nh.setup_drops)
+        self.assertEqual({"ADDHON-230": 2}, nh.degraded_census)
+        # Two identities collapse into ONE row, which is what makes the reduction a
+        # reduction rather than a rename of the mapping beside it.
+        self.assertEqual(
+            ["AA:BB:CC:DD:EE:FF#0", "11:22:33:44:55:66#0"],
+            list(nh.degraded_appliances),
+        )
+        # The leak test, on the writer side, where section 3.5 of the design puts
+        # it: the census is what crosses into the dump, and a dump is pasted into a
+        # public issue. "#" is asserted as well as the two MACs because a key that
+        # leaked in a form we did not anticipate would still carry the separator.
+        blob = json.dumps(nh.degraded_census)
+        self.assertNotIn("AA:BB:CC:DD:EE:FF", blob)
+        self.assertNotIn("11:22:33:44:55:66", blob)
+        self.assertNotIn("#", blob)
+
+    def test_the_census_separates_the_two_causes_it_is_fed(self) -> None:
+        # Beyond the design's list, and the reason is that the test above cannot
+        # tell "groups by label" apart from "emits the one label this branch always
+        # produces": with a single cause in play, a census that ignored `code`
+        # entirely would pass it. The two branches that call `_record_partial` pass
+        # DIFFERENT codes -- APPLIANCE_DATA_MALFORMED at session.py:332 and
+        # `classify(error)` at :344 -- and a maintainer reading the dump acts on
+        # which one it is: ADDHON-230 is a payload this build cannot parse and will
+        # parse the same way after a reload, ADDHON-400 is a network timeout that a
+        # reload may well clear.
+        good = {"macAddress": "A", "applianceTypeName": "REF"}
+        malformed = {"macAddress": "B", "applianceTypeName": "WM"}
+        timed_out = {"macAddress": "C", "applianceTypeName": "AC"}
+        h = _Harness(self, [good, malformed, timed_out], fail_macs={"B"})
+        h.install()
+        built = factory.create_appliance  # the harness fake, already installed
+
+        def create_with_a_timeout(api, data, zone=0):
+            appliance = built(api, data, zone=zone)
+            if data.get("macAddress") == "C":
+                async def load_commands():
+                    raise TimeoutError("hOn did not answer in time")
+
+                appliance.load_commands = load_commands
+            return appliance
+
+        self._patch(factory, "create_appliance", create_with_a_timeout)
+        nh = self._nh_with_api(h)
+        # WARNING, not ERROR: the transport branch logs at WARNING and the malformed
+        # one at ERROR, and both have to be captured or the second escapes to the
+        # root logger and prints through the run.
+        with self.assertLogs(session_mod._LOGGER, level="WARNING"):
+            _run(nh.setup())
+        self.assertEqual(3, len(nh.appliances))
+        # ADDHON-400 rather than the 460 a bare `classify(TimeoutError())` returns:
+        # `budgeted` converts every TimeoutError that leaves its scope into a coded
+        # error attributed to the innermost phase (client/budget.py:227-229), and
+        # inside "load_appliance" that resolves to NETWORK_TIMEOUT instead of the
+        # mute "setup timed out". The census reports what the session recorded and
+        # re-derives nothing, which is what keeps it and `last_error` from naming one
+        # failure two ways.
+        self.assertEqual({"ADDHON-230": 1, "ADDHON-400": 1}, nh.degraded_census)
+        # One healthy appliance is in neither census: `degraded` counts what is
+        # broken, never what was loaded.
+        self.assertEqual({}, nh.setup_drops)
+        self.assertEqual(3, nh.setup_expanded)
+
+
+class DegradedCensusThreadSafetyTest(unittest.TestCase):
+    """`degraded_census` is read from a DIFFERENT thread than the one that fills it.
+
+    `_record_partial` mutates `_hydration_failures` IN PLACE (session.py) on the
+    dedicated hOn loop thread, while a Download Diagnostics reads this property on
+    Home Assistant's event loop -- during setup, and during the runtime re-auth that
+    re-runs setup in an executor with the config entry still loaded.
+
+    The property loops in PYTHON over the values, and a Python-level `for` gives up
+    the GIL between items, so without the `dict()` copy it raises `RuntimeError:
+    dictionary changed size during iteration`. `_last_fetch` catches that and renders
+    the whole block `{"state": "unreadable"}` -- the block the download was for.
+
+    This is the ONLY guard in the census whose failure mechanism reproduces on demand:
+    the sibling copy in `setup_drops` is a single C-level `dict()` call that never
+    yields, measured at 0 failures in 50_000 reads with the same writer, which is why
+    it is pinned by an identity assertion (`test_count_drop_rebinds_instead_of_
+    mutating`) rather than by a race. The one defended by a measurement was the one
+    tested by nothing, and this closes that.
+    """
+
+    def _hammer(self, reader, *, keys: int, reads: int):
+        """Run `reader` against a writer thread churning `_hydration_failures`.
+
+        Returns (escaped exception or None, results). The switch interval is dropped
+        so the interpreter preempts inside a Python-level loop rather than once every
+        few milliseconds; it is restored unconditionally.
+        """
+        nh = NativeHon("u@x", "p")
+        code = ec.APPLIANCE_DATA_MALFORMED
+        for i in range(keys):
+            nh._hydration_failures[f"AA:BB:CC:DD:EE:{i:02X}#0"] = code
+        stop = threading.Event()
+        failures: list = []
+
+        def writer() -> None:
+            # Grow by a batch, then drop the batch, rather than add/remove one key at
+            # a time: an insert immediately undone leaves the size wrong for two
+            # bytecodes and a reader almost never lands there. `_record_partial` is
+            # itself a burst -- one write per degraded appliance as the setup loop
+            # walks the inventory -- so the batch is also the truer shape.
+            i = 0
+            try:
+                while not stop.is_set():
+                    nh._hydration_failures[f"11:22:33:44:55:{i % 64:02X}#1"] = code
+                    if i % 64 == 63:
+                        for j in range(64):
+                            nh._hydration_failures.pop(f"11:22:33:44:55:{j:02X}#1", None)
+                    i += 1
+            except Exception as err:  # pragma: no cover - writer must stay clean
+                failures.append(err)
+
+        # Registered BEFORE the interval is touched and before the thread exists, so
+        # neither can leak into the rest of the run no matter where this fails. A
+        # switch interval left at 1e-6 slows every Python-level operation in the
+        # process, which is how a threaded test takes an unrelated wall-clock test
+        # down with it several files later.
+        # Cleanups run LIFO, so these are registered in reverse of the order they must
+        # execute: signal the writer to stop, THEN join it, THEN restore the interval.
+        previous = sys.getswitchinterval()
+        self.addCleanup(sys.setswitchinterval, previous)
+        sys.setswitchinterval(1e-6)
+        thread = threading.Thread(target=writer, daemon=True)
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(stop.set)
+        thread.start()
+        try:
+            escaped = None
+            results = []
+            for _ in range(reads):
+                try:
+                    results.append(reader(nh))
+                except Exception as err:
+                    escaped = err
+                    break
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+            sys.setswitchinterval(previous)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(previous, sys.getswitchinterval())
+        self.assertEqual([], failures)
+        return escaped, results
+
+    def test_a_concurrent_writer_cannot_make_the_census_raise(self) -> None:
+        escaped, results = self._hammer(
+            lambda nh: nh.degraded_census, keys=400, reads=2000
+        )
+        self.assertIsNone(escaped, f"degraded_census raised: {escaped!r}")
+        self.assertEqual(2000, len(results))
+        # Not merely "did not raise": every snapshot is still a shape-checked label
+        # mapped to a count, so a copy that traded the race for a torn read would be
+        # caught here too. The count floats with the writer's batch, hence the bound
+        # rather than an equality.
+        for row in results[:: max(1, len(results) // 50)]:
+            self.assertEqual({"ADDHON-230"}, set(row))
+            self.assertGreaterEqual(row["ADDHON-230"], 400)
+
+    def test_the_reader_this_test_stands_in_for_really_does_tear(self) -> None:
+        # The control. Without it this class proves nothing: a guard test that stays
+        # green because the race is unreachable on this interpreter is indistinguish-
+        # able from one that stays green because the guard works. This runs the
+        # UNGUARDED shape -- the same Python-level loop over the live mapping that
+        # `degraded_census` would be if the `dict()` copy were dropped -- and asserts
+        # it does tear, so a future reader knows the copy above is load-bearing here
+        # and not cargo.
+        def unguarded(nh):
+            out: dict = {}
+            for value in nh._hydration_failures.values():
+                label = getattr(value, "label", None)
+                if isinstance(label, str):
+                    out[label] = out.get(label, 0) + 1
+            return out
+
+        escaped, _ = self._hammer(unguarded, keys=400, reads=2000)
+        self.assertIsInstance(
+            escaped,
+            RuntimeError,
+            "the unguarded loop did NOT tear on this interpreter, so the test above "
+            "proves nothing about the dict() copy in degraded_census. Re-derive "
+            "whether that copy is still load-bearing here before deleting either "
+            "test -- do not delete this guard to make the run green.",
+        )
+        self.assertIn("changed size during iteration", str(escaped))
+
+
+class FetchCensusLifetimeTest(unittest.TestCase):
+    """How far the appliance-list fetch census actually travels, stated as behaviour.
+
+    `HonApi.load_appliances` records `outcome: "raised"` when the POST dies before a
+    body (a 429, any >= 500, a non-JSON CDN page). The obvious reading of that branch
+    -- that a diagnostics dump will therefore show `outcome: "raised"` -- is WRONG,
+    and this class exists so nobody has to rediscover why by instrumenting a running
+    Home Assistant.
+
+    The census lives on the transport api, the api lives on the session, and the raise
+    that produced the census also destroys the session: it propagates out of setup(),
+    `create()`'s `except BaseException` calls `close()`, and `close()` nulls `_api`.
+    From that point the session answers `None`, `HonClient._close_sync` nulls the
+    session, and `async_setup_entry` pops the entry bucket -- so the dump for that
+    entry reads `client_absent`.
+
+    That is by design, not by oversight: making a FAILED SETUP diagnosable is refused
+    for this change (it would change the meaning of `_last_error`'s existing
+    `client_absent` answer and opens an ownership question of its own), and the shape
+    that will carry this census when it lands is inscribed in the design note. Until
+    then the branch is correct where it is written and unreachable where it is read,
+    and that is exactly what the two tests below say.
+    """
+
+    def test_the_census_records_the_raise_on_the_api_that_made_the_call(self) -> None:
+        nh = NativeHon("u@x", "p")
+        api = FakeApi([], [])
+
+        async def failing_load_appliances():
+            api.last_appliance_fetch = {
+                "at": None,
+                "status": None,
+                "code": "ADDHON-450",
+                "outcome": "raised",
+                "stopped_at": None,
+                "node_type": None,
+                "siblings": None,
+                "count": None,
+            }
+            raise RuntimeError("hOn server error (status 503)")
+
+        api.last_appliance_fetch = None
+        api.load_appliances = failing_load_appliances
+        nh._api = api
+        with self.assertRaises(RuntimeError):
+            _run(nh.setup())
+        # Written, and readable through the session -- for as long as the session has
+        # an api to read it from.
+        self.assertEqual("raised", nh.last_appliance_fetch["outcome"])
+
+    def test_the_raise_that_writes_the_census_also_destroys_its_reader(self) -> None:
+        # The half that bounds the feature. close() nulls `_api`, so the census the
+        # branch above just wrote stops being reachable from the session, and every
+        # reader downstream of the session (HonClient -> diagnostics) reads None.
+        nh = NativeHon("u@x", "p")
+        api = FakeApi([], [])
+        nh._api = api
+        api.last_appliance_fetch = {"outcome": "raised", "code": "ADDHON-450"}
+        self.assertEqual("raised", nh.last_appliance_fetch["outcome"])
+        _run(nh.close())
+        self.assertIsNone(nh._api)
+        # `never_ran` in the dump, and after the entry bucket is popped,
+        # `client_absent`. Neither says "raised", and that is the documented cost.
+        self.assertIsNone(nh.last_appliance_fetch)
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import logging
 import sys
 import types
@@ -83,9 +84,14 @@ from custom_components.addhon.client.transport.api import HonApi, API_URL  # noq
 # Test doubles                                                                #
 # --------------------------------------------------------------------------- #
 class FakeResponse:
-    def __init__(self, body, text="<text>") -> None:
+    # `status` mirrors aiohttp.ClientResponse.status, which load_appliances reads into
+    # its fetch census: a 4xx carrying a JSON body decodes cleanly and is delivered as
+    # a success by connection.py (it re-raises only on 429 and >= 500), so the status
+    # is the only thing that separates "the endpoint moved" from "the schema drifted".
+    def __init__(self, body, text="<text>", status: int = 200) -> None:
         self._body = body
         self._text = text
+        self.status = status
 
     async def json(self, content_type=None):
         return self._body
@@ -119,14 +125,17 @@ class _ReqCtx:
 class FakeConnection:
     """Replaces HonConnection: records the requests, returns a fixed body."""
 
-    def __init__(self, body, text="<text>", mobile_id="pyhOn") -> None:
+    def __init__(self, body, text="<text>", mobile_id="pyhOn", status: int = 200) -> None:
         self._body = body
         self._text = text
+        self._status = status
         self.calls: list = []
         self.device = _device.HonDevice(mobile_id)
 
     def _ctx(self, method, url, kwargs):
-        return _ReqCtx(self, method, url, kwargs, FakeResponse(self._body, self._text))
+        return _ReqCtx(
+            self, method, url, kwargs, FakeResponse(self._body, self._text, self._status)
+        )
 
     def get(self, url, **kwargs):
         return self._ctx("GET", url, kwargs)
@@ -680,7 +689,9 @@ class _StrictResponse(FakeResponse):
 
 class _StrictConnection(FakeConnection):
     def _ctx(self, method, url, kwargs):
-        return _ReqCtx(self, method, url, kwargs, _StrictResponse(self._body, self._text))
+        return _ReqCtx(
+            self, method, url, kwargs, _StrictResponse(self._body, self._text, self._status)
+        )
 
 
 class ContentTypeTest(unittest.TestCase):
@@ -707,6 +718,234 @@ class ContentTypeTest(unittest.TestCase):
 
     def test_load_statistics_passes_content_type_none(self) -> None:
         _run(_call(_StrictConnection({})).load_statistics(FakeAppliance()))
+
+
+# --------------------------------------------------------------------------- #
+# The appliance-list fetch census                                              #
+# --------------------------------------------------------------------------- #
+class _RaisingCtx:
+    """A request context that dies before there is a body, like connection.py does on
+    429, on any >= 500 and on a non-JSON body (a CDN or maintenance page)."""
+
+    def __init__(self, conn, method, url, kwargs, error) -> None:
+        self._conn = conn
+        self._method = method
+        self._url = url
+        self._kwargs = kwargs
+        self._error = error
+
+    async def __aenter__(self):
+        self._conn.calls.append((self._method, self._url, self._kwargs))
+        raise self._error
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _RaisingConnection(FakeConnection):
+    def __init__(self, error, **kwargs) -> None:
+        super().__init__(None, **kwargs)
+        self._error = error
+
+    def _ctx(self, method, url, kwargs):
+        return _RaisingCtx(self, method, url, kwargs, self._error)
+
+
+class _NoStatusResponse:
+    """A duck-typed response with no `status` attribute at all.
+
+    Every response double in this suite grew one when the census landed; this one
+    deliberately did not, because the field the census reads must be optional. A
+    diagnostic field that can abort a setup is worse than the missing diagnosis.
+    """
+
+    def __init__(self, body) -> None:
+        self._body = body
+
+    async def json(self, content_type=None):
+        return self._body
+
+
+class _NoStatusConnection(FakeConnection):
+    def _ctx(self, method, url, kwargs):
+        return _ReqCtx(self, method, url, kwargs, _NoStatusResponse(self._body))
+
+
+class FetchCensusTest(unittest.TestCase):
+    """`load_appliances` records what the ONE appliance-list call did, on BOTH paths.
+
+    The live case this exists for: the cloud answered with `result` keys
+    ['executionTime', 'modules', 'success'] and `modules` keys ['applianceList'], the
+    hOn app showed two appliances, and the dump said `"appliances": []` with
+    `"last_error": null`. Nothing in that file said whether the list was empty, whether
+    our walk stopped early, or whether the call reached a body at all. The census is
+    what answers that, and it has to survive the raising path too -- an exception
+    leaves the field untouched otherwise, which reads exactly like "no session".
+    """
+
+    def test_a_successful_fetch_records_status_and_probe(self) -> None:
+        body = {
+            "modules": {"applianceList": {"payload": {"appliances": [{"a": 1}, {"b": 2}]}}}
+        }
+        api = _call(FakeConnection(body))
+        # Nothing recorded before the call: the field starts as None so the diagnostics
+        # reader can tell "this session never fetched" from "this session fetched".
+        self.assertIsNone(api.last_appliance_fetch)
+        _run(api.load_appliances())
+        census = api.last_appliance_fetch
+        self.assertEqual(200, census["status"])
+        self.assertEqual("ok", census["outcome"])
+        self.assertEqual(2, census["count"])
+        self.assertIsNone(census["code"])
+        self.assertIsNone(census["stopped_at"])
+        # Aware UTC, so the diagnostics layer can subtract it from its own clock.
+        self.assertIsNotNone(census["at"].utcoffset())
+
+    def test_a_non_200_with_a_json_body_records_its_status(self) -> None:
+        # Root cause (C): the endpoint moved. connection.py re-raises only on 429 and
+        # >= 500, so a 404 with a JSON body is delivered here as a success and the
+        # parser reports an empty account. The status is the whole diagnosis.
+        api = _call(FakeConnection({"message": "Not Found"}, status=404))
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ):
+            self.assertEqual([], _run(api.load_appliances()))
+        census = api.last_appliance_fetch
+        self.assertEqual(404, census["status"])
+        self.assertEqual("missing_key", census["outcome"])
+        self.assertEqual("modules", census["stopped_at"])
+        self.assertIsNone(census["count"])
+
+    def test_a_raising_fetch_still_records_a_census(self) -> None:
+        # Root cause (E): the call never reached a body. The exception must still
+        # propagate untouched -- the census is a bystander, not a handler.
+        from custom_components.addhon.error_codes import classify
+
+        error = RuntimeError("hOn server error (status 503)")
+        api = _call(_RaisingConnection(error))
+        with self.assertRaises(RuntimeError) as caught:
+            _run(api.load_appliances())
+        self.assertIs(error, caught.exception)
+        census = api.last_appliance_fetch
+        self.assertEqual("raised", census["outcome"])
+        self.assertEqual(classify(error).label, census["code"])
+        self.assertRegex(census["code"], r"^ADDHON-[0-9]{3}$")
+        # No body was reached, so nothing downstream of it can be reported.
+        self.assertIsNone(census["status"])
+        self.assertIsNone(census["count"])
+        self.assertIsNone(census["node_type"])
+
+    def test_a_response_without_a_status_attribute_does_not_raise(self) -> None:
+        body = {"modules": {"applianceList": {"payload": {"appliances": [{"a": 1}]}}}}
+        api = _call(_NoStatusConnection(body))
+        self.assertEqual([{"a": 1}], _run(api.load_appliances()))
+        self.assertIsNone(api.last_appliance_fetch["status"])
+        self.assertEqual("ok", api.last_appliance_fetch["outcome"])
+
+    def test_the_census_carries_no_cloud_string(self) -> None:
+        # The leak test on the writer side: this dict is published verbatim into a
+        # document users paste into public issues, so not one string of it may come
+        # from the response. `default=str` so the datetime does not hide a failure to
+        # serialize behind a TypeError.
+        import json
+
+        body = {
+            "AA:BB:CC:DD:EE:FF": "user@example.com",
+            "modules": {
+                "applianceList": {
+                    "payload": {
+                        "appliances": [
+                            {
+                                "macAddress": "AA:BB:CC:DD:EE:FF",
+                                "serialNumber": "PLAINTEXT-SERIAL",
+                                "nickName": "Kitchen Washer",
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+        api = _call(FakeConnection(body))
+        _run(api.load_appliances())
+        blob = json.dumps(api.last_appliance_fetch, default=str)
+        for leak in (
+            "AA:BB:CC:DD:EE:FF",
+            "user@example.com",
+            "PLAINTEXT-SERIAL",
+            "Kitchen Washer",
+        ):
+            self.assertNotIn(leak, blob, leak)
+
+    def test_both_paths_stamp_an_instant_the_dump_can_render(self) -> None:
+        """WHEN the fetch ran, on both paths, carried end to end into the block.
+
+        Without the stamp the block says the cloud sent an empty list without saying
+        whether that was six seconds or six days ago -- that is, without saying whether
+        asking the reporter for a reload would change anything. `generated_at` dates the
+        DOWNLOAD, not the fetch, and in a dump whose account came back empty it is the only
+        instant left in the document: every other one lives inside an appliance block,
+        and there are none.
+
+        BOTH paths are asserted because `load_appliances` builds two SEPARATE dict
+        literals (api.py:98-107 for the raising branch, :115-120 for the success branch)
+        and
+        nothing else in this suite reads `at` on the raising one. A stamp dropped there,
+        or written as a naive `datetime.now()`, is refused by `_as_utc(...,
+        assume_naive_utc=False)` (diagnostics.py:1259-1260), which blanks `at` AND
+        `age_s` on exactly the root cause where the age decides what to do next: a 503
+        six days old is a census nobody should act on, a 503 six seconds old is an
+        outage in progress.
+
+        The READER half runs here and not in tests/test_diagnostics.py because that file
+        stubs only the `homeassistant.*` tree and deliberately provides no `yarl` (its
+        comment at :844-845), so it cannot import this transport at all; this file stubs
+        aiohttp and yarl already, so it is the only place where the instant the writer
+        stamps meets the real `_stamp_text` -> `_age_seconds` path. Split across the two
+        files both halves stay green while the field renders `null`: every writer test
+        above reads `census["at"]` as a datetime object, and every reader test in
+        test_diagnostics.py hand-writes the instant it then reads back.
+
+        The api object stands in for the client because the accessor chain forwards this
+        very dict without copying it: `HonApi.last_appliance_fetch` ->
+        `NativeHon.last_appliance_fetch` (session.py:654) -> `HonClient`
+        (hon_client.py:853).
+        """
+        from datetime import timedelta
+        from types import SimpleNamespace
+
+        from custom_components.addhon import diagnostics
+        from custom_components.addhon.const import DOMAIN
+
+        body = {"modules": {"applianceList": {"payload": {"appliances": [{"a": 1}]}}}}
+        served = _call(FakeConnection(body))
+        _run(served.load_appliances())
+        refused = _call(_RaisingConnection(RuntimeError("hOn server error (status 503)")))
+        with self.assertRaises(RuntimeError):
+            _run(refused.load_appliances())
+
+        for path, api in (("served", served), ("refused", refused)):
+            with self.subTest(path=path):
+                stamped = api.last_appliance_fetch["at"]
+                # Aware UTC at the source. An offset-carrying instant is what the reader
+                # is allowed to subtract from a clock of its own, and normalising to
+                # +00:00 is also what keeps the emitted text from matching `_MAC_RE` --
+                # `_stamp_text` measured '2026-04-09T12:34:56-05:30:15' surviving
+                # `_jsonable` as '2026-04-09T***' (diagnostics.py:1286-1292).
+                self.assertEqual(timedelta(0), stamped.utcoffset())
+                hass = SimpleNamespace(data={DOMAIN: {"e1": {"client": api}}})
+                block = diagnostics._last_fetch(
+                    hass,
+                    SimpleNamespace(entry_id="e1"),
+                    now=stamped + timedelta(seconds=51_840),
+                )
+                self.assertEqual("recorded", block["state"])
+                # Equality with the writer's own isoformat, not merely "not None": it is
+                # what proves the real stamp clears `_ISO_RE` and the 40-character cap
+                # instead of being dropped by them.
+                self.assertEqual(stamped.isoformat(), block["at"])
+                self.assertTrue(block["at"].endswith("+00:00"), block["at"])
+                self.assertEqual(51_840, block["age_s"])
+
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_parse.py
+++ b/tests/test_transport_parse.py
@@ -10,10 +10,15 @@ extraction. The contract: return the list at
 non-dict intermediate level, non-list final value) -> `[]` (sec9 fail-safe), and a
 truthy non-list final value additionally logs a warning. parse.py is stdlib-only, so
 it is loaded in isolation.
+
+The second half of the file covers `probe_appliance_list`, which has no pyhOn
+counterpart at all: it reports WHERE that fail-safe walk stopped, so a diagnostics
+dump can separate the three responses sec9 deliberately collapses into `[]`.
 """
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -85,6 +90,250 @@ class ParseApplianceListTest(unittest.TestCase):
             with self.subTest(result=result):
                 # sec9: schema drift is treated as "0 appliances", never a crash.
                 self.assertEqual(self.parse(result), [])
+
+
+# (response, "does this payload carry a list at the path") -- the truth is STATED
+# here, not computed from the probe, so the equivalence below compares the probe
+# against an author's claim instead of against itself.
+_EMPTY_LIST_TABLE = [
+    ({"modules": {"applianceList": {"payload": {"appliances": []}}}}, True),
+    ({"modules": {"applianceList": {"payload": {"appliances": _REAL}}}}, False),
+    ({"modules": {"applianceList": {"payload": {"appliances": {}}}}}, False),
+    ({"modules": {"applianceList": {"payload": {"appliances": ""}}}}, False),
+    ({"modules": {"applianceList": {"payload": {"appliances": 0}}}}, False),
+    ({"modules": {"applianceList": {"payload": {"appliances": None}}}}, False),
+    ({"modules": {"applianceList": {"payload": {}}}}, False),
+    ({"modules": {"applianceList": {}}}, False),
+    ({"modules": {}}, False),
+    ({}, False),
+    (None, False),
+    ({"modules": []}, False),
+    ({"modules": {"applianceList": {"payload": []}}}, False),
+]
+
+
+class _HostileDict(dict):
+    """A dict SUBCLASS that raises from `__contains__`.
+
+    `isinstance(x, dict)` is True for it, so it walks straight past the type guard and
+    into the membership test -- the one input on which the probe's try/except is not
+    theoretical. Not reachable from `json.loads`, but reachable from a caller handing
+    the transport a duck-typed response, which is what the test doubles in this suite
+    do all day.
+    """
+
+    def __contains__(self, key):
+        raise RuntimeError("hostile mapping")
+
+
+def _deep(depth: int) -> dict:
+    node: dict = {}
+    for _ in range(depth):
+        node = {"modules": node}
+    return node
+
+
+class ProbeApplianceListTest(unittest.TestCase):
+    """`probe_appliance_list` names the LEVEL at which the walk stopped.
+
+    Why it exists: a dump reading `"appliances": []` is compatible with an account the
+    cloud reports as empty, with a schema drift our walk cannot follow, and with a body
+    that never arrived. The parser above cannot tell them apart -- it returns `[]` for
+    all three by contract (sec9 fail-safe) -- and the probe is what does, WITHOUT
+    copying a single string chosen by the cloud into a document the user pastes into a
+    public issue.
+    """
+
+    def setUp(self) -> None:
+        module = _load(_OUR_PARSE, "addhon_transport_parse")
+        self.probe = module.probe_appliance_list
+        self.parse = module.parse_appliance_list
+        self.path = module.APPLIANCE_LIST_PATH
+
+    def test_probe_reports_ok_and_the_raw_count(self) -> None:
+        full = {"modules": {"applianceList": {"payload": {"appliances": _REAL}}}}
+        self.assertEqual(
+            {
+                "outcome": "ok",
+                "stopped_at": None,
+                "node_type": "list",
+                "siblings": None,
+                "count": 2,
+            },
+            self.probe(full),
+        )
+
+    def test_probe_names_the_level_a_missing_key_broke(self) -> None:
+        # One case per level: the whole point of the field is that a maintainer can
+        # tell "the cloud stopped sending `modules`" from "the payload lost its
+        # `appliances`", which are different bugs with different owners.
+        # `siblings` is the size of the dict the key was missing FROM, counted after
+        # the removal, so each level carries a different number of neighbours and a
+        # confusion between two levels cannot pass this test.
+        for missing, siblings in (
+            ("modules", 1),
+            ("applianceList", 2),
+            ("payload", 1),
+            ("appliances", 3),
+        ):
+            with self.subTest(missing=missing):
+                payload = {"appliances": _REAL, "p1": 1, "p2": 2, "p3": 3}
+                appliance_list = {"payload": payload, "a1": 1}
+                modules = {"applianceList": appliance_list, "m1": 1, "m2": 2}
+                response = {"modules": modules, "r1": 1}
+                container = {
+                    "modules": response,
+                    "applianceList": modules,
+                    "payload": appliance_list,
+                    "appliances": payload,
+                }[missing]
+                del container[missing]
+                probe = self.probe(response)
+                self.assertEqual("missing_key", probe["outcome"])
+                self.assertEqual(missing, probe["stopped_at"])
+                self.assertEqual("dict", probe["node_type"])
+                self.assertEqual(siblings, probe["siblings"])
+                # NOT 0: nothing here reached a list, and `count: 0` is reserved for
+                # the one state that did and found it empty.
+                self.assertIsNone(probe["count"])
+
+    def test_probe_names_the_level_a_non_dict_broke(self) -> None:
+        self.assertEqual(
+            {
+                "outcome": "not_a_dict",
+                "stopped_at": "applianceList",
+                "node_type": "int",
+                "siblings": None,
+                "count": None,
+            },
+            self.probe({"modules": 3}),
+        )
+        # The response itself is not a dict: the walk stops before its first segment.
+        probe = self.probe(None)
+        self.assertEqual("not_a_dict", probe["outcome"])
+        self.assertEqual("modules", probe["stopped_at"])
+        self.assertEqual("NoneType", probe["node_type"])
+
+    def test_probe_reports_a_non_list_leaf(self) -> None:
+        probe = self.probe(
+            {"modules": {"applianceList": {"payload": {"appliances": "x"}}}}
+        )
+        self.assertEqual("not_a_list", probe["outcome"])
+        self.assertEqual("str", probe["node_type"])
+        self.assertIsNone(probe["count"])
+
+    def test_a_count_of_zero_means_an_empty_list_and_nothing_else(self) -> None:
+        # The pin on `None` vs `0` for every non-ok branch. With `0` there, the single
+        # most consequential reading of the whole dump -- "the cloud sent an empty
+        # list, so the bug is not ours" -- would be indistinguishable from a walk that
+        # never got near a list.
+        for response, carries_empty_list in _EMPTY_LIST_TABLE:
+            with self.subTest(response=response):
+                self.assertEqual(
+                    carries_empty_list, self.probe(response)["count"] == 0
+                )
+
+    def test_probe_and_parse_agree_on_the_list(self) -> None:
+        # The probe is a SEPARATE walk, not a refactor of the parser (that
+        # independence is what makes it shippable on a setup path). This is the pin
+        # that keeps the two walks describing the same response.
+        table = [response for response, _ in _CASES]
+        table += _FAILSAFE
+        table += [response for response, _ in _EMPTY_LIST_TABLE]
+        self.assertGreaterEqual(len(table), 8)
+        for response in table:
+            with self.subTest(response=response):
+                probe = self.probe(response)
+                parsed = self.parse(response)
+                if probe["outcome"] == "ok":
+                    self.assertEqual(probe["count"], len(parsed))
+                else:
+                    self.assertEqual([], parsed)
+
+    def test_probe_never_raises(self) -> None:
+        # It runs inside NativeHon.setup(): an exception here does not spoil a
+        # diagnostic field, it takes the config entry down.
+        outcomes = {"ok", "not_a_dict", "missing_key", "not_a_list", "raised", "other"}
+        for response in (
+            None,
+            [],
+            "",
+            0,
+            {"modules": []},
+            {str(i): i for i in range(10_000)},
+            _deep(200),
+            _HostileDict({"modules": {}}),
+        ):
+            with self.subTest(response=type(response).__name__):
+                probe = self.probe(response)
+                self.assertIn(probe["outcome"], outcomes)
+        # The reserved token has exactly one producer, and this is it.
+        self.assertEqual("other", self.probe(_HostileDict({"modules": {}}))["outcome"])
+
+    def test_probe_emits_no_cloud_string(self) -> None:
+        # The leak test on the WRITER side. `stopped_at` looks like the natural place
+        # to put "the key we were looking for when we stopped", and the key we were
+        # looking for is ours -- but the SIBLING key names beside it are the cloud's,
+        # and a probe that reported them would ship a MAC-shaped key straight into a
+        # public issue.
+        hostile = {
+            "3C:71:BF:AA:BB:CC": "user@example.com",
+            "modules": {
+                "SN-PLAINTEXT": {"user@example.com": "3C:71:BF:AA:BB:CC"},
+            },
+        }
+        # A CLASS NAME is the third string the probe could copy, and the only one it
+        # reads from an object rather than from the response. `type(x).__name__` is
+        # chosen by whoever wrote the class, so `_node_type` MAPS it onto a literal
+        # set instead of returning it -- and every other node in this file is a plain
+        # dict/list/str, so without this leaf the mapping is never exercised and
+        # `return type(node).__name__` passes the whole suite.
+        leaked = type("Kitchen_Washer_3C71BFAABBCC", (), {})()
+        for probe in (
+            self.probe(hostile),
+            self.probe(
+                {
+                    "modules": {
+                        "applianceList": {
+                            "payload": {
+                                "appliances": [
+                                    {"macAddress": "3C:71:BF:AA:BB:CC"},
+                                    {"serialNumber": "SN-PLAINTEXT"},
+                                ]
+                            }
+                        }
+                    }
+                }
+            ),
+            self.probe(
+                {"modules": {"applianceList": {"payload": {"appliances": leaked}}}}
+            ),
+        ):
+            blob = json.dumps(probe)
+            for leak in (
+                "3C:71:BF:AA:BB:CC",
+                "user@example.com",
+                "SN-PLAINTEXT",
+                "Kitchen_Washer_3C71BFAABBCC",
+            ):
+                self.assertNotIn(leak, blob, leak)
+        # ...and the finding survives the mapping: the probe still says it reached the
+        # list and found something that is not one.
+        foreign = self.probe(
+            {"modules": {"applianceList": {"payload": {"appliances": leaked}}}}
+        )
+        self.assertEqual("not_a_list", foreign["outcome"])
+        self.assertEqual("other", foreign["node_type"])
+
+    def test_parse_appliance_list_return_type_is_unchanged(self) -> None:
+        # The probe was added beside the parser, not inside it. This is the whole
+        # claim, stated on the parser's own contract.
+        for response, _ in _CASES:
+            with self.subTest(response=response):
+                self.assertIsInstance(self.parse(response), list)
+        for response in _FAILSAFE:
+            with self.subTest(response=response):
+                self.assertIsInstance(self.parse(response), list)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated release PR for `v5.17.0`.

<!-- release-tag: v5.17.0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed diagnostics for appliance-list fetches, including outcomes, counts, timestamps, and safely summarized failure reasons.
  - Added setup accounting for skipped, expanded, and degraded appliances.
  - Setup failures and cancellations now retain useful diagnostic information for troubleshooting.
  - Added cleanup of stored failure details when an integration entry is removed.

- **Bug Fixes**
  - Improved handling and reporting of malformed appliance data and failed appliance-list requests.
  - Diagnostic output now remains stable when information is unavailable or invalid.

- **Chores**
  - Updated integration version to 5.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release adds bounded appliance-fetch and setup-failure diagnostics while preserving teardown when diagnostic properties fail.
- Records appliance-list response shape, outcome, timing, and setup accounting.
- Retains safe failure details after unsuccessful setup and removes them with the config entry.
- Updates the integration version to 5.17.0 and expands lifecycle, transport, parsing, and diagnostics tests.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/__init__.py | Retains setup-failure diagnostics while guarding record construction so teardown and cancellation semantics are preserved. |
| custom_components/addhon/client/session.py | Adds bounded setup accounting for expanded, skipped, built, and degraded appliance states. |
| custom_components/addhon/client/transport/api.py | Records a closed-domain census for appliance-list successes, malformed responses, and raised requests. |
| custom_components/addhon/client/transport/parse.py | Adds a failure-safe structural probe independent of the existing appliance-list parser. |
| custom_components/addhon/diagnostics.py | Renders validated fetch and failed-setup evidence with stable output shapes and safe fallback states. |
| custom_components/addhon/hon_client.py | Exposes and snapshots session diagnostics across setup failure and session closure. |
| custom_components/addhon/manifest.json | Advances the integration release version to 5.17.0. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HA as Home Assistant
    participant Client as HonClient
    participant API as Appliance API
    participant Store as Entry diagnostics
    participant Report as Diagnostics report
    HA->>Client: Set up config entry
    Client->>API: Fetch appliance list
    API-->>Client: Result or classified failure
    alt Setup succeeds
        Client-->>HA: Live client and coordinator
        Report->>Client: Read latest fetch census
    else Setup fails
        Client->>Store: Snapshot safe failure and fetch details
        Client-->>Client: Close session and background loop
        Report->>Store: Read retained setup-failure record
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(setup): let a raising census propert..."](https://github.com/tis24dev/addhon/commit/2c13a6d25f3607464cf9964e2be6c48754f9756a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56173207)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Home Assistant integration lifecycle](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/integration-lifecycle.md)
- Knowledge Base — [Client runtime and cloud sessions](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/client-runtime.md)
- Knowledge Base — [Session orchestration and runtime phases](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/session-orchestration.md)
- Knowledge Base — [API transport and protocol handling](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/api-transport-and-protocols.md)
- Knowledge Base — [Diagnostics and safe observability](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/diagnostics-and-safe-observability.md)
</details>


<!-- /greptile_comment -->