### PR TITLE
Make an empty appliance list diagnose itself

### DIFF
--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -290,16 +290,35 @@ class HonApi:
             # Request/auth OK but 0 appliances: log the response structure to
             # distinguish a truly empty account from an API change (the
             # unified-api list includes offline ones too).
-            modules = result.get("modules") if isinstance(result, dict) else None
+            # Reading the key NAMES is the last unguarded stretch of this method, and
+            # it is a diagnostic: `.get` and `.keys()` are calls on an object the cloud
+            # supplied, so on the hostile mapping the parse now survives they are what
+            # would still abort the setup -- and abort it while BUILDING the message
+            # that exists to explain the failure. The `n/a` above is the shape-mismatch
+            # answer; `unreadable` is the object-fought-back one, and they are worth
+            # telling apart in the log for the same reason `outcome: "other"` is worth
+            # telling apart in the dump.
+            try:
+                modules = result.get("modules") if isinstance(result, dict) else None
+                result_keys = sorted(result.keys()) if isinstance(result, dict) else "n/a"
+                module_keys = sorted(modules.keys()) if isinstance(modules, dict) else "n/a"
+            except Exception:  # noqa: BLE001 - a log line must never abort a setup
+                result_keys = module_keys = "unreadable"
+            # Emitted OUTSIDE the try so the code the user is told to search for is
+            # emitted whatever the body did: ADDHON-210 is the signal, the key names
+            # are the detail.
             _LOGGER.warning(
                 "[%s] hOn API: 0 appliances (request OK). result keys=%s; modules keys=%s. "
                 "If the appliances appear in the hOn app, it is more likely an API change "
                 "than an empty/unshared account.",
                 APPLIANCE_LIST_EMPTY.label,
-                sorted(result.keys()) if isinstance(result, dict) else "n/a",
-                sorted(modules.keys()) if isinstance(modules, dict) else "n/a",
+                result_keys,
+                module_keys,
             )
-            _LOGGER.debug("hOn raw appliance response: %s", redact_identity(result))
+            try:
+                _LOGGER.debug("hOn raw appliance response: %s", redact_identity(result))
+            except Exception:  # noqa: BLE001 - same rule, and this one is gated anyway
+                _LOGGER.debug("hOn raw appliance response: <unreadable>", exc_info=True)
         return appliances
 
     async def load_commands(self, appliance: Any) -> dict:

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -30,7 +30,8 @@ from typing import Any
 
 from . import device as _device
 from .connection import HonConnection
-from .parse import parse_appliance_list, probe_appliance_list
+from .parse import APPLIANCE_LIST_PATH, parse_appliance_list, probe_appliance_list
+from .tokens import token_person_account_id
 from .values import API_URL
 from ...debug_utils import redact_identity
 from ...error_codes import APPLIANCE_LIST_EMPTY, classify
@@ -48,6 +49,102 @@ def _command_timestamp() -> str:
     """
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     return f"{now.isoformat(timespec='milliseconds')}Z"
+
+
+# The verdicts `account_match` may return. PUBLIC (no leading underscore) for the same
+# reason `parse.APPLIANCE_LIST_PATH` is: a reader outside this module depends on it --
+# `tests/test_diagnostics.py` pins `diagnostics._FETCH_ACCOUNTS` against this tuple, so
+# the domain the dump is allowed to print cannot drift away from the domain the writer
+# produces. A verdict this build does not declare here would reach a document as
+# "other", which for an identity check is the one answer nobody can act on.
+ACCOUNT_TOKENS = ("match", "mismatch", "mixed", "no_appliances", "no_claim", "unknown")
+
+# The account id the cloud stamps on every element of the appliance list. Present on
+# 1/1 entries of the healthy live capture, alongside the DynamoDB `PK`/`SK` markers
+# that make the list a per-identity query rather than a per-account table
+# (apk/analysis/addhon210-healthy-envelope-baseline.md).
+_APPLIANCE_ACCOUNT_KEY = "sfPersonAccountId"
+
+
+def account_match(result: Any, person_account_id: str | None) -> str:
+    """Do the appliances the cloud returned belong to the account WE authenticated as?
+
+    The self-check the ADDHON-210 investigation kept needing and could not make: our
+    id_token carries `custom_attributes.PersonAccountId`, every appliance in the
+    response carries `sfPersonAccountId`, and until now nothing compared the two. A
+    session that silently resolves to a different account answers 200 with a
+    well-formed envelope and a list that is empty or simply not ours -- and every
+    other field of the dump reads like a legitimately empty account.
+
+    RETURNS A TOKEN OF `ACCOUNT_TOKENS`, NEVER AN IDENTIFIER. Both values compared here
+    are account ids; neither is emitted, neither is logged. That is the whole design
+    rule of the census block and the reason this function returns a verdict instead of
+    the two strings that produced it.
+
+    The verdicts, and why each is a different diagnosis:
+      * `no_claim`     -- OUR token has no readable PersonAccountId, so the check could
+                          not be attempted. Takes priority over everything below: it
+                          says the problem may be on our side of the wire.
+      * `unknown`      -- the claim is there but the response could not be read that
+                          far, or no appliance in it declares an owner.
+      * `no_appliances` -- the claim is there and the cloud returned an EMPTY list.
+                          Distinct from `unknown` for the one reason this function
+                          walks the response itself instead of calling
+                          `parse_appliance_list`: that parser returns `[]` for an empty
+                          list AND for a drift our walk cannot follow (its sec9
+                          fail-safe), which is exactly the distinction being made here.
+      * `match`        -- every appliance whose owner we could read is ours.
+      * `mismatch`     -- none of them is: the session resolved to another account.
+      * `mixed`        -- some are and some are not, i.e. the response spans accounts.
+
+    Appliances with no readable owner do not vote and are silent rather than counted
+    as a mismatch: a missing or non-string `sfPersonAccountId` is a schema question,
+    and the schema questions are what `probe_appliance_list` already answers. When
+    they are ALL silent the verdict is `unknown`, so a "match" is never returned by an
+    empty vote. `count` sits beside this field in the same block, so a reader can see
+    how many appliances the verdict was drawn from.
+
+    `type(owner) is str`, not isinstance: this is an equality test against a value
+    chosen by the cloud, and `json.loads` cannot produce a str subclass but a
+    duck-typed response double can -- one with an `__eq__` that returns True would turn
+    a mismatch into a match, which is the single most misleading thing this field could
+    say.
+
+    Never raises, for the reason `probe_appliance_list` gives at length: it runs inside
+    `NativeHon.setup()`, where an exception does not spoil a diagnostic field, it takes
+    the config entry down.
+    """
+    try:
+        if type(person_account_id) is not str or not person_account_id:
+            return "no_claim"
+        node: Any = result
+        for key in APPLIANCE_LIST_PATH:
+            if not isinstance(node, dict) or key not in node:
+                return "unknown"
+            node = node[key]
+        if not isinstance(node, list):
+            return "unknown"
+        if not node:
+            return "no_appliances"
+        ours = 0
+        theirs = 0
+        for entry in node:
+            owner = entry.get(_APPLIANCE_ACCOUNT_KEY) if isinstance(entry, dict) else None
+            if type(owner) is not str or not owner:
+                continue
+            if owner == person_account_id:
+                ours += 1
+            else:
+                theirs += 1
+        if not ours and not theirs:
+            return "unknown"
+        if not theirs:
+            return "match"
+        if not ours:
+            return "mismatch"
+        return "mixed"
+    except Exception:  # noqa: BLE001 - a census field must never abort a setup
+        return "unknown"
 
 
 class HonApi:
@@ -76,6 +173,22 @@ class HonApi:
     def auth(self) -> Any:
         """The connection's auth object."""
         return self._connection.auth
+
+    def _person_account_id(self) -> str | None:
+        """The account id OUR id_token claims, for `account_match`. Never emitted.
+
+        GUARDED, and the guard is not decoration: `HonConnection.auth` RAISES when the
+        connection was never created (connection.py:102-105), and every test double and
+        every duck-typed connection in this transport is free to have no `auth` at all.
+        This value feeds one census field, and the rule the census lives under is the
+        one the `getattr` on `resp.status` follows a few lines below -- a diagnostic
+        field must answer "unknown", never abort a setup.
+        """
+        try:
+            token = self.auth.id_token
+        except Exception:  # noqa: BLE001 - a census field must never abort a setup
+            return None
+        return token_person_account_id(token) if type(token) is str else None
 
     async def load_appliances(self) -> list:
         # The hOn app reads the appliance list from the unified-api aggregator via POST
@@ -124,6 +237,14 @@ class HonApi:
                 "node_type": None,
                 "siblings": None,
                 "count": None,
+                # Every field downstream of a body, written out as null rather than
+                # left off: the census key set must be the same on both paths, or the
+                # reader has to distinguish "the call never got a response" from "this
+                # build did not record that field yet".
+                "envelope_ok": None,
+                "module_ok": None,
+                "auth_keys": None,
+                "account": None,
             }
             raise
         # Recorded BEFORE the parse, and independently of it. "The cloud sent an empty
@@ -137,6 +258,13 @@ class HonApi:
             "status": status,
             "code": None,
             **probe_appliance_list(result),
+            # The identity self-check, and the only census field that needs something
+            # the RESPONSE does not carry -- which is why it is assembled here, where
+            # the connection (and through it our id_token) is in scope, instead of
+            # inside the probe. It walks the response itself for the reason its
+            # docstring gives: `parse_appliance_list` collapses "empty" and "drift"
+            # into the same `[]`, and telling those apart is half of what it answers.
+            "account": account_match(result, self._person_account_id()),
         }
         appliances = parse_appliance_list(result)
         if not appliances:

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -33,7 +33,7 @@ from .connection import HonConnection
 from .parse import APPLIANCE_LIST_PATH, parse_appliance_list, probe_appliance_list
 from .tokens import token_person_account_id
 from .values import API_URL
-from ...debug_utils import redact_identity, structure_only
+from ...debug_utils import redact_identity, safe_key_names, structure_only
 from ...error_codes import APPLIANCE_LIST_EMPTY, classify
 
 _LOGGER = logging.getLogger(__name__)
@@ -298,10 +298,16 @@ class HonApi:
             # answer; `unreadable` is the object-fought-back one, and they are worth
             # telling apart in the log for the same reason `outcome: "other"` is worth
             # telling apart in the dump.
+            # `safe_key_names`, not `sorted(...keys())`. Reading "just the names" looks
+            # obviously harmless and is not: a mapping the vendor keyed BY a serial or
+            # by a cognito identity partition carries that identity in the key
+            # position, and this line goes to a level meant for pasting into public
+            # issues. Same shape rule as the response shape below, so the summary and
+            # the detail cannot disagree about what is safe to print.
             try:
                 modules = result.get("modules") if isinstance(result, dict) else None
-                result_keys = sorted(result.keys()) if isinstance(result, dict) else "n/a"
-                module_keys = sorted(modules.keys()) if isinstance(modules, dict) else "n/a"
+                result_keys = safe_key_names(result)
+                module_keys = safe_key_names(modules)
             except Exception:  # noqa: BLE001 - a log line must never abort a setup
                 result_keys = module_keys = "unreadable"
             # Emitted OUTSIDE the try so the code the user is told to search for is

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -74,7 +74,9 @@ def account_match(result: Any, person_account_id: str | None) -> str:
     response carries `sfPersonAccountId`, and until now nothing compared the two. A
     session that silently resolves to a different account answers 200 with a
     well-formed envelope and a list that is empty or simply not ours -- and every
-    other field of the dump reads like a legitimately empty account.
+    other field of the dump reads like a legitimately empty account. What this field
+    adds is the account BOUNDARY; whether crossing it is a fault is a question the
+    complaint answers, not this function (see the note under the verdicts).
 
     RETURNS A TOKEN OF `ACCOUNT_TOKENS`, NEVER AN IDENTIFIER. Both values compared here
     are account ids; neither is emitted, neither is logged. That is the whole design
@@ -94,8 +96,25 @@ def account_match(result: Any, person_account_id: str | None) -> str:
                           list AND for a drift our walk cannot follow (its sec9
                           fail-safe), which is exactly the distinction being made here.
       * `match`        -- every appliance whose owner we could read is ours.
-      * `mismatch`     -- none of them is: the session resolved to another account.
-      * `mixed`        -- some are and some are not, i.e. the response spans accounts.
+      * `mismatch`     -- none of them is.
+      * `mixed`        -- some are and some are not.
+
+    `mismatch` AND `mixed` ARE NOT FAULTS ON THEIR OWN, and reading them as one would
+    mis-triage a healthy install. hOn family sharing puts appliances a member does not
+    OWN into that member's own list -- the same `view/appliance-list` serves owned and
+    shared alike, proven by the app re-running `retrieveInitialAppliances()` when an
+    invitation turns CONFIRMED (apk/analysis/addhon210-empty-appliance-list.md). A user
+    who joined someone else's group therefore sees every appliance stamped with the
+    OWNER's account id, and reads `mismatch` while everything works. A household where
+    one of two appliances is shared reads `mixed`, likewise correctly.
+
+    What the two verdicts actually mean is "the list is not stamped with our account
+    id", which is a fact, not a diagnosis. They earn their weight only NEXT TO the
+    symptom: a `mismatch` on a user who reports missing appliances says the session and
+    the appliances are on different sides of an account boundary, which is worth
+    chasing; the same `mismatch` on a working install says the user is a group member,
+    which is worth nothing. `no_appliances` is the verdict that carries a complaint on
+    its own, because an empty list is the complaint.
 
     Appliances with no readable owner do not vote and are silent rather than counted
     as a mismatch: a missing or non-string `sfPersonAccountId` is a schema question,

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -307,18 +307,42 @@ class HonApi:
             # Emitted OUTSIDE the try so the code the user is told to search for is
             # emitted whatever the body did: ADDHON-210 is the signal, the key names
             # are the detail.
+            #
+            # THE CENSUS TRAVELS WITH THE WARNING, at WARNING level, and that is a
+            # deliberate departure from "diagnostics live in the dump". This branch is
+            # reached only when the account shows no appliances -- the single hardest
+            # report to act on, and the one where asking for a downloaded dump has
+            # repeatedly failed to produce one. Every value here is a closed-domain
+            # token or a bounded int produced by OUR code (`probe_appliance_list`,
+            # `account_match`), not a value chosen by the cloud, so the line is
+            # leak-proof by the same construction the dump block relies on and can be
+            # pasted into a public issue as it stands. A reporter who can copy one log
+            # line can now hand over a complete diagnosis without touching a toggle.
+            census = self.last_appliance_fetch or {}
             _LOGGER.warning(
-                "[%s] hOn API: 0 appliances (request OK). result keys=%s; modules keys=%s. "
+                "[%s] hOn API: 0 appliances (request OK). result keys=%s; modules keys=%s; "
+                "envelope_ok=%s module_ok=%s auth_keys=%s account=%s. "
                 "If the appliances appear in the hOn app, it is more likely an API change "
                 "than an empty/unshared account.",
                 APPLIANCE_LIST_EMPTY.label,
                 result_keys,
                 module_keys,
+                census.get("envelope_ok"),
+                census.get("module_ok"),
+                census.get("auth_keys"),
+                census.get("account"),
             )
+            # WARNING, not DEBUG. This is the line the investigation asked for about ten
+            # times and never got, because it required the reporter to enable a toggle
+            # BEFORE a reload -- the appliance-list call happens once, during setup, so
+            # turning debug on afterwards captures nothing. The cost of raising it is
+            # bounded by the branch it sits in: it prints only when the list is empty,
+            # which is when the body is small, and never on a working install.
+            # `redact_identity` keeps the structure and masks the identity values.
             try:
-                _LOGGER.debug("hOn raw appliance response: %s", redact_identity(result))
-            except Exception:  # noqa: BLE001 - same rule, and this one is gated anyway
-                _LOGGER.debug("hOn raw appliance response: <unreadable>", exc_info=True)
+                _LOGGER.warning("hOn raw appliance response: %s", redact_identity(result))
+            except Exception:  # noqa: BLE001 - a log line must never abort a setup
+                _LOGGER.warning("hOn raw appliance response: <unreadable>", exc_info=True)
         return appliances
 
     async def load_commands(self, appliance: Any) -> dict:

--- a/custom_components/addhon/client/transport/api.py
+++ b/custom_components/addhon/client/transport/api.py
@@ -33,7 +33,7 @@ from .connection import HonConnection
 from .parse import APPLIANCE_LIST_PATH, parse_appliance_list, probe_appliance_list
 from .tokens import token_person_account_id
 from .values import API_URL
-from ...debug_utils import redact_identity
+from ...debug_utils import redact_identity, structure_only
 from ...error_codes import APPLIANCE_LIST_EMPTY, classify
 
 _LOGGER = logging.getLogger(__name__)
@@ -332,17 +332,28 @@ class HonApi:
                 census.get("auth_keys"),
                 census.get("account"),
             )
-            # WARNING, not DEBUG. This is the line the investigation asked for about ten
-            # times and never got, because it required the reporter to enable a toggle
-            # BEFORE a reload -- the appliance-list call happens once, during setup, so
-            # turning debug on afterwards captures nothing. The cost of raising it is
-            # bounded by the branch it sits in: it prints only when the list is empty,
-            # which is when the body is small, and never on a working install.
-            # `redact_identity` keeps the structure and masks the identity values.
+            # WARNING, not DEBUG. This is the artefact the investigation asked for about
+            # ten times and never got, because it required the reporter to enable a
+            # toggle BEFORE a reload -- the appliance-list call happens once, during
+            # setup, so turning debug on afterwards captures nothing.
+            #
+            # SHAPE, not the redacted body. `redact_identity` is a blacklist keyed on
+            # names, and a blacklist is always one vendor spelling behind: `token` was
+            # in it and `cognitoTokenNew` -- the replacement bearer credential the
+            # aggregator returns inside `authInfo` -- was not. Promoting a
+            # masked-by-blacklist body to a level meant for pasting into public issues
+            # is the wrong trade; `structure_only` copies no leaf value at all, so
+            # there is nothing left to have forgotten to mask.
+            #
+            # It costs almost nothing HERE, which is why it is affordable: this branch
+            # fires when `appliances` is `[]`, so the body carries no appliance data to
+            # begin with. What survives is the envelope -- both `success` flags, the
+            # shape of `payload`, how many keys `authInfo` holds -- which is precisely
+            # what "why is the list empty" is asking about.
             try:
-                _LOGGER.warning("hOn raw appliance response: %s", redact_identity(result))
+                _LOGGER.warning("hOn appliance response shape: %s", structure_only(result))
             except Exception:  # noqa: BLE001 - a log line must never abort a setup
-                _LOGGER.warning("hOn raw appliance response: <unreadable>", exc_info=True)
+                _LOGGER.warning("hOn appliance response shape: <unreadable>", exc_info=True)
         return appliances
 
     async def load_commands(self, appliance: Any) -> dict:

--- a/custom_components/addhon/client/transport/parse.py
+++ b/custom_components/addhon/client/transport/parse.py
@@ -34,19 +34,40 @@ def parse_appliance_list(result: Any) -> list:
     Returns the list at `modules.applianceList.payload.appliances`. Any unexpected
     shape (missing key, non-dict intermediate level, non-list final value)
     -> `[]`. A non-list but *truthy* final value = schema drift: log + `[]`.
+
+    The guard makes that promise TRUE rather than merely stated. `isinstance` accepts
+    a dict SUBCLASS, and a subclass is free to raise from `get` -- in production
+    `json.loads` cannot build one, but the input is `await resp.json(content_type=None)`
+    on a duck-typed response, so "a json.loads output cannot raise here" is not the
+    same claim as "this can never abort a setup". It runs inside `NativeHon.setup()`
+    (session.py), where an exception does not spoil a returned list, it takes the
+    config entry down with a bare TypeError that names nothing a reporter can act on.
+
+    NOTHING IS LOST BY SWALLOWING IT. `probe_appliance_list` walks the same response
+    under its own guard and reports `outcome: "other"` for exactly this input, and that
+    token reaches the diagnostics dump, so the difference between "the cloud sent an
+    empty list" and "the body fought back" survives in the one place a reader looks.
+    Returning `[]` also keeps the single documented contract instead of adding a second
+    failure mode that only this call site would know how to handle.
     """
-    node: Any = result
-    for key in APPLIANCE_LIST_PATH:
-        if not isinstance(node, dict):
-            return []
-        node = node.get(key)
-    if isinstance(node, list):
-        return node
-    if node:
-        _LOGGER.warning(
-            "appliance-list response: 'appliances' of unexpected type %s, ignored",
-            type(node).__name__,
-        )
+    try:
+        node: Any = result
+        for key in APPLIANCE_LIST_PATH:
+            if not isinstance(node, dict):
+                return []
+            node = node.get(key)
+        if isinstance(node, list):
+            return node
+        if node:
+            _LOGGER.warning(
+                "appliance-list response: 'appliances' of unexpected type %s, ignored",
+                type(node).__name__,
+            )
+    except Exception:  # noqa: BLE001 - a parse must never abort a setup
+        # Deliberately not logged here: the caller already emits ADDHON-210 with the
+        # response structure when the list comes back empty, and the census carries
+        # `outcome: "other"`. A second warning would say less and repeat more.
+        return []
     return []
 
 

--- a/custom_components/addhon/client/transport/parse.py
+++ b/custom_components/addhon/client/transport/parse.py
@@ -65,6 +65,84 @@ def _node_type(node: Any) -> str:
     return name if name in _NODE_TYPES else "other"
 
 
+# The envelope ABOVE the payload, and the two keys read there. The path is SLICED from
+# `APPLIANCE_LIST_PATH` instead of being written again, because `success` and
+# `authInfo` are only ever looked up in the module envelope -- if a level of the
+# response is ever renamed, both walks have to move together or the flags would start
+# describing a different node than the one `stopped_at` names.
+_MODULE_PATH = APPLIANCE_LIST_PATH[:2]
+_SUCCESS_KEY = "success"
+# `authInfo` is the channel through which the cloud can hand back a REPLACEMENT cognito
+# token (`cognitoTokenNew`): the hOn app adopts it in its generic request layer
+# (decomp.txt:525784-525805) and this integration has never read it at all. On a
+# freshly authenticated session it is verifiably `{}` (live capture,
+# apk/analysis/addhon210-healthy-envelope-baseline.md), which is what makes a COUNT
+# worth having: a channel that is silent when things are healthy turns any content
+# into a signal. Only the size is taken. Never a key NAME and never a value -- one of
+# those values is a bearer token, and a count carries no identity at all.
+_AUTH_INFO_KEY = "authInfo"
+
+
+def _flag(node: Any) -> bool | None:
+    """`node` when it is a real bool, else None.
+
+    `type(node) is bool`, not isinstance and not `bool(node)`: the point of these two
+    fields is to report what the cloud SAID, so `1`, `"true"` and `"false"` must all
+    read as "this build could not tell", not as True. Coercing would invent the one
+    answer the field exists to establish. `bool` cannot be subclassed in CPython, so
+    the value returned here is `True`, `False` or `None` and nothing else can wear
+    those clothes.
+    """
+    return node if type(node) is bool else None
+
+
+def _envelope_flags(result: Any) -> dict:
+    """The two `success` flags and the SIZE of `authInfo`, above the payload walk.
+
+    Why they are here at all. On the ADDHON-210 report the cloud answered 200 with a
+    well-formed envelope and an empty list, and the dump could say only that. But a
+    live capture of a HEALTHY response (2026-08-24, one appliance) shows the module
+    envelope carries its OWN `success` beside the payload -- and neither this
+    integration NOR the official app reads it. A `modules.applianceList.success` of
+    false is therefore a state in which the app shows zero appliances too, and in
+    which every field the dump already prints looks exactly like a legitimately empty
+    account. Two booleans separate those, and nothing else in the document can.
+
+    Read BEFORE the payload walk and merged into every branch of
+    `probe_appliance_list`, including the ones that stop early. The failure branches
+    are precisely where a reader most needs to know whether the cloud declared the
+    call a success: "our walk stopped at `payload`" and "the module reported failure,
+    so there was no payload to walk" are the same picture until these are in it.
+
+    Same leak-proof contract as the rest of the probe: `_flag` returns one of two
+    singletons of this file or None, and `auth_keys` is `len()` of a mapping -- an
+    int, which cannot carry identity. Not one string from the response is read.
+
+    Never raises, and keeps whatever it managed to read when something does: the guard
+    is `probe_appliance_list`'s (see its docstring) applied one level down, so a
+    hostile mapping cannot cost the caller the flags it had already established.
+    """
+    flags: dict = {"envelope_ok": None, "module_ok": None, "auth_keys": None}
+    try:
+        if not isinstance(result, dict):
+            return flags
+        flags["envelope_ok"] = _flag(result.get(_SUCCESS_KEY))
+        node: Any = result
+        for key in _MODULE_PATH:
+            if not isinstance(node, dict):
+                return flags
+            node = node.get(key)
+        if not isinstance(node, dict):
+            return flags
+        flags["module_ok"] = _flag(node.get(_SUCCESS_KEY))
+        auth_info = node.get(_AUTH_INFO_KEY)
+        if isinstance(auth_info, dict):
+            flags["auth_keys"] = len(auth_info)
+    except Exception:  # noqa: BLE001 - a probe must never abort a setup
+        return flags
+    return flags
+
+
 def probe_appliance_list(result: Any) -> dict:
     """Where the appliance-list walk stopped, as closed-domain primitives.
 
@@ -93,22 +171,33 @@ def probe_appliance_list(result: Any) -> dict:
     inside `NativeHon.setup()` (session.py:450), so "it cannot raise on a json.loads
     output" is not the same claim as "it can never abort a setup" -- the guard makes the
     second one true too, and gives the reserved "other" token its only producer.
+
+    `envelope_ok`/`module_ok`/`auth_keys` describe the envelope ABOVE the walk and are
+    computed by `_envelope_flags` FIRST, then merged into every branch below --
+    including the early returns and the `except`. A flag captured only on the happy
+    path would be missing from exactly the responses that need explaining: see that
+    function for what the three answer.
     """
+    flags = _envelope_flags(result)
     try:
         node: Any = result
         for key in APPLIANCE_LIST_PATH:
             if not isinstance(node, dict):
                 return {"outcome": "not_a_dict", "stopped_at": key,
-                        "node_type": _node_type(node), "siblings": None, "count": None}
+                        "node_type": _node_type(node), "siblings": None,
+                        "count": None, **flags}
             if key not in node:
                 return {"outcome": "missing_key", "stopped_at": key,
-                        "node_type": "dict", "siblings": len(node), "count": None}
+                        "node_type": "dict", "siblings": len(node),
+                        "count": None, **flags}
             node = node[key]
         if isinstance(node, list):
             return {"outcome": "ok", "stopped_at": None,
-                    "node_type": "list", "siblings": None, "count": len(node)}
+                    "node_type": "list", "siblings": None,
+                    "count": len(node), **flags}
         return {"outcome": "not_a_list", "stopped_at": None,
-                "node_type": _node_type(node), "siblings": None, "count": None}
+                "node_type": _node_type(node), "siblings": None,
+                "count": None, **flags}
     except Exception:  # noqa: BLE001 - a probe must never abort a setup
         return {"outcome": "other", "stopped_at": None,
-                "node_type": None, "siblings": None, "count": None}
+                "node_type": None, "siblings": None, "count": None, **flags}

--- a/custom_components/addhon/client/transport/tokens.py
+++ b/custom_components/addhon/client/transport/tokens.py
@@ -19,6 +19,12 @@ Two independent pieces, both authored from public contracts (RFC 6749 / RFC 7519
 
 2. :func:`token_expiry` -- read the JWT ``exp`` claim (RFC 7519 sec4.1.4) so the
    transport trusts the token's own stated lifetime instead of a guessed constant.
+
+3. :func:`token_person_account_id` -- read the Salesforce person-account id our own
+   id_token claims, so the appliance-list census can check WHOSE account the cloud
+   answered for without asking the cloud anything (see :func:`api.account_match`).
+   A sibling of `token_expiry`, over the same decoder: both are unverified reads of a
+   claim out of a token we already hold.
 """
 from __future__ import annotations
 
@@ -78,13 +84,24 @@ def parse_token_fragment(text: str) -> OAuthTokens:
     )
 
 
-def token_expiry(jwt: str) -> float | None:
-    """Unverified read of a JWT's ``exp`` claim as epoch seconds (RFC 7519 sec4.1.4).
+def _jwt_claims(jwt: str) -> dict | None:
+    """Unverified read of a JWT payload section as a claims mapping, or None.
 
-    The signature is NOT checked (the IdP already validated it and we only need the
-    stated lifetime, so we never send a token past its own ``exp``). Returns None for
-    anything that is not a readable JWT with a numeric ``exp`` -- the caller then falls
-    back to a conservative window rather than trusting a made-up lifetime.
+    The signature is NOT checked: every caller reads a token THIS process already
+    holds and the IdP already validated, and none of them makes a trust decision on
+    what comes back -- `token_expiry` only shortens a lifetime, and
+    `token_person_account_id` only feeds a comparison whose output is a closed-domain
+    token. A verifying parser here would need the IdP's keys and a network round trip
+    to answer a question nobody asks.
+
+    EXTRACTED from `token_expiry` rather than copied into the second reader. The three
+    steps below (take section 1, restore the base64url padding RFC 7515 sec2 strips,
+    urlsafe-decode) are exactly the ones that go wrong quietly: a padding rule that
+    drifts between two copies gives one reader a claim and the other a None, and this
+    one sits under the token-refresh path of every request in the transport.
+
+    Returns None -- never a partial value -- for anything that is not a readable JWT
+    carrying a JSON OBJECT, so a caller always reads its claim off a real mapping.
     """
     try:
         payload_b64 = jwt.split(".")[1]
@@ -95,5 +112,55 @@ def token_expiry(jwt: str) -> float | None:
         claims = json.loads(base64.urlsafe_b64decode(payload_b64))
     except (binascii.Error, ValueError, UnicodeDecodeError):
         return None
-    exp = claims.get("exp") if isinstance(claims, dict) else None
+    return claims if isinstance(claims, dict) else None
+
+
+def token_expiry(jwt: str) -> float | None:
+    """Unverified read of a JWT's ``exp`` claim as epoch seconds (RFC 7519 sec4.1.4).
+
+    The signature is NOT checked (the IdP already validated it and we only need the
+    stated lifetime, so we never send a token past its own ``exp``). Returns None for
+    anything that is not a readable JWT with a numeric ``exp`` -- the caller then falls
+    back to a conservative window rather than trusting a made-up lifetime.
+
+    `bool` is refused explicitly: ``isinstance(True, int)`` is True, and an ``exp`` of
+    ``true`` would otherwise become an expiry of 1.0 (the epoch), i.e. a token this
+    transport would consider permanently stale.
+    """
+    claims = _jwt_claims(jwt)
+    exp = claims.get("exp") if claims is not None else None
     return float(exp) if isinstance(exp, (int, float)) and not isinstance(exp, bool) else None
+
+
+# Where the hOn id_token keeps its Salesforce identity claims. Both names are OURS --
+# read off a live capture of this integration's own token and written down here
+# (apk/analysis/addhon210-healthy-envelope-baseline.md) -- not values chosen by the
+# cloud, so nothing in this lookup can be steered by a response.
+_CUSTOM_ATTRIBUTES = "custom_attributes"
+_PERSON_ACCOUNT_ID = "PersonAccountId"
+
+
+def token_person_account_id(jwt: str) -> str | None:
+    """The ``custom_attributes.PersonAccountId`` claim of an id_token, or None.
+
+    The one identity of ours that the appliance-list response also carries: every
+    appliance in it is stamped with `sfPersonAccountId`, so this claim is what lets
+    `api.account_match` answer "did this session resolve to the account we think we
+    are logged into" WITHOUT a second request and without the cloud's cooperation.
+
+    Returns None -- "we have no identity to compare with", a diagnosis in its own
+    right -- for a token that is not readable, that carries no `custom_attributes`
+    object, or whose claim is absent or empty. `type(value) is str`, not isinstance:
+    the value is about to be compared for equality against a string from the cloud,
+    and a str SUBCLASS is free to override `__eq__` so that it equals anything, which
+    would turn a mismatch into a match. `json.loads` cannot produce one; a future
+    caller handing this function a claims-shaped object could.
+
+    THE VALUE IS AN IDENTIFIER AND NEVER LEAVES THE PROCESS. Its only consumer
+    compares it and emits a token of `api.ACCOUNT_TOKENS`; it is never logged, never
+    stored, and never reaches a diagnostics document.
+    """
+    claims = _jwt_claims(jwt)
+    custom = claims.get(_CUSTOM_ATTRIBUTES) if claims is not None else None
+    value = custom.get(_PERSON_ACCOUNT_ID) if isinstance(custom, dict) else None
+    return value if type(value) is str and value else None

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -228,6 +228,24 @@ def redact_identity(obj):
     return obj
 
 
+def safe_key_names(obj) -> list | str:
+    """The sorted key names of a mapping, each masked unless it is a schema key.
+
+    The companion of `structure_only` for the places that want the names alone. Same
+    rule and the same reason: a mapping the vendor keyed BY a serial or by a cognito
+    identity partition puts that identity in the key position, where copying "just the
+    names" is copying a value. `sorted(x.keys())` reads as obviously safe and is not.
+
+    Returns "n/a" for a non-mapping, so a caller can print the result either way.
+    """
+    if not isinstance(obj, dict):
+        return "n/a"
+    return sorted(
+        key if _is_schema_key(key) and not _is_identity_key(key) else _REDACTED
+        for key in obj
+    )
+
+
 def structure_only(obj, _depth: int = 0):
     """The SHAPE of a response: key names and value types, never a value.
 

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -107,6 +107,30 @@ _IDENTITY_KEYS = frozenset(
 # and a wider list would start masking the structure the logs exist to show.
 _IDENTITY_KEY_PARTS = ("token", "password", "secret")
 
+# A key NAME is safe to print only when it is a SCHEMA key -- a name the vendor's
+# developers typed -- and not a value the vendor used AS a key. The distinction cannot
+# be made by blacklist (that is what `cognitoTokenNew` cost), so it is made by SHAPE,
+# the same way `_ADDHON_LABEL_RE` bounds a catalog label in the diagnostics dump.
+#
+# A schema key is a short identifier with at least one lowercase letter: `payload`,
+# `applianceTypeName`, `fwVersion`, `authInfo`. A value used as a key is not: an
+# identity partition `user#eu-west-1:8f3c-...` fails on `#` and `:`, a serial
+# `ABC123456789` fails for having no lowercase, an email fails on `@`, a UUID fails on
+# `-`, and anything the vendor made long fails the length bound. Digit runs are capped
+# because a schema key does not carry a five-digit number; `tempSelZ2` survives, a
+# stock code does not.
+_SCHEMA_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,39}$")
+_DIGIT_RUN_RE = re.compile(r"[0-9]{5,}")
+
+
+def _is_schema_key(key) -> bool:
+    """True when a key NAME may be printed as-is in a log meant for public issues."""
+    if not isinstance(key, str) or not _SCHEMA_KEY_RE.match(key):
+        return False
+    if _DIGIT_RUN_RE.search(key):
+        return False
+    return any(c.islower() for c in key)
+
 
 def _is_identity_key(key) -> bool:
     if not isinstance(key, str):
@@ -218,10 +242,12 @@ def structure_only(obj, _depth: int = 0):
     begin with: what is left is the envelope, which is exactly what the question
     "why is the list empty" is about.
 
-    Key NAMES are emitted, because they are the answer, and they are the same class of
-    value the ADDHON-210 line already prints as `result keys=`. A name that is itself
-    identity (a mapping keyed by MAC, an identity key holding a nested object) is
-    masked with the same rules as the values.
+    Key NAMES are emitted, because they are the answer -- but only the ones that pass
+    `_is_schema_key`, a SHAPE test rather than a blacklist. A mapping keyed by a serial,
+    by an account id or by a cognito identity partition (`user#<region>:<identity>`) is
+    a vendor using a VALUE as a key, and its names are masked exactly like values. That
+    residual is why this is not simply `{k: type(v)}`: printing every key verbatim would
+    reintroduce, one level up, the leak the whole function exists to remove.
 
     Depth-bounded so a self-referential or pathologically nested body cannot turn a log
     line into a hang; the bound is generous next to the four levels the envelope has.
@@ -230,9 +256,9 @@ def structure_only(obj, _depth: int = 0):
         return "<deeper>"
     if isinstance(obj, dict):
         return {
-            (_REDACTED if _is_identity_key(key) else _MAC_RE.sub(_REDACTED, str(key))): (
+            (key if _is_schema_key(key) and not _is_identity_key(key) else _REDACTED): (
                 _REDACTED
-                if _is_identity_key(key)
+                if _is_identity_key(key) or not _is_schema_key(key)
                 else structure_only(val, _depth + 1)
             )
             for key, val in obj.items()

--- a/custom_components/addhon/debug_utils.py
+++ b/custom_components/addhon/debug_utils.py
@@ -85,8 +85,34 @@ _IDENTITY_KEYS = frozenset(
         "transaction_id",
         "mobileid",
         "mobile_id",
+        # Added after the appliance-list envelope was captured live: the cloud stamps
+        # each appliance with its owning Salesforce account and with DynamoDB keys whose
+        # PK is `user#<region>:<cognito-identity>` -- the identity itself, in plain text
+        # under a two-letter key no exact-name rule would have guessed.
+        "sfpersonaccountid",
+        "personaccountid",
+        "personcontactid",
+        "pk",
+        "sk",
+        "applianceid",
+        "eepromid",
     }
 )
+
+# Substring rule, applied to the lowercased key AFTER the exact set misses. The exact
+# set cannot enumerate a vendor's naming: `token` is in it and `cognitoTokenNew` is not,
+# which is how a bearer credential the aggregator returns inside `authInfo` would have
+# travelled unmasked into a log this project asks users to paste into public issues.
+# Kept deliberately short -- these three words do not appear in a benign key by accident,
+# and a wider list would start masking the structure the logs exist to show.
+_IDENTITY_KEY_PARTS = ("token", "password", "secret")
+
+
+def _is_identity_key(key) -> bool:
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    return lowered in _IDENTITY_KEYS or any(p in lowered for p in _IDENTITY_KEY_PARTS)
 
 
 # A float holds every integer only up to 2**53. Past that, distinct integers share one
@@ -155,8 +181,10 @@ def _as_float(text: str) -> float | None:
 def redact_identity(obj):
     """Deep-copy a mapping/list masking identity/credential VALUES to '***'.
 
-    Redaction is keyed on the dict KEY name (exact, case-insensitive) against
-    _IDENTITY_KEYS. As a second layer, any MAC embedded in a STRING LEAF is masked
+    Redaction is keyed on the dict KEY name (case-insensitive) against _IDENTITY_KEYS
+    exactly, then against _IDENTITY_KEY_PARTS as a substring -- the second rule exists
+    because an exact set cannot enumerate a vendor's naming, and `cognitoTokenNew` is
+    the counter-example that proved it: `token` was in the set and that key was not. As a second layer, any MAC embedded in a STRING LEAF is masked
     too (same _MAC_RE as redact_topic) -- so identity that arrives where key-name
     redaction can't reach it (a bare list element, or a value under a benign key, e.g.
     a malformed MQTT `parameters` scalar -- CR#4) does not slip through. Non-MAC
@@ -166,11 +194,7 @@ def redact_identity(obj):
     """
     if isinstance(obj, dict):
         return {
-            key: (
-                _REDACTED
-                if isinstance(key, str) and key.lower() in _IDENTITY_KEYS
-                else redact_identity(val)
-            )
+            key: (_REDACTED if _is_identity_key(key) else redact_identity(val))
             for key, val in obj.items()
         }
     if isinstance(obj, (list, tuple)):
@@ -178,6 +202,50 @@ def redact_identity(obj):
     if isinstance(obj, str):
         return _MAC_RE.sub(_REDACTED, obj)
     return obj
+
+
+def structure_only(obj, _depth: int = 0):
+    """The SHAPE of a response: key names and value types, never a value.
+
+    `redact_identity` is a blacklist, and a blacklist is always one vendor spelling
+    behind -- `cognitoTokenNew` proved that at the cost of a bearer token nearly
+    reaching a public issue. Where a log is meant to be pasted in public, the shape is
+    the stronger contract: no leaf value is copied at all, so there is nothing to have
+    forgotten to mask.
+
+    It loses less than it sounds on the branch that uses it. The empty-list warning
+    fires when `appliances` is `[]`, so the response carries no appliance data to
+    begin with: what is left is the envelope, which is exactly what the question
+    "why is the list empty" is about.
+
+    Key NAMES are emitted, because they are the answer, and they are the same class of
+    value the ADDHON-210 line already prints as `result keys=`. A name that is itself
+    identity (a mapping keyed by MAC, an identity key holding a nested object) is
+    masked with the same rules as the values.
+
+    Depth-bounded so a self-referential or pathologically nested body cannot turn a log
+    line into a hang; the bound is generous next to the four levels the envelope has.
+    """
+    if _depth >= 8:
+        return "<deeper>"
+    if isinstance(obj, dict):
+        return {
+            (_REDACTED if _is_identity_key(key) else _MAC_RE.sub(_REDACTED, str(key))): (
+                _REDACTED
+                if _is_identity_key(key)
+                else structure_only(val, _depth + 1)
+            )
+            for key, val in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        # The length is the finding on this branch: `<list of 0>` IS the report.
+        if not obj:
+            return "<list of 0>"
+        return [f"<list of {len(obj)}>", structure_only(obj[0], _depth + 1)]
+    if isinstance(obj, bool) or obj is None:
+        # Booleans and null are the envelope's own verdicts (`success`), not data.
+        return obj
+    return f"<{type(obj).__name__}>"
 
 
 def redact_mac(mac: str | None) -> str | None:

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -2829,6 +2829,15 @@ _FETCH_OUTCOMES = frozenset(
 _FETCH_NODE_TYPES = frozenset(
     {"dict", "list", "str", "int", "float", "bool", "NoneType", "other"}
 )
+# The verdicts of the identity self-check `api.account_match` makes: does the account
+# our id_token names still own the appliances the cloud answered with. Duplicated and
+# drift-tested against `api.ACCOUNT_TOKENS` exactly like the sets above -- and here the
+# duplication matters more than anywhere else in the block, because a verdict this
+# build has not heard of would print as "other", which for an identity question is the
+# one answer a reader cannot act on.
+_FETCH_ACCOUNTS = frozenset(
+    {"match", "mismatch", "mixed", "no_appliances", "no_claim", "unknown"}
+)
 # The reasons a setup may drop an appliance the cloud returned. The counts arrive from
 # the session, which declares the same tokens as `SETUP_DROP_REASONS` and is pinned
 # against this tuple by a drift guard; a reason this build does not know is a reason
@@ -2873,6 +2882,25 @@ def _bounded_int(value, low: int, high: int) -> int | None:
     """An int inside [low, high], else None. `bool` is refused on purpose:
     isinstance(True, int) is True and would render this field as `true`."""
     return value if type(value) is int and low <= value <= high else None
+
+
+def _closed_bool(value) -> bool | None:
+    """`True`, `False` or None -- never the object the writer handed over.
+
+    The mirror image of `_bounded_int` beside it: that one refuses a bool because
+    isinstance(True, int) is True, this one refuses an INT because `1` is not the same
+    statement as `true`. The fields it guards report what the CLOUD said about its own
+    call, so `1`, `"true"` and `"success"` must all come out as null -- "this build
+    could not tell" -- rather than be coerced into the very answer the field exists to
+    establish. `bool(value)` here would make every non-empty string in the document
+    read as a cloud that declared success.
+
+    `type(value) is bool` also makes the output provably one of two singletons of this
+    process: `bool` cannot be subclassed in CPython, so unlike `_closed_token` there is
+    no `__eq__` trick to close and no "other" bucket to keep -- the value is a literal
+    or it is nothing.
+    """
+    return value if type(value) is bool else None
 
 
 def _label_token(value) -> str | None:
@@ -2950,6 +2978,7 @@ def _fetch_empty() -> dict:
     return {
         "at": None, "age_s": None, "status": None, "code": None, "outcome": None,
         "stopped_at": None, "node_type": None, "siblings": None, "count": None,
+        "envelope_ok": None, "module_ok": None, "auth_keys": None, "account": None,
         "expanded": None, "built": None, "skipped": {}, "degraded": {},
     }
 
@@ -2975,10 +3004,16 @@ def _last_fetch(hass: HomeAssistant, entry: ConfigEntry, *, now: datetime) -> di
 
     Leak-proof by construction on the strongest terms in the file: every KEY is a
     literal written above, and every VALUE is either an int this function range-checks,
-    an instant `_stamp_text` validates against `_ISO_RE`, a token `_closed_token` looks
-    up in a frozenset written above, or a label `_label_token` shape-checks. Not one
-    string from the cloud, from the session or from the client is copied into the
-    document -- so `_redact` is not merely skipped here, it would have nothing to do.
+    a boolean `_closed_bool` refuses to coerce, an instant `_stamp_text` validates
+    against `_ISO_RE`, a token `_closed_token` looks up in a frozenset written above,
+    or a label `_label_token` shape-checks. Not one string from the cloud, from the
+    session or from the client is copied into the document -- so `_redact` is not
+    merely skipped here, it would have nothing to do.
+
+    That rule is what shapes `account`, the block's identity self-check: the two
+    account ids it rests on are compared in the transport (`api.account_match`) and
+    only the VERDICT crosses into this file. Same for `auth_keys`, which is a count of
+    the keys in an object whose values include a bearer token, and never their names.
 
     Deliberate divergence from `_last_poll` next door, which passes the census through
     as `dict(census)` and rests entirely on its writer. This one does not trust its
@@ -3076,6 +3111,25 @@ def _fetch_block(raw: Mapping, counters: Mapping, *, now: datetime) -> dict:
         "node_type": _closed_token(raw.get("node_type"), _FETCH_NODE_TYPES),
         "siblings": _bounded_int(raw.get("siblings"), 0, _FETCH_MAX_INT),
         "count": _bounded_int(raw.get("count"), 0, _FETCH_MAX_INT),
+        # The envelope ABOVE the walk, and the question `count: 0` cannot answer on its
+        # own. A `success: false` at either level is a state in which the official app
+        # shows zero appliances too -- neither it nor this integration has ever read
+        # them -- and in which every other field of this block looks exactly like a
+        # legitimately empty account. `null` at either means the cloud sent something
+        # that was not a boolean, which is itself worth seeing.
+        "envelope_ok": _closed_bool(raw.get("envelope_ok")),
+        "module_ok": _closed_bool(raw.get("module_ok")),
+        # How many keys `modules.applianceList.authInfo` carried, never which. That
+        # object is how the cloud hands back a replacement cognito token, and on a
+        # healthy session it is verifiably empty -- so 0 is the baseline and any other
+        # number is a signal. A count is an int and an int carries no identity; a key
+        # NAME here would be a value chosen by the cloud, and one of the values behind
+        # those names is a bearer token.
+        "auth_keys": _bounded_int(raw.get("auth_keys"), 0, _FETCH_MAX_INT),
+        # Whose appliances the cloud answered with, as a verdict and never as an id.
+        # See `api.account_match`: the comparison happens in the transport and only the
+        # token crosses into this document.
+        "account": _closed_token(raw.get("account"), _FETCH_ACCOUNTS),
         "expanded": _bounded_int(counters.get("expanded"), 0, _FETCH_MAX_INT),
         "built": _bounded_int(counters.get("built"), 0, _FETCH_MAX_INT),
         "skipped": _skip_census(counters.get("skipped")),

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -3129,6 +3129,12 @@ def _fetch_block(raw: Mapping, counters: Mapping, *, now: datetime) -> dict:
         # Whose appliances the cloud answered with, as a verdict and never as an id.
         # See `api.account_match`: the comparison happens in the transport and only the
         # token crosses into this document.
+        #
+        # `mismatch` and `mixed` are NOT faults to triage on their own: family sharing
+        # puts appliances a member does not own into that member's own list, so a group
+        # member reads `mismatch` on a perfectly healthy install. The verdict states an
+        # account BOUNDARY; only the reported symptom says whether crossing it is the
+        # bug. `no_appliances` is the one that carries a complaint by itself.
         "account": _closed_token(raw.get("account"), _FETCH_ACCOUNTS),
         "expanded": _bounded_int(counters.get("expanded"), 0, _FETCH_MAX_INT),
         "built": _bounded_int(counters.get("built"), 0, _FETCH_MAX_INT),

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -60,6 +60,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    ACCOUNT_DEVICE_SUFFIX,
     APPLIANCE_AC,
     APPLIANCE_AP,
     APPLIANCE_FR,
@@ -3173,15 +3174,11 @@ async def async_get_device_diagnostics(
     ``device.identifiers`` is a set of ``(domain, id)`` tuples; base_entity.device_info
     registers ``{(DOMAIN, appliance_id)}``, so the appliance_id is recovered directly.
     The raw identifier (which may BE the serial) is never echoed into the output.
-    """
-    # Read BEFORE the two early returns below, not after. A device dump that
-    # resolves no appliance is precisely the one that gets pasted into an issue
-    # as 'the download gave me nothing', and an undated empty object cannot
-    # even be placed in time relative to the entry dump beside it.
-    now = _utcnow()
-    coordinator = _coordinator(hass, entry)
-    coord_data = getattr(coordinator, "data", None)
 
+    One device per entry is NOT an appliance: the synthetic per-account service
+    device that carries the debug controls. Asked for its diagnostics, this
+    returns the account's own dump -- see the route below.
+    """
     appliance_id = next(
         (
             ident[1]
@@ -3190,13 +3187,55 @@ async def async_get_device_diagnostics(
         ),
         None,
     )
+    # The account's service device asks an ACCOUNT question, so it gets the
+    # account's answer. Its identifier is `{entry_id}{ACCOUNT_DEVICE_SUFFIX}`
+    # (base_entity.device_info), which is never a key of `coordinator.data` --
+    # that mapping is indexed by appliance id. Without this route the lookup
+    # below could only miss, so every user pressing "Download diagnostics" on
+    # that device got the degraded dated stub; and in the one install that has
+    # ZERO appliances the service device is the only device that exists, so the
+    # only such button reachable is the one that could never answer. That is how
+    # the ADDHON-210 report arrived as `{"generated_at": ...}` instead of the
+    # self-contained dump 5.17.0 shipped for exactly that case.
+    #
+    # Delegating returns the entry dump byte for byte rather than a bespoke
+    # subset. That is deliberate on two counts: it introduces no new class of
+    # value and therefore no new privacy surface (`entry` still goes through
+    # _redact_title/_redact_email/_entry_options, `appliances` through
+    # _appliance_block + _redact, and the leak-proof-by-construction keys stay
+    # the same ones), and it leaves ONE top-level key set to maintain instead of
+    # a second shape that would drift out of step with the first -- the drift
+    # `_fetch_empty` exists to prevent.
+    entry_id = getattr(entry, "entry_id", "") or ""
+    # Exact equality, never `endswith`: a suffix test would swallow an appliance
+    # whose own id happens to end in `_diagnostics` and answer an appliance
+    # question with the account dump. Guarded on a non-empty entry_id because
+    # without one the expected identifier collapses to the bare suffix, which is
+    # a plausible id in its own right; with no entry to compare against the old
+    # behaviour stands.
+    if entry_id and appliance_id == f"{entry_id}{ACCOUNT_DEVICE_SUFFIX}":
+        return await async_get_config_entry_diagnostics(hass, entry)
+
+    # Read BEFORE the two early returns below, not after. A device dump that
+    # resolves no appliance is precisely the one that gets pasted into an issue
+    # as 'the download gave me nothing', and an undated empty object cannot
+    # even be placed in time relative to the entry dump beside it. Read AFTER
+    # the account route above so that every path reads the clock exactly once:
+    # the delegated dump takes its own single instant.
+    now = _utcnow()
+    coordinator = _coordinator(hass, entry)
+    coord_data = getattr(coordinator, "data", None)
+
     # Both degraded paths still return a DATED document rather than a bare {}.
     # They are the two dumps most likely to be attached to an issue, because
     # they are what a user gets when the thing they are reporting is that
     # nothing works, and 'the file was empty' is a materially different report
     # from 'the file said it was taken at 07:09 and had nothing in it'. Like
     # the entry dump's own `generated_at`, these bypass `_redact` and are
-    # leak-proof by construction rather than by masking.
+    # leak-proof by construction rather than by masking. What reaches them is
+    # now only what they were meant for -- a device whose identifier this
+    # integration does not own, or an appliance device the coordinator has
+    # nothing for -- because the account device is answered above.
     if appliance_id is None or not isinstance(coord_data, Mapping):
         return {"generated_at": _stamp_text(now)}
     data = coord_data.get(appliance_id)

--- a/custom_components/addhon/hon_client.py
+++ b/custom_components/addhon/hon_client.py
@@ -1192,7 +1192,11 @@ class HonClient:
                         ),
                     )
             else:
-                _LOGGER.debug(
+                # INFO, not DEBUG: it is the pointer to the WARNING that carries the
+                # whole diagnosis, and a pointer that only appears when debug is on is
+                # a pointer nobody follows. It fires only on the empty-list branch, so
+                # a working install never sees it.
+                _LOGGER.info(
                     "Discovery: the hOn cloud returned 0 appliances for this "
                     "account (request OK). With the unified-api endpoint the list "
                     "also includes offline devices, so 0 = a truly empty/not-shared "

--- a/tests/_envelopes.py
+++ b/tests/_envelopes.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2026 tis24dev
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The two appliance-list envelopes the ADDHON-210 investigation turns on.
+
+ONE definition, shared by the three suites that need it (`test_transport_parse.py`
+for the flags, `test_transport_api.py` for the census the transport assembles, and
+`test_diagnostics.py` for the document a reporter downloads). A fixture copied into
+three files is three fixtures, and the entire value of these two is that they are
+compared against each other.
+
+`healthy()` is a LIVE CAPTURE, not an authored shape: taken on 2026-08-24 against a
+real account holding one appliance, through `apk/probe_2fa_envelope.py`, and written
+up in `apk/analysis/addhon210-healthy-envelope-baseline.md`. Everything about it that
+the census reads is reproduced here exactly as observed:
+
+    HTTP 200
+    top level                                 keys ['executionTime','modules','success']
+    top level success                         True
+    modules                                   keys ['applianceList']
+    modules.applianceList                     keys ['authInfo','executionTime','payload','success']
+    modules.applianceList.success             True
+    modules.applianceList.authInfo            {}   <- empty on a healthy session
+    modules.applianceList.payload             keys ['appliances']
+    modules.applianceList.payload.appliances  <list of 1>, carrying PK / SK /
+                                              sfPersonAccountId on 1/1 entries
+
+The identifier VALUES are synthetic (`ACCOUNT-OURS`, the MAC, the serial): the shape
+is the evidence, the values were never the point, and a fixture in a public repo is
+not where a real account id belongs. The MAC and serial are deliberately hostile
+strings so the leak tests over the finished dump have something to look for.
+
+`reporter()` is the envelope of the user who sees NO appliances -- and it is an
+honest reconstruction, not a capture. Their log records exactly two levels (log lines
+1989/1997): the `result` key set and the `modules` key set. Both are IDENTICAL to the
+healthy capture, which is what closed the "the API changed" hypothesis. Everything
+below `modules.applianceList` is unrecorded, so it is filled here with the healthy
+shape ON PURPOSE: that is the null hypothesis this block exists to test, and the only
+difference between the two dicts is the one thing their dump did report -- an empty
+list. If the fields added on top of it cannot separate these two documents, they are
+not worth shipping.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+# The account id the id_token of the session claims (`custom_attributes
+# .PersonAccountId`), and the one every appliance of a healthy response repeats under
+# `sfPersonAccountId`. Never emitted by anything under test: the transport compares
+# them and publishes a verdict.
+OUR_ACCOUNT = "ACCOUNT-OURS"
+OTHER_ACCOUNT = "ACCOUNT-SOMEONE-ELSE"
+
+_APPLIANCE: dict[str, Any] = {
+    # The DynamoDB single-table markers, present on 1/1 entries of the live capture:
+    # the list is a query BY IDENTITY, which is why an identity check on it is
+    # meaningful at all.
+    "PK": "user#eu-west-1:SYNTHETIC-IDENTITY",
+    "SK": "app#AA:BB:CC:DD:EE:FF",
+    "sfPersonAccountId": OUR_ACCOUNT,
+    "applianceTypeName": "REF",
+    "macAddress": "AA:BB:CC:DD:EE:FF",
+    "serialNumber": "PLAINTEXT-SERIAL",
+    "nickName": "Kitchen Fridge",
+}
+
+
+def _envelope(appliances: list) -> dict[str, Any]:
+    return {
+        "executionTime": 114,
+        "success": True,
+        "modules": {
+            "applianceList": {
+                "authInfo": {},
+                "executionTime": 114,
+                "success": True,
+                "payload": {"appliances": appliances},
+            }
+        },
+    }
+
+
+def healthy() -> dict[str, Any]:
+    """The live 2026-08-24 capture: 200, one appliance, both `success` true."""
+    return _envelope([copy.deepcopy(_APPLIANCE)])
+
+
+def reporter() -> dict[str, Any]:
+    """ADDHON-210 as reported: the same envelope, and nothing in the list."""
+    return _envelope([])

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -333,6 +333,55 @@ class IdentityKeysBehaviouralTest(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertFalse(debug_utils._is_identity_key(key))
 
+    def test_a_value_used_as_a_key_is_masked_by_shape(self) -> None:
+        """A vendor keying a mapping BY an identity would leak it one level up.
+
+        `structure_only` exists so no leaf value is copied, and printing every key
+        verbatim would have reintroduced exactly that leak in the key position. The
+        test is by shape and not by blacklist for the reason `cognitoTokenNew` already
+        demonstrated: no set enumerates a vendor's naming.
+        """
+        for hostile in (
+            "user#eu-west-1:8f3c-4a21-9b0e",       # the DynamoDB identity partition
+            "0011q00001IbepGAAR",                   # a Salesforce account id
+            "ABC123456789",                         # a serial: long digit run
+            "ABCDEFGH",                             # a serial with no digits at all:
+                                                    # only the lowercase rule stops it
+            "mario.rossi@gmail.com",
+            "3C:71:BF:AA:BB:CC",
+            "a1b2c3d4-5e6f-7890-abcd-ef1234567890",
+        ):
+            with self.subTest(key=hostile):
+                shape = debug_utils.structure_only({"payload": {hostile: {"x": 1}}})
+                self.assertEqual({"payload": {"***": "***"}}, shape)
+
+    def test_the_shape_rule_keeps_every_key_the_real_envelope_carries(self) -> None:
+        # Measured against the appliance-list capture of 2026-08-24: a rule that
+        # masked a real schema key would leave the log unreadable, which is the other
+        # way to fail. Identity keys are excluded here -- they are masked ON PURPOSE
+        # and covered by _MUST_MASK above.
+        real = (
+            "applianceModelId", "applianceStatus", "applianceTypeId",
+            "applianceTypeName", "attributes", "brand", "connectivity", "coords",
+            "defaultWarrantyYears", "eepromName", "enrollmentDate", "firstEnrollment",
+            "firstEnrollmentTBC", "fwVersion", "id", "lastCheckUp", "lastUpdate",
+            "modelName", "purchaseDate", "sections", "series", "seriesVersion",
+            "topics", "executionTime", "modules", "success", "payload", "appliances",
+            "authInfo", "tempSelZ2",
+        )
+        for key in real:
+            with self.subTest(key=key):
+                self.assertTrue(debug_utils._is_schema_key(key))
+                self.assertEqual(
+                    {key: "<int>"}, debug_utils.structure_only({key: 1})
+                )
+
+    def test_the_shape_never_copies_a_leaf_value(self) -> None:
+        # The whole contract in one assertion.
+        body = {"payload": {"appliances": []}, "note": "CANARY", "n": 42,
+                "deep": {"deeper": ["CANARY", 1]}}
+        self.assertNotIn("CANARY", repr(debug_utils.structure_only(body)))
+
     def test_every_identity_key_has_a_behavioural_assertion(self) -> None:
         # The replacement for the old pin. This is still a set equality, but the
         # right-hand side is no longer a copy kept only for comparison: _MUST_MASK is

--- a/tests/test_debug_utils_redact.py
+++ b/tests/test_debug_utils_redact.py
@@ -266,6 +266,23 @@ class IdentityKeysBehaviouralTest(unittest.TestCase):
         "password", "token", "access_token", "refresh_token",
         "authorization", "secret",
         "transactionid", "transaction_id", "mobileid", "mobile_id",
+        # The appliance-list envelope, captured live 2026-08-24: every element carries
+        # the owning Salesforce account and the DynamoDB keys, whose PK IS the cognito
+        # identity (`user#<region>:<identity>`) in plain text under two letters.
+        "sfpersonaccountid", "personaccountid", "personcontactid",
+        "pk", "sk", "applianceid", "eepromid",
+    )
+
+    # Keys no exact set would have contained, masked by the substring rule. Named the
+    # same way and for the same reason: a loop over _IDENTITY_KEY_PARTS would prove the
+    # rule fires without proving it fires on the SPELLING the cloud actually sends.
+    _MUST_MASK_BY_PART = (
+        "cognitoTokenNew",   # the one that proved the exact set insufficient
+        "cognitoToken",
+        "idToken",
+        "sfAccessToken",
+        "userPassword",
+        "clientSecret",
     )
 
     def test_named_identity_keys_mask_their_value_on_the_log_path(self) -> None:
@@ -288,6 +305,33 @@ class IdentityKeysBehaviouralTest(unittest.TestCase):
                     self.assertEqual(
                         "***", nested["payload"][0]["attributes"][spelling]
                     )
+
+    def test_vendor_spellings_are_masked_by_the_substring_rule(self) -> None:
+        """`token` was in the set and `cognitoTokenNew` was not.
+
+        That gap was a bearer credential travelling unmasked into a WARNING this
+        project asks users to paste into public issues -- the aggregator returns a
+        replacement cognito token inside `modules.applianceList.authInfo`, and the
+        empty-list branch is exactly where that response gets logged.
+        """
+        for key in self._MUST_MASK_BY_PART:
+            with self.subTest(key=key):
+                self.assertTrue(debug_utils._is_identity_key(key))
+                nested = debug_utils.redact_identity(
+                    {"modules": {"applianceList": {"authInfo": {key: self._CANARY_VALUE}}}}
+                )
+                self.assertEqual(
+                    "***",
+                    nested["modules"]["applianceList"]["authInfo"][key],
+                )
+
+    def test_the_substring_rule_stays_narrow(self) -> None:
+        # A wider list would start masking the structure the logs exist to show. These
+        # are keys the envelope really carries and that must survive redaction.
+        for key in ("applianceTypeName", "modelName", "connectivity", "attributes",
+                    "success", "payload", "modules", "series", "brand"):
+            with self.subTest(key=key):
+                self.assertFalse(debug_utils._is_identity_key(key))
 
     def test_every_identity_key_has_a_behavioural_assertion(self) -> None:
         # The replacement for the old pin. This is still a set equality, but the

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1158,6 +1158,60 @@ def _probe_outcome_tokens() -> set[str]:
     )
 
 
+_API_SOURCE = (
+    REPO_ROOT / "custom_components" / "addhon" / "client" / "transport" / "api.py"
+)
+
+
+def _api_account_tokens() -> tuple:
+    """The `ACCOUNT_TOKENS` tuple `transport/api.py` declares.
+
+    Parsed, never imported, the same idiom `_session_drop_reasons` applies to
+    session.py: api.py reaches `connection.py` and through it `aiohttp`, which the
+    stubs in this file deliberately do not provide, so the module whose next verdict
+    this guard exists to catch is precisely the one it must not fail to read.
+    """
+    for node in ast.walk(ast.parse(_API_SOURCE.read_text(encoding="utf-8"))):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if "ACCOUNT_TOKENS" in names and isinstance(node.value, ast.Tuple):
+            return tuple(
+                element.value
+                for element in node.value.elts
+                if isinstance(element, ast.Constant)
+            )
+    raise AssertionError(
+        "transport/api.py no longer declares ACCOUNT_TOKENS as a tuple literal: point "
+        "this guard at the new form -- do not delete it."
+    )
+
+
+def _account_match_verdicts() -> set[str]:
+    """Every string `account_match` can RETURN, read from its body.
+
+    The second half of the pin, and the one a tuple constant cannot give on its own:
+    `ACCOUNT_TOKENS` is a promise about what the function emits, and nothing but the
+    function's own returns can check it. Read with `ast` rather than by calling the
+    function over a table of responses, for the reason `_probe_outcome_tokens` states:
+    a table proves the tokens it triggers are known, never that no OTHER token exists.
+    """
+    for node in ast.walk(ast.parse(_API_SOURCE.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.FunctionDef) and node.name == "account_match":
+            return {
+                statement.value.value
+                for statement in ast.walk(node)
+                if isinstance(statement, ast.Return)
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, str)
+            }
+    raise AssertionError(
+        "transport/api.py::account_match was not found, so the verdicts it can produce "
+        "could not be read. If it was renamed, point this guard at the new name -- do "
+        "not delete it."
+    )
+
+
 class DiagnosticsDriftGuardTest(unittest.TestCase):
     def test_custom_mapped_attrs_are_not_reported_unmapped(self):
         """The behavioural half of the pin above: the EFFECT the comment there claims,
@@ -1229,6 +1283,51 @@ class DiagnosticsDriftGuardTest(unittest.TestCase):
         # which is the one reading the block cannot afford for its main field.
         self.assertEqual(
             _probe_outcome_tokens() | {"raised"}, set(diagnostics._FETCH_OUTCOMES)
+        )
+
+    def test_account_verdicts_track_the_writer(self):
+        # A THREE-WAY pin, because two of the three can drift on their own.
+        # `account_match` is the producer, `ACCOUNT_TOKENS` is the promise it makes to
+        # the outside, and `_FETCH_ACCOUNTS` is what this file allows into a document.
+        # A verdict added to the function and not to the reader is printed as "other",
+        # and "other" as the answer to "whose appliances are these" is the one reading
+        # nobody can act on -- it is indistinguishable from a value this build refused.
+        declared = _api_account_tokens()
+        self.assertEqual(set(declared), _account_match_verdicts())
+        self.assertEqual(set(declared), set(diagnostics._FETCH_ACCOUNTS))
+        # The tuple has no duplicates: a repeated token would make the two set
+        # comparisons above agree while the declaration itself was wrong.
+        self.assertEqual(len(declared), len(set(declared)))
+
+    def test_the_census_keys_and_the_block_keys_are_the_same_set(self):
+        """Every key the WRITER puts in the census is a key the block declares.
+
+        The structural half of `test_the_census_the_probe_builds_survives_into_the_dump`
+        below, which checks two responses. This checks the key set itself, so a field
+        added to the probe and forgotten in `_fetch_empty` -- or renamed on one side --
+        fails here instead of quietly rendering as a missing key in half the states.
+
+        The five keys the census does NOT carry are named rather than subtracted
+        blindly: `age_s` is computed by the reader, and the four counters are what
+        SETUP made of the list rather than what the CALL returned, so they arrive from
+        the client and not from this mapping.
+        """
+        from custom_components.addhon.client.transport import parse
+
+        census = {
+            "at": None,
+            "status": None,
+            "code": None,
+            **parse.probe_appliance_list(
+                {"modules": {"applianceList": {"payload": {"appliances": []}}}}
+            ),
+            "account": "no_appliances",
+        }
+        block = diagnostics._fetch_empty()
+        self.assertLessEqual(set(census), set(block))
+        self.assertEqual(
+            {"age_s", "expanded", "built", "skipped", "degraded"},
+            set(block) - set(census),
         )
 
     def test_ac_climate_params_pinned(self):
@@ -1885,6 +1984,136 @@ class LastFetchDiagnosticsTest(unittest.TestCase):
         self.assertEqual(0, blocks[1]["count"])
         # The sibling key beside the level we stopped at was chosen by the cloud.
         self.assertNotIn("AA:BB:CC:DD:EE:FF", json.dumps(blocks))
+
+    def test_a_failed_module_is_not_an_empty_account(self) -> None:
+        """The second acceptance test, on the level above the walk.
+
+        The field report reached us as an empty list under a 200 with a well-formed
+        envelope, and `outcome: "ok", count: 0` already reads that as "the cloud sent
+        nothing, so the bug is not ours". That reading is only sound if the cloud also
+        DECLARED the call a success -- and the module envelope carries its own
+        `success` beside the payload, which neither this integration nor the official
+        app has ever read. With it false the app shows zero appliances too, and every
+        other field in this block is identical to a legitimately empty account.
+        """
+        empty = self._fetch(
+            {"status": 200, "outcome": "ok", "count": 0,
+             "envelope_ok": True, "module_ok": True, "auth_keys": 0,
+             "account": "no_appliances"}
+        )
+        failed = self._fetch(
+            {"status": 200, "outcome": "ok", "count": 0,
+             "envelope_ok": True, "module_ok": False, "auth_keys": 0,
+             "account": "no_appliances"}
+        )
+        self.assertNotEqual(empty, failed)
+        self.assertIs(True, empty["module_ok"])
+        self.assertIs(False, failed["module_ok"])
+        # The rest of the block is word for word the same, which is the point: nothing
+        # else in the document could have separated these two dumps.
+        for key in ("outcome", "count", "status", "envelope_ok", "account"):
+            with self.subTest(key=key):
+                self.assertEqual(empty[key], failed[key])
+
+    def test_a_session_that_resolved_to_another_account_is_visible(self) -> None:
+        # The third state the block could not name. All three of these carry
+        # `outcome: "ok"`, and two of them carry `count: 0`; before `account` the dump
+        # answered "the cloud sent an empty list" to all three and stopped.
+        empty = self._fetch({"outcome": "ok", "count": 0, "account": "no_appliances"})
+        blind = self._fetch({"outcome": "ok", "count": 0, "account": "no_claim"})
+        theirs = self._fetch({"outcome": "ok", "count": 2, "account": "mismatch"})
+        self.assertEqual("no_appliances", empty["account"])
+        self.assertEqual("no_claim", blind["account"])
+        self.assertEqual("mismatch", theirs["account"])
+        self.assertNotEqual(empty, blind)
+
+    def test_a_success_that_is_not_a_boolean_is_never_coerced(self) -> None:
+        # `_closed_bool` is the mirror of `_bounded_int`: that one refuses a bool
+        # because isinstance(True, int) is True, this one refuses an INT because `1` is
+        # not the same statement as `true`. Coercing with `bool(value)` would let the
+        # field answer the very question it exists to establish -- and would render
+        # every non-empty string the cloud sent as a declared success.
+        for junk in ("true", "false", "", 1, 0, [], {}, [1], object()):
+            with self.subTest(junk=type(junk).__name__):
+                fetch = self._fetch({"envelope_ok": junk, "module_ok": junk})
+                self.assertIsNone(fetch["envelope_ok"])
+                self.assertIsNone(fetch["module_ok"])
+        # ...and a real boolean still comes through, both ways, so the assertions above
+        # are not passing merely because the fields are always null.
+        for value in (True, False):
+            with self.subTest(value=value):
+                fetch = self._fetch({"envelope_ok": value, "module_ok": value})
+                self.assertIs(value, fetch["envelope_ok"])
+                self.assertIs(value, fetch["module_ok"])
+
+    def test_an_auth_key_count_is_a_count_and_nothing_else(self) -> None:
+        # `auth_keys` is the size of an object whose values include a bearer token, so
+        # the count is the entire permitted output. A string that fell through would be
+        # a key name or a token, i.e. the one thing this field is designed not to be.
+        for junk in ("2", True, -1, diagnostics._FETCH_MAX_INT + 1,
+                     ["cognitoTokenNew"], {"cognitoTokenNew": "SECRET"}):
+            with self.subTest(junk=type(junk).__name__):
+                self.assertIsNone(self._fetch({"auth_keys": junk})["auth_keys"])
+        # 0 is the healthy baseline and must survive as a value, not be treated as
+        # "nothing to report": it is what makes any other number a signal.
+        self.assertEqual(0, self._fetch({"outcome": "ok", "auth_keys": 0})["auth_keys"])
+        self.assertEqual(3, self._fetch({"outcome": "ok", "auth_keys": 3})["auth_keys"])
+
+    def test_an_unknown_account_verdict_collapses_to_other(self) -> None:
+        # An identifier is exactly the shape a wrong writer would put here, so the
+        # reader keeps the finding and loses the value -- the same rule `outcome` and
+        # `node_type` already follow.
+        for junk in ("ACCOUNT-0012345", "user@example.com", "3C:71:BF:AA:BB:CC"):
+            with self.subTest(junk=junk):
+                self.assertEqual("other", self._fetch({"account": junk})["account"])
+        blob = json.dumps(self._dump(_FetchClient({
+            "account": "3C:71:BF:AA:BB:CC", "auth_keys": "cognitoTokenNew",
+            "envelope_ok": "user@example.com",
+        })))
+        for leak in ("3C:71:BF:AA:BB:CC", "cognitoTokenNew", "user@example.com"):
+            self.assertNotIn(leak, blob, leak)
+
+    def test_the_healthy_and_the_reporter_envelope_are_told_apart(self) -> None:
+        """The two responses of the investigation, through the real writer.
+
+        `healthy()` is the live 2026-08-24 capture and `reporter()` is the ADDHON-210
+        envelope: identical at both levels their log records, which is what closed the
+        "the API changed" hypothesis. Everything the dump could say about them used to
+        be identical too. Built by the WRITER rather than hand-written, so the pin
+        covers the whole path and not this file's idea of it.
+        """
+        from custom_components.addhon.client.transport.parse import probe_appliance_list
+        from _envelopes import healthy, reporter
+
+        blocks = {
+            name: self._fetch(
+                {"at": FROZEN, "status": 200, "code": None,
+                 **probe_appliance_list(body), "account": account}
+            )
+            for name, body, account in (
+                ("healthy", healthy(), "match"),
+                ("reporter", reporter(), "no_appliances"),
+            )
+        }
+        self.assertNotEqual(blocks["healthy"], blocks["reporter"])
+        # The calibration: every field of the healthy capture, as observed on the wire.
+        self.assertEqual("ok", blocks["healthy"]["outcome"])
+        self.assertEqual(1, blocks["healthy"]["count"])
+        self.assertIs(True, blocks["healthy"]["envelope_ok"])
+        self.assertIs(True, blocks["healthy"]["module_ok"])
+        self.assertEqual(0, blocks["healthy"]["auth_keys"])
+        self.assertEqual("match", blocks["healthy"]["account"])
+        # ...and the reporter's, which is now a finished diagnosis rather than a
+        # shrug: the cloud declared success at both levels, the session resolved to
+        # the account we authenticated as, and that account owns nothing.
+        self.assertEqual(0, blocks["reporter"]["count"])
+        self.assertIs(True, blocks["reporter"]["module_ok"])
+        self.assertEqual("no_appliances", blocks["reporter"]["account"])
+        # The capture carries a MAC, a serial and a nickname on its one appliance.
+        blob = json.dumps(blocks)
+        for leak in ("AA:BB:CC:DD:EE:FF", "PLAINTEXT-SERIAL", "Kitchen Fridge",
+                     "ACCOUNT-OURS", "user#eu-west-1"):
+            self.assertNotIn(leak, blob, leak)
 
     def test_a_dropped_inventory_is_not_an_empty_account(self) -> None:
         # State (D): the cloud sent two appliances and this setup dropped both at the
@@ -7261,6 +7490,62 @@ class SetupFailureRecordTest(unittest.TestCase):
         )["last_fetch"]
         self.assertEqual((2, 2, 0), (block["count"], block["expanded"], block["built"]))
         self.assertEqual({"mac_empty": 2}, block["skipped"])
+
+    def test_the_envelope_and_the_identity_check_survive_a_failed_setup(self) -> None:
+        """A failed setup must not be LESS diagnosable than a successful one.
+
+        `_setup_failure_record` flattens the census with `**dict(census)`, so a field
+        added to the writer reaches hass.data without a second edit -- which is a
+        property worth asserting rather than assuming: the day someone replaces that
+        spread with an explicit key list (the shape the four counters beside it are
+        already written in) the new fields vanish from exactly the dump that is hardest
+        to reproduce. The record path is also the one a reporter downloads most often,
+        because Home Assistant is usually still retrying when they go looking.
+        """
+        init = _addhon_init()
+        client = _FailedClient()
+        client.last_appliance_fetch = {
+            "outcome": "ok", "count": 0, "status": 200,
+            "envelope_ok": True, "module_ok": False, "auth_keys": 2,
+            "account": "mismatch",
+        }
+        hass = FakeHass(_build_coordinator())
+        init._store_setup_failure(hass, FakeEntry(), client)
+        stored = hass.data[DOMAIN]["e1"]["setup_failure"]["fetch"]
+        for key in ("envelope_ok", "module_ok", "auth_keys", "account"):
+            with self.subTest(key=key):
+                self.assertIn(key, stored)
+        block = _run(
+            diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry())
+        )["last_fetch"]
+        self.assertEqual("recorded", block["state"])
+        self.assertIs(True, block["envelope_ok"])
+        self.assertIs(False, block["module_ok"])
+        self.assertEqual(2, block["auth_keys"])
+        self.assertEqual("mismatch", block["account"])
+
+    def test_the_recorded_new_fields_are_validated_like_the_live_ones(self) -> None:
+        # The record has been through hass.data, so it is the LESS trusted of the two
+        # sources and must not be the one that gets the shorter check. Same hostile
+        # values, same refusals as on the live path.
+        block = self._dump_record(
+            self._record(
+                fetch={
+                    "outcome": "ok",
+                    "envelope_ok": "true",
+                    "module_ok": 1,
+                    "auth_keys": "cognitoTokenNew",
+                    "account": "ACCOUNT-0012345",
+                }
+            )
+        )["last_fetch"]
+        self.assertIsNone(block["envelope_ok"])
+        self.assertIsNone(block["module_ok"])
+        self.assertIsNone(block["auth_keys"])
+        # A token the reader does not know keeps the finding and loses the value.
+        self.assertEqual("other", block["account"])
+        self.assertNotIn("ACCOUNT-0012345", json.dumps(block))
+        self.assertNotIn("cognitoTokenNew", json.dumps(block))
 
     def test_a_record_without_a_census_still_reads_client_absent(self) -> None:
         # The failure happened before the call, so there is nothing to say about it.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -919,6 +919,162 @@ class DiagnosticsDeviceTest(unittest.TestCase):
         self.assertEqual({"generated_at": FROZEN_TEXT}, result)
 
 
+class AccountDeviceDiagnosticsTest(unittest.TestCase):
+    """The synthetic per-account service device carries a "Download diagnostics"
+    button of its own, and its identifier -- `entry_id` + ACCOUNT_DEVICE_SUFFIX -- is
+    never a key of `coordinator.data`, which is indexed by appliance id. Before the
+    account route that lookup could only miss, so the button could only ever hand
+    back the degraded dated stub. That is what the ADDHON-210 reporter downloaded and
+    sent us, instead of the self-contained dump 5.17.0 shipped for exactly that case:
+    with zero appliances the service device is the ONLY device that exists, so its
+    broken button was the only one there was to press.
+    """
+
+    @staticmethod
+    def _account_device(entry):
+        """The real service device, built by the function that BUILDS it.
+
+        Spelling `f"{entry_id}_diagnostics"` again here would make this a one-sided
+        pin that keeps passing after the suffix moves; reading it out of
+        `account_device_info` means a rename has to fail here instead of silently
+        re-breaking the button. Same two-sided pin as
+        `test_legacy_cleanup.py`'s account-device guard.
+        """
+        from custom_components.addhon.base_entity import account_device_info
+
+        identifiers = set(account_device_info(entry)["identifiers"])
+        # Anti-vacuity: a device with no identifiers resolves no appliance_id and
+        # would reach a degraded dump for an unrelated reason.
+        assert len(identifiers) == 1, identifiers
+        return FakeDevice(identifiers=identifiers)
+
+    def test_the_account_device_returns_the_entry_dump_itself(self):
+        # Not "a dump with the same keys": the SAME document. One clock, one shape,
+        # one set of privacy guarantees to argue about -- the reason this route
+        # delegates instead of assembling a second, subtly different, top-level
+        # object that would drift out of step with the first.
+        entry = FakeEntry()
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(
+                    FakeHass(_build_coordinator()), entry, self._account_device(entry)
+                )
+            )
+            expected = _run(
+                diagnostics.async_get_config_entry_diagnostics(
+                    FakeHass(_build_coordinator()), FakeEntry()
+                )
+            )
+        self.assertEqual(
+            [
+                "generated_at",
+                "entry",
+                "last_error",
+                "platforms",
+                "last_poll",
+                "last_fetch",
+                "appliances",
+            ],
+            list(result),
+        )
+        self.assertEqual(expected, result)
+
+    def test_the_account_device_dump_is_read_from_one_instant(self):
+        # The device path reads `_utcnow` before its own degraded returns. On this
+        # route that read would be a second one, discarded, while the document
+        # carries the entry dump's instant -- harmless today, but it is the shape
+        # that lets two ages in one document disagree tomorrow.
+        entry = FakeEntry()
+        with _FrozenClock(FROZEN) as clock:
+            result = _run(
+                diagnostics.async_get_device_diagnostics(
+                    FakeHass(_build_coordinator()), entry, self._account_device(entry)
+                )
+            )
+        self.assertEqual(FROZEN_TEXT, result["generated_at"])
+        self.assertEqual(1, clock.calls)
+
+    def test_an_account_dump_with_no_appliances_still_carries_the_evidence(self):
+        # THE ADDHON-210 CASE, verbatim: the cloud answered, the walk found nothing,
+        # `coordinator.data` is `{}`. What the reporter needed to send is exactly
+        # what a `{"generated_at": ...}` stub cannot say -- how the one inventory
+        # call went (`last_fetch`), what the poll counted (`last_poll`), which
+        # platforms forwarded (`platforms`) and whether an error was recorded
+        # (`last_error`). An empty `appliances` list is the SYMPTOM, not the dump
+        # failing to build.
+        entry = FakeEntry()
+        result = _run(
+            diagnostics.async_get_device_diagnostics(
+                FakeHass(FakeCoordinator({})), entry, self._account_device(entry)
+            )
+        )
+        self.assertEqual([], result["appliances"])
+        for key in ("entry", "last_error", "platforms", "last_poll", "last_fetch"):
+            self.assertIn(key, result)
+
+    def test_an_appliance_id_merely_ending_in_the_suffix_stays_an_appliance(self):
+        # The guard against the shortcut this file refuses everywhere:
+        # `ident[1].endswith(ACCOUNT_DEVICE_SUFFIX)` would answer an APPLIANCE
+        # question with the account dump for any cloud id that happens to end that
+        # way. The comparison is against the id built from THIS entry, and nothing
+        # else.
+        entry = FakeEntry()
+        decoy_id = f"x{entry.entry_id}{const.ACCOUNT_DEVICE_SUFFIX}"
+        # Anti-vacuity: the decoy must really be the near-miss it claims to be.
+        self.assertTrue(decoy_id.endswith(const.ACCOUNT_DEVICE_SUFFIX))
+        self.assertNotEqual(
+            f"{entry.entry_id}{const.ACCOUNT_DEVICE_SUFFIX}", decoy_id
+        )
+        coord = _build_coordinator()
+        coord.data[decoy_id] = coord.data.pop(WD_ID)
+        result = _run(
+            diagnostics.async_get_device_diagnostics(
+                FakeHass(coord), entry, FakeDevice(identifiers={(DOMAIN, decoy_id)})
+            )
+        )
+        self.assertEqual(["generated_at", "appliance"], list(result))
+        self.assertEqual("WD", result["appliance"]["type"])
+
+    def test_an_entry_with_no_id_does_not_take_the_account_route(self):
+        # With an empty `entry_id` the expected identifier collapses to the bare
+        # suffix, which is a perfectly plausible appliance id. The route is skipped
+        # rather than guessed at, and the previous behaviour stands.
+        entry = FakeEntry(entry_id="")
+        device = FakeDevice(identifiers={(DOMAIN, const.ACCOUNT_DEVICE_SUFFIX)})
+        with _FrozenClock(FROZEN):
+            result = _run(
+                diagnostics.async_get_device_diagnostics(
+                    FakeHass(_build_coordinator()), entry, device
+                )
+            )
+        self.assertEqual({"generated_at": FROZEN_TEXT}, result)
+
+    def test_no_raw_identity_reaches_the_account_dump(self):
+        # Same whole-document scan as `AttributeTimestampPrivacyTest`, run through
+        # the new route: delegating must not become a way of reaching the cloud
+        # values WITHOUT the validations, so the claim "byte for byte the entry
+        # dump" is checked on the property that matters rather than assumed from
+        # the call site.
+        entry = FakeEntry()
+        encoded = json.dumps(
+            _run(
+                diagnostics.async_get_device_diagnostics(
+                    FakeHass(_build_coordinator()), entry, self._account_device(entry)
+                )
+            )
+        )
+        for identity in (
+            "PLAINTEXT-SERIAL",
+            "SN-PLAINTEXT",
+            "AA:BB:CC:DD:EE:FF",
+            "11:22:33:44:55:66",
+            "phone-install-xyz",
+            "user@example.com",
+            "hunter2",
+        ):
+            self.assertNotIn(identity, encoded)
+
+
 # The bare attributes CUSTOM entity classes consume. They have no description
 # table, so no walk can derive them: `HonMeanWaterConsumption` needs both
 # `totalWaterUsed` and `totalWashCycle`, `HonWashingMachinePauseSwitch` reads

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -18,6 +18,7 @@ into HonApi, so we do not touch the real transport.
 from __future__ import annotations
 
 import asyncio
+import base64
 import copy
 import json
 import logging
@@ -25,6 +26,8 @@ import sys
 import types
 import unittest
 from pathlib import Path
+
+from _envelopes import OTHER_ACCOUNT, OUR_ACCOUNT, healthy, reporter
 
 REPO = Path(__file__).resolve().parents[1]
 if str(REPO) not in sys.path:
@@ -946,6 +949,343 @@ class FetchCensusTest(unittest.TestCase):
                 self.assertTrue(block["at"].endswith("+00:00"), block["at"])
                 self.assertEqual(51_840, block["age_s"])
 
+
+# --------------------------------------------------------------------------- #
+# The identity self-check                                                      #
+# --------------------------------------------------------------------------- #
+def _id_token(person_account_id) -> str:
+    """An id_token shaped like the live one, carrying `person_account_id`.
+
+    The nine `custom_attributes` and the top-level claims are the ones observed on
+    2026-08-24 (apk/analysis/addhon210-healthy-envelope-baseline.md): the reader has to
+    find its claim among neighbours, not alone in an otherwise empty object.
+    """
+    claims = {
+        "sub": "SYNTHETIC-SUB",
+        "email": "user@example.com",
+        "exp": 1_800_000_000,
+        "custom_attributes": {
+            "Country": "IT",
+            "EulaUpdateRequired": "false",
+            "ExternalSource": "hOn",
+            "ExternalSubSource": "app",
+            "OemAppId": "haier",
+            "PersonContactId": "CONTACT-OURS",
+            "PrivacyUpdated": "true",
+            "UserLanguage": "it",
+        },
+    }
+    if person_account_id is not None:
+        claims["custom_attributes"]["PersonAccountId"] = person_account_id
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"eyJhbGciOiJIUzI1NiJ9.{body}.sig"
+
+
+class _AuthedConnection(FakeConnection):
+    """A connection whose `auth` holds an id_token, as the live one does.
+
+    Every other double in this file has NO `auth` at all -- `HonConnection.auth` raises
+    when the connection was never created -- which is exactly the state the census
+    guard is written for, and exactly why a double that does carry one is needed for
+    the verdict to be anything but `no_claim`.
+    """
+
+    def __init__(self, body, id_token, **kwargs) -> None:
+        super().__init__(body, **kwargs)
+        self.auth = types.SimpleNamespace(id_token=id_token)
+
+
+class AccountMatchTest(unittest.TestCase):
+    """`account_match` answers whose appliances these are, as a verdict.
+
+    The question ADDHON-210 kept needing and nothing could answer: a session that
+    silently resolves to another account returns 200, a well-formed envelope, and a
+    list that is empty or simply not ours -- and every other field of the dump reads
+    like an account that owns nothing.
+    """
+
+    def setUp(self) -> None:
+        self.match = api_mod.account_match
+
+    def test_the_healthy_capture_matches(self) -> None:
+        self.assertEqual("match", self.match(healthy(), OUR_ACCOUNT))
+
+    def test_the_reporter_envelope_separates_empty_from_unreadable(self) -> None:
+        # THE acceptance case, and the reason this function walks the response itself
+        # instead of calling `parse_appliance_list`: that parser returns [] for an
+        # empty list AND for a drift its fail-safe cannot follow (sec9), which is the
+        # very distinction between these two verdicts.
+        self.assertEqual("no_appliances", self.match(reporter(), OUR_ACCOUNT))
+        # A level that went missing: the walk never reaches a list at all.
+        drifted = reporter()
+        del drifted["modules"]["applianceList"]["payload"]
+        self.assertEqual("unknown", self.match(drifted, OUR_ACCOUNT))
+        # And the case that separates the two BRANCHES rather than the two responses:
+        # the walk completes and the leaf is not a list. `no_appliances` claims the
+        # cloud said "you own nothing"; only an actual empty list says that, and a
+        # single `not isinstance(node, list) or not node` would quietly report the
+        # cloud's silence as its answer. Both falsy and truthy non-lists, because a
+        # falsy one is what a merged condition swallows.
+        for leaf in ({"x": 1}, "x", 0, None, {}, ""):
+            with self.subTest(leaf=leaf):
+                bent = reporter()
+                bent["modules"]["applianceList"]["payload"]["appliances"] = leaf
+                self.assertEqual("unknown", self.match(bent, OUR_ACCOUNT))
+
+    def test_a_foreign_account_is_a_mismatch_not_an_empty_account(self) -> None:
+        theirs = healthy()
+        theirs["modules"]["applianceList"]["payload"]["appliances"][0][
+            "sfPersonAccountId"
+        ] = OTHER_ACCOUNT
+        self.assertEqual("mismatch", self.match(theirs, OUR_ACCOUNT))
+
+    def test_a_response_spanning_two_accounts_is_mixed(self) -> None:
+        both = healthy()
+        appliances = both["modules"]["applianceList"]["payload"]["appliances"]
+        appliances.append({**appliances[0], "sfPersonAccountId": OTHER_ACCOUNT})
+        self.assertEqual("mixed", self.match(both, OUR_ACCOUNT))
+
+    def test_no_claim_wins_over_every_other_verdict(self) -> None:
+        # "Our own token carries no identity" says the problem may be on our side of
+        # the wire, so it is reported ahead of anything read off the response -- and
+        # ahead of `no_appliances`, which the field report would otherwise show while
+        # the real finding was that no comparison happened at all.
+        for response in (healthy(), reporter(), None, {"modules": 3}):
+            with self.subTest(response=type(response).__name__):
+                for claim in (None, "", 42, b"ACCOUNT-OURS", ["ACCOUNT-OURS"]):
+                    self.assertEqual("no_claim", self.match(response, claim))
+
+    def test_appliances_with_no_readable_owner_do_not_vote(self) -> None:
+        # A missing or non-string `sfPersonAccountId` is a SCHEMA question, and the
+        # schema questions are what the probe already answers. Counting it as a
+        # mismatch would report an identity failure for a renamed key.
+        silent = healthy()
+        appliances = silent["modules"]["applianceList"]["payload"]["appliances"]
+        appliances.append({"macAddress": "AA:BB:CC:DD:EE:FF"})
+        appliances.append({"sfPersonAccountId": {"nested": "object"}})
+        appliances.append({"sfPersonAccountId": ""})
+        appliances.append("not-a-dict")
+        self.assertEqual("match", self.match(silent, OUR_ACCOUNT))
+
+    def test_an_all_silent_list_is_unknown_and_never_a_match(self) -> None:
+        # The vote must not be won by acclamation: with nothing readable the honest
+        # answer is that the check did not run.
+        nameless = healthy()
+        nameless["modules"]["applianceList"]["payload"]["appliances"] = [
+            {"macAddress": "AA:BB:CC:DD:EE:FF"},
+            {"sfPersonAccountId": 42},
+        ]
+        self.assertEqual("unknown", self.match(nameless, OUR_ACCOUNT))
+
+    def test_a_string_subclass_owner_cannot_forge_a_match(self) -> None:
+        # The single most misleading thing this field could say. `isinstance` admits a
+        # str SUBCLASS, and one whose `__eq__` returns True equals our account id while
+        # its characters are someone else's -- turning the mismatch that explains the
+        # whole report into a clean bill of health. The guard is `type(v) is str`.
+        class Sneaky(str):
+            def __eq__(self, other):  # pragma: no cover - only if the guard fails
+                return True
+
+            def __hash__(self):
+                return hash(str(self))
+
+        forged = healthy()
+        forged["modules"]["applianceList"]["payload"]["appliances"][0][
+            "sfPersonAccountId"
+        ] = Sneaky(OTHER_ACCOUNT)
+        self.assertEqual("unknown", self.match(forged, OUR_ACCOUNT))
+
+    def test_every_verdict_is_a_declared_token_and_it_never_raises(self) -> None:
+        # It runs inside NativeHon.setup(): an exception here does not spoil a
+        # diagnostic field, it takes the config entry down. And a verdict outside the
+        # declared tuple would print as "other" in the dump, which for an identity
+        # question is the one answer nobody can act on.
+        class Hostile(dict):
+            def __contains__(self, key):
+                raise RuntimeError("hostile mapping")
+
+        responses = [
+            healthy(), reporter(), None, [], "", 0, {}, {"modules": []},
+            {"modules": {"applianceList": {"payload": {"appliances": "x"}}}},
+            Hostile({"modules": {}}),
+            {"modules": {"applianceList": {"payload": {"appliances": [None, 1, "x"]}}}},
+        ]
+        seen = set()
+        for response in responses:
+            for claim in (OUR_ACCOUNT, OTHER_ACCOUNT, None):
+                with self.subTest(response=type(response).__name__, claim=claim):
+                    verdict = self.match(response, claim)
+                    self.assertIn(verdict, api_mod.ACCOUNT_TOKENS)
+                    seen.add(verdict)
+        # The guard has a producer: without it the hostile mapping raises out of a
+        # setup instead of answering.
+        self.assertEqual("unknown", self.match(Hostile({"modules": {}}), OUR_ACCOUNT))
+        self.assertLessEqual({"match", "mismatch", "no_appliances", "no_claim",
+                              "unknown"}, seen)
+
+    def test_the_verdict_carries_no_identifier(self) -> None:
+        # Both values compared here are account ids. Neither may appear in the answer:
+        # the whole reason the comparison happens in the transport is that only the
+        # verdict is allowed to cross into a document a user pastes into a public issue.
+        hostile = healthy()
+        hostile["modules"]["applianceList"]["payload"]["appliances"][0][
+            "sfPersonAccountId"
+        ] = "3C:71:BF:AA:BB:CC"
+        for claim in (OUR_ACCOUNT, "user@example.com"):
+            verdict = self.match(hostile, claim)
+            self.assertNotIn("3C:71:BF:AA:BB:CC", verdict)
+            self.assertNotIn("example.com", verdict)
+            self.assertNotIn(OUR_ACCOUNT, verdict)
+
+
+class FetchCensusEnvelopeTest(unittest.TestCase):
+    """The census carries the envelope and the identity check, end to end.
+
+    Written against the two envelopes of the investigation (`tests/_envelopes.py`):
+    the healthy one captured live on 2026-08-24, and the reporter's, whose two
+    recorded levels are identical to it. Everything the dump could already say about
+    those two responses was the same; this is the pin that it no longer is.
+    """
+
+    def _census(self, body, claim=OUR_ACCOUNT, **kwargs):
+        api = _call(_AuthedConnection(body, _id_token(claim), **kwargs))
+        _run(api.load_appliances())
+        return api.last_appliance_fetch
+
+    def test_the_healthy_capture_reads_as_healthy(self) -> None:
+        census = self._census(healthy())
+        self.assertEqual(200, census["status"])
+        self.assertEqual("ok", census["outcome"])
+        self.assertEqual(1, census["count"])
+        self.assertIs(True, census["envelope_ok"])
+        self.assertIs(True, census["module_ok"])
+        self.assertEqual(0, census["auth_keys"])
+        self.assertEqual("match", census["account"])
+
+    def test_the_reporter_envelope_is_an_account_that_owns_nothing(self) -> None:
+        # The verdict the field report deserved: the cloud declared success at BOTH
+        # levels, the session resolved to the account we authenticated as, and that
+        # account has no appliances. That is a finished diagnosis, and none of it was
+        # readable from a dump before.
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ):
+            census = self._census(reporter())
+        self.assertEqual(0, census["count"])
+        self.assertIs(True, census["envelope_ok"])
+        self.assertIs(True, census["module_ok"])
+        self.assertEqual("no_appliances", census["account"])
+
+    def test_a_failed_module_stops_looking_like_an_empty_account(self) -> None:
+        # THE case the two flags exist for. `modules.applianceList.success: false` with
+        # an empty payload is a state in which the official app shows zero appliances
+        # too -- it does not read the flag either -- and in which every other field of
+        # the census is byte-identical to a legitimately empty account.
+        failed = reporter()
+        failed["modules"]["applianceList"]["success"] = False
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ):
+            broken = self._census(failed)
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ):
+            legit = self._census(reporter())
+        self.assertNotEqual(
+            {k: v for k, v in broken.items() if k != "at"},
+            {k: v for k, v in legit.items() if k != "at"},
+        )
+        self.assertIs(False, broken["module_ok"])
+        self.assertIs(True, legit["module_ok"])
+
+    def test_a_rotated_cognito_token_shows_up_as_a_key_count(self) -> None:
+        # `authInfo` is empty on every healthy session captured, so it is a channel
+        # that stays silent when things work: any content at all is a signal, and the
+        # count is the whole of what may be published about it.
+        rotating = healthy()
+        rotating["modules"]["applianceList"]["authInfo"] = {
+            "cognitoTokenNew": "eyJhbGciOiJIUzI1NiJ9.SECRET-TOKEN-VALUE.sig"
+        }
+        census = self._census(rotating)
+        self.assertEqual(1, census["auth_keys"])
+        blob = json.dumps(census, default=str)
+        for leak in ("cognitoTokenNew", "SECRET-TOKEN-VALUE"):
+            self.assertNotIn(leak, blob, leak)
+
+    def test_a_session_that_resolved_elsewhere_is_visible(self) -> None:
+        census = self._census(healthy(), claim=OTHER_ACCOUNT)
+        self.assertEqual("mismatch", census["account"])
+        self.assertEqual(1, census["count"])
+
+    def test_a_connection_without_an_auth_object_records_no_claim(self) -> None:
+        # `HonConnection.auth` RAISES when the connection was never created, and no
+        # other double in this file has one. The census must answer, not abort: the
+        # rule the `getattr` on `resp.status` follows, for the same reason.
+        api = _call(FakeConnection(healthy()))
+        self.assertEqual(1, len(_run(api.load_appliances())))
+        self.assertEqual("no_claim", api.last_appliance_fetch["account"])
+        # ...and the rest of the census is unaffected: the guard costs the identity
+        # check, not the fetch.
+        self.assertEqual("ok", api.last_appliance_fetch["outcome"])
+        self.assertIs(True, api.last_appliance_fetch["module_ok"])
+
+    def test_a_raising_auth_property_does_not_abort_the_fetch(self) -> None:
+        class _Exploding(FakeConnection):
+            @property
+            def auth(self):
+                raise RuntimeError("connection not created (create() is missing)")
+
+        api = _call(_Exploding(healthy()))
+        self.assertEqual(1, len(_run(api.load_appliances())))
+        self.assertEqual("no_claim", api.last_appliance_fetch["account"])
+
+    def test_both_census_paths_declare_the_same_keys(self) -> None:
+        # `load_appliances` builds two SEPARATE dict literals, and the reader compares
+        # two downloads of the same issue field by field: a key present on one path and
+        # absent on the other turns "this got worse" into "this file is shaped
+        # differently".
+        served = self._census(healthy())
+        refused = _call(_RaisingConnection(RuntimeError("hOn server error (status 503)")))
+        with self.assertRaises(RuntimeError):
+            _run(refused.load_appliances())
+        self.assertEqual(set(served), set(refused.last_appliance_fetch))
+        for key in ("envelope_ok", "module_ok", "auth_keys", "account"):
+            with self.subTest(key=key):
+                # Nothing downstream of a body can be reported when there was no body.
+                self.assertIsNone(refused.last_appliance_fetch[key])
+
+    def test_the_new_fields_reach_the_diagnostics_block_unchanged(self) -> None:
+        # The whole path in one assertion: the writer here, the reader in
+        # diagnostics.py, and no other file in the suite can exercise both (see the
+        # docstring of test_both_paths_stamp_an_instant_the_dump_can_render above).
+        # Split across two files, a rename on either side leaves both halves green
+        # while the block quietly renders null.
+        from datetime import timedelta
+        from types import SimpleNamespace
+
+        from custom_components.addhon import diagnostics
+        from custom_components.addhon.const import DOMAIN
+
+        rotated = healthy()
+        rotated["modules"]["applianceList"]["authInfo"] = {"cognitoTokenNew": "SECRET"}
+        rotated["modules"]["applianceList"]["success"] = False
+        api = _call(_AuthedConnection(rotated, _id_token(OTHER_ACCOUNT)))
+        _run(api.load_appliances())
+        hass = SimpleNamespace(data={DOMAIN: {"e1": {"client": api}}})
+        block = diagnostics._last_fetch(
+            hass,
+            SimpleNamespace(entry_id="e1"),
+            now=api.last_appliance_fetch["at"] + timedelta(seconds=1),
+        )
+        self.assertEqual("recorded", block["state"])
+        self.assertIs(True, block["envelope_ok"])
+        self.assertIs(False, block["module_ok"])
+        self.assertEqual(1, block["auth_keys"])
+        self.assertEqual("mismatch", block["account"])
+        blob = json.dumps(block, default=str)
+        for leak in ("SECRET", "cognitoTokenNew", OUR_ACCOUNT, OTHER_ACCOUNT,
+                     "AA:BB:CC:DD:EE:FF", "PLAINTEXT-SERIAL", "Kitchen Fridge"):
+            self.assertNotIn(leak, blob, leak)
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -1152,6 +1152,53 @@ class FetchCensusEnvelopeTest(unittest.TestCase):
         _run(api.load_appliances())
         return api.last_appliance_fetch
 
+    def test_a_body_that_fights_back_never_takes_the_setup_down(self) -> None:
+        """The last unguarded stretch of `load_appliances`, closed end to end.
+
+        Three separate calls on the response object stood between a hostile body and a
+        surviving setup: `parse_appliance_list` walking with `.get`, the ADDHON-210
+        message reading `.keys()` to name the levels, and the redacted DEBUG dump. All
+        three ran on an object the CLOUD supplied, and the middle one would have raised
+        while building the very message that exists to explain the failure.
+
+        The input is a dict subclass raising from `get`. Not reachable from
+        `json.loads`, which is precisely why the old reasoning held that none of this
+        could raise: the input is `await resp.json(content_type=None)` on a duck-typed
+        response, so "a json.loads output is safe" and "this cannot abort a setup" are
+        different claims, and only the second one matters inside `NativeHon.setup()`.
+
+        What must survive is not just the absence of an exception: the census still has
+        to say something, and ADDHON-210 still has to be logged, because that code is
+        what a reporter is told to search for.
+        """
+
+        class _HostileGetBody(dict):
+            def get(self, *args, **kwargs):
+                raise RuntimeError("hostile mapping")
+
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ) as logs:
+            census = self._census(_HostileGetBody(healthy()))
+        self.assertEqual([], _run(_call(_AuthedConnection(
+            _HostileGetBody(healthy()), _id_token(OUR_ACCOUNT))).load_appliances()))
+        # ADDHON-210 is still emitted, and the key names degrade to `unreadable`
+        # rather than to the `n/a` that means "the shape was wrong": the two are
+        # different findings and the log keeps them apart.
+        self.assertIn("ADDHON-210", logs.output[0])
+        self.assertIn("unreadable", logs.output[0])
+        # The census is still a census. Note WHICH census: the probe walks with
+        # `key in node` + `node[key]` and this subclass only poisons `get`, so the
+        # probe sails through and reports the healthy walk it genuinely performed.
+        # The result is a dump saying `count: 1` beside `"appliances": []`, and that
+        # pair is not a contradiction to paper over -- it is the signature of this
+        # exact failure, and the only one that names it. A response where the walk
+        # finds a list and the parse cannot return it is neither "the cloud sent
+        # nothing" nor "the chain changed", and before this it looked like the first.
+        self.assertEqual("ok", census["outcome"])
+        self.assertEqual(1, census["count"])
+        self.assertEqual(200, census["status"])
+
     def test_the_healthy_capture_reads_as_healthy(self) -> None:
         census = self._census(healthy())
         self.assertEqual(200, census["status"])

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -1209,6 +1209,28 @@ class FetchCensusEnvelopeTest(unittest.TestCase):
         # ...and the finding still travels: the census counts the keys it refused to name.
         self.assertIn("auth_keys=2", blob)
 
+    def test_the_summary_key_names_are_filtered_too(self) -> None:
+        """`sorted(result.keys())` reads as obviously safe and is not.
+
+        A mapping the vendor keyed BY an identity carries it in the key position, and
+        this summary goes to the level meant for pasting into public issues. The shape
+        line below it was fixed first; a summary that stayed raw would have leaked the
+        same value one line earlier.
+        """
+        poisoned = reporter()
+        poisoned["user#eu-west-1:CANARY-IDENTITY"] = {"x": 1}
+        poisoned["modules"]["0011q00001CANARYAAA"] = {"y": 2}
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ) as logs:
+            self._census(poisoned)
+        blob = "\n".join(logs.output)
+        self.assertNotIn("CANARY-IDENTITY", blob)
+        self.assertNotIn("0011q00001CANARYAAA", blob)
+        # The real schema keys still print, or the summary stops being a summary.
+        self.assertIn("modules", blob)
+        self.assertIn("applianceList", blob)
+
     def test_a_failed_module_says_so_in_the_warning(self) -> None:
         # The reason the flag is worth logging at all: with `success: false` the list
         # is empty for a reason that is NOT an empty account, and until now the two

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -1177,12 +1177,37 @@ class FetchCensusEnvelopeTest(unittest.TestCase):
             "account=no_appliances",
         ):
             self.assertIn(fragment, summary)
-        # And the raw response is emitted at WARNING too, redacted: it is the one
-        # artefact that answers what is UNDER `payload`, which no census field can.
-        self.assertTrue(
-            any("hOn raw appliance response" in line for line in logs.output),
-            logs.output,
+        # And the response SHAPE is emitted at WARNING too: it is the one artefact
+        # that answers what is UNDER `payload`, which no census field can.
+        shape = next(
+            (line for line in logs.output if "appliance response shape" in line), None
         )
+        self.assertIsNotNone(shape, logs.output)
+        self.assertIn("<list of 0>", shape)
+
+    def test_the_shape_line_cannot_carry_a_bearer_token(self) -> None:
+        """The reason it is a shape and not a redacted body.
+
+        `redact_identity` matches key NAMES against a set, and no set enumerates a
+        vendor's naming: `token` was in it and `cognitoTokenNew` was not. That key is
+        the replacement cognito credential the aggregator returns inside
+        `modules.applianceList.authInfo`, and THIS branch is where the response is
+        logged -- at a level this project asks reporters to paste into public issues.
+        """
+        poisoned = reporter()
+        poisoned["modules"]["applianceList"]["authInfo"] = {
+            "cognitoTokenNew": "eyJhbGciOiJIUzI1NiJ9.CANARY-BEARER-CREDENTIAL.sig",
+            "sfPersonAccountId": "0011q00001CANARYAAA",
+        }
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ) as logs:
+            self._census(poisoned)
+        blob = "\n".join(logs.output)
+        self.assertNotIn("CANARY-BEARER-CREDENTIAL", blob)
+        self.assertNotIn("0011q00001CANARYAAA", blob)
+        # ...and the finding still travels: the census counts the keys it refused to name.
+        self.assertIn("auth_keys=2", blob)
 
     def test_a_failed_module_says_so_in_the_warning(self) -> None:
         # The reason the flag is worth logging at all: with `success: false` the list

--- a/tests/test_transport_api.py
+++ b/tests/test_transport_api.py
@@ -1152,6 +1152,52 @@ class FetchCensusEnvelopeTest(unittest.TestCase):
         _run(api.load_appliances())
         return api.last_appliance_fetch
 
+    def test_the_warning_carries_the_whole_diagnosis_without_debug(self) -> None:
+        """The empty-list WARNING is a finished diagnosis, at a level everyone sees.
+
+        This branch is the hardest report in the project to act on, and asking for a
+        downloaded dump has repeatedly failed to produce one: the appliance-list call
+        happens ONCE, during setup, so a reporter who enables debug afterwards captures
+        nothing, and the raw response used to live at DEBUG behind exactly that trap.
+
+        So the census travels with the warning. Everything asserted here is a token or
+        a bounded int produced by OUR code -- `probe_appliance_list` and
+        `account_match` -- never a value chosen by the cloud, which is what lets a
+        WARNING carry it into a public issue unedited.
+        """
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ) as logs:
+            self._census(reporter())
+        summary = next(line for line in logs.output if "ADDHON-210" in line)
+        for fragment in (
+            "envelope_ok=True",
+            "module_ok=True",
+            "auth_keys=0",
+            "account=no_appliances",
+        ):
+            self.assertIn(fragment, summary)
+        # And the raw response is emitted at WARNING too, redacted: it is the one
+        # artefact that answers what is UNDER `payload`, which no census field can.
+        self.assertTrue(
+            any("hOn raw appliance response" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_a_failed_module_says_so_in_the_warning(self) -> None:
+        # The reason the flag is worth logging at all: with `success: false` the list
+        # is empty for a reason that is NOT an empty account, and until now the two
+        # produced the same line.
+        broken = reporter()
+        broken["modules"]["applianceList"]["success"] = False
+        with self.assertLogs(
+            "custom_components.addhon.client.transport.api", level="WARNING"
+        ) as logs:
+            self._census(broken)
+        summary = next(line for line in logs.output if "ADDHON-210" in line)
+        self.assertIn("module_ok=False", summary)
+        self.assertIn("envelope_ok=True", summary)
+
     def test_a_body_that_fights_back_never_takes_the_setup_down(self) -> None:
         """The last unguarded stretch of `load_appliances`, closed end to end.
 

--- a/tests/test_transport_parse.py
+++ b/tests/test_transport_parse.py
@@ -14,6 +14,12 @@ it is loaded in isolation.
 The second half of the file covers `probe_appliance_list`, which has no pyhOn
 counterpart at all: it reports WHERE that fail-safe walk stopped, so a diagnostics
 dump can separate the three responses sec9 deliberately collapses into `[]`.
+
+The third covers the envelope ABOVE that walk -- the two `success` flags and the size
+of `authInfo` -- whose oracle is not a spec at all but a live capture of a healthy
+response (apk/analysis/addhon210-healthy-envelope-baseline.md, shared as
+`tests/_envelopes.py`). sec9 never mentions those levels because nothing read them:
+not this integration, and not the official app.
 """
 from __future__ import annotations
 
@@ -22,6 +28,8 @@ import json
 import sys
 import unittest
 from pathlib import Path
+
+from _envelopes import healthy, reporter  # noqa: E402
 
 _ROOT = Path(__file__).resolve().parents[1]
 _OUR_PARSE = _ROOT / "custom_components" / "addhon" / "client" / "transport" / "parse.py"
@@ -126,6 +134,20 @@ class _HostileDict(dict):
         raise RuntimeError("hostile mapping")
 
 
+class _HostileGetDict(dict):
+    """A dict SUBCLASS that raises from `get`.
+
+    The membership test is not the only door. `_envelope_flags` runs BEFORE the walk's
+    try/except and reaches the response through `.get`, so this is the input that
+    decides whether its own guard is load-bearing: without it an exception here
+    propagates out of `probe_appliance_list` entirely and aborts a config entry setup,
+    which is the one thing the whole probe is written not to do.
+    """
+
+    def get(self, key, default=None):
+        raise RuntimeError("hostile mapping")
+
+
 def _deep(depth: int) -> dict:
     node: dict = {}
     for _ in range(depth):
@@ -151,6 +173,9 @@ class ProbeApplianceListTest(unittest.TestCase):
         self.path = module.APPLIANCE_LIST_PATH
 
     def test_probe_reports_ok_and_the_raw_count(self) -> None:
+        # Asserted as a WHOLE dict, so a field added to the probe has to be added here
+        # too: the census this returns is copied verbatim into the diagnostics document
+        # and its key set is the block's key set.
         full = {"modules": {"applianceList": {"payload": {"appliances": _REAL}}}}
         self.assertEqual(
             {
@@ -159,6 +184,12 @@ class ProbeApplianceListTest(unittest.TestCase):
                 "node_type": "list",
                 "siblings": None,
                 "count": 2,
+                # No envelope at all around this fixture: the two `success` flags and
+                # the `authInfo` size are absent, and absent reads as null rather than
+                # as false. See EnvelopeFlagsTest below.
+                "envelope_ok": None,
+                "module_ok": None,
+                "auth_keys": None,
             },
             self.probe(full),
         )
@@ -205,6 +236,9 @@ class ProbeApplianceListTest(unittest.TestCase):
                 "node_type": "int",
                 "siblings": None,
                 "count": None,
+                "envelope_ok": None,
+                "module_ok": None,
+                "auth_keys": None,
             },
             self.probe({"modules": 3}),
         )
@@ -324,6 +358,175 @@ class ProbeApplianceListTest(unittest.TestCase):
         )
         self.assertEqual("not_a_list", foreign["outcome"])
         self.assertEqual("other", foreign["node_type"])
+
+    def test_the_envelope_flags_survive_every_branch_of_the_walk(self) -> None:
+        # The reason `_envelope_flags` runs BEFORE the try and is spread into all five
+        # returns. A failure branch is exactly where a reader needs to know whether the
+        # cloud declared the call a success: "our walk stopped at `payload`" and "the
+        # module said false, so there was no payload" are the same picture otherwise.
+        # Computing them on the happy path only would have left the field null in every
+        # dump that needed it, and every test asserting the ok branch would still pass.
+        broken = healthy()
+        del broken["modules"]["applianceList"]["payload"]
+        broken["modules"]["applianceList"]["success"] = False
+        probe = self.probe(broken)
+        self.assertEqual("missing_key", probe["outcome"])
+        self.assertEqual("payload", probe["stopped_at"])
+        self.assertIs(True, probe["envelope_ok"])
+        self.assertIs(False, probe["module_ok"])
+        self.assertEqual(0, probe["auth_keys"])
+        # ...and on the branch that reaches nothing at all, including the reserved
+        # `other` one, which is reached through the guard rather than through a return.
+        hostile = _HostileDict(healthy())
+        self.assertEqual("other", self.probe(hostile)["outcome"])
+        self.assertIs(True, self.probe(hostile)["envelope_ok"])
+        self.assertIs(True, self.probe(hostile)["module_ok"])
+
+    def test_every_branch_emits_the_same_key_set(self) -> None:
+        # The census this returns IS the diagnostics block's key set (the reader spreads
+        # it into a document whose fields must be comparable between two downloads), so
+        # a branch that forgot `**flags` would silently drop three fields from exactly
+        # the responses that need them.
+        keys = {
+            frozenset(self.probe(response))
+            for response in (
+                healthy(), reporter(), None, {}, {"modules": 3},
+                {"modules": {"applianceList": {"payload": {"appliances": "x"}}}},
+                _HostileDict({"modules": {}}),
+            )
+        }
+        self.assertEqual(1, len(keys), keys)
+        self.assertEqual(
+            {"outcome", "stopped_at", "node_type", "siblings", "count",
+             "envelope_ok", "module_ok", "auth_keys"},
+            next(iter(keys)),
+        )
+
+    def test_the_healthy_capture_reads_as_healthy(self) -> None:
+        # The calibration. Every field of the block, against a response verified on the
+        # wire: without this the flags are asserted only against shapes this file
+        # invented, and "true means the cloud said true" is an assumption.
+        self.assertEqual(
+            {
+                "outcome": "ok", "stopped_at": None, "node_type": "list",
+                "siblings": None, "count": 1,
+                "envelope_ok": True, "module_ok": True, "auth_keys": 0,
+            },
+            self.probe(healthy()),
+        )
+
+    def test_the_reporter_envelope_differs_only_in_the_count(self) -> None:
+        # The null hypothesis, stated as a test. Their log records the two key sets and
+        # both match the healthy capture, so a schema drift at those levels is ruled
+        # out -- and this pins that the fields added on top do NOT invent a difference
+        # where the evidence shows none. The one field that moves is the one their dump
+        # already reported.
+        healthy_probe = self.probe(healthy())
+        reporter_probe = self.probe(reporter())
+        self.assertEqual(1, healthy_probe.pop("count"))
+        self.assertEqual(0, reporter_probe.pop("count"))
+        self.assertEqual(healthy_probe, reporter_probe)
+
+    def test_a_success_that_is_not_a_boolean_is_not_coerced(self) -> None:
+        # `bool("false")` is True and `bool(0)` is False: coercion would let the field
+        # answer the exact question it exists to establish, using a value the cloud
+        # never gave. Null means "this build could not tell", which is the truth.
+        for junk in ("true", "false", 1, 0, [], {}, None):
+            with self.subTest(junk=junk):
+                response = healthy()
+                response["success"] = junk
+                response["modules"]["applianceList"]["success"] = junk
+                probe = self.probe(response)
+                self.assertIsNone(probe["envelope_ok"])
+                self.assertIsNone(probe["module_ok"])
+        # ...and a real boolean still comes through, so the assertions above are not
+        # passing merely because the fields are always null.
+        false = healthy()
+        false["success"] = False
+        false["modules"]["applianceList"]["success"] = False
+        self.assertIs(False, self.probe(false)["envelope_ok"])
+        self.assertIs(False, self.probe(false)["module_ok"])
+
+    def test_auth_info_is_counted_and_never_named(self) -> None:
+        # `authInfo` is empty on a healthy session and can carry `cognitoTokenNew`, a
+        # bearer token the app adopts and we ignore. The COUNT is the whole signal: a
+        # channel that is silent when healthy makes any content meaningful, and a
+        # number cannot carry an identity or a credential.
+        rotated = healthy()
+        rotated["modules"]["applianceList"]["authInfo"] = {
+            "cognitoTokenNew": "eyJhbGciOiJIUzI1NiJ9.SECRET-TOKEN-VALUE.sig",
+            "3C:71:BF:AA:BB:CC": "user@example.com",
+        }
+        probe = self.probe(rotated)
+        self.assertEqual(2, probe["auth_keys"])
+        blob = json.dumps(probe)
+        for leak in ("cognitoTokenNew", "SECRET-TOKEN-VALUE", "3C:71:BF:AA:BB:CC",
+                     "user@example.com"):
+            self.assertNotIn(leak, blob, leak)
+
+    def test_a_foreign_auth_info_is_refused_rather_than_measured(self) -> None:
+        # A list has a len() too, and `len("abcdef")` is 6: without the isinstance
+        # guard the field would report a character count as a key count, which reads
+        # as a rotation that never happened.
+        for junk in ([], ["a", "b"], "abcdef", 7, None, True):
+            with self.subTest(junk=junk):
+                response = healthy()
+                response["modules"]["applianceList"]["authInfo"] = junk
+                self.assertIsNone(self.probe(response)["auth_keys"])
+        # Absent entirely is the same answer as unreadable: null, never 0. 0 is
+        # reserved for "the object was there and it was empty", which is the baseline
+        # the whole field is calibrated against.
+        missing = healthy()
+        del missing["modules"]["applianceList"]["authInfo"]
+        self.assertIsNone(self.probe(missing)["auth_keys"])
+
+    def test_the_flags_are_read_under_the_module_and_nowhere_else(self) -> None:
+        # `success` exists at two levels and the two mean different things, so a walk
+        # that read the wrong one would report the envelope's answer as the module's.
+        # Deliberately opposite values: a confusion between the levels cannot pass.
+        response = healthy()
+        response["success"] = False
+        response["modules"]["applianceList"]["success"] = True
+        probe = self.probe(response)
+        self.assertIs(False, probe["envelope_ok"])
+        self.assertIs(True, probe["module_ok"])
+        # A `success` sitting anywhere else is not either of them.
+        stray = healthy()
+        del stray["success"]
+        del stray["modules"]["applianceList"]["success"]
+        stray["modules"]["success"] = True
+        stray["modules"]["applianceList"]["payload"]["success"] = True
+        self.assertIsNone(self.probe(stray)["envelope_ok"])
+        self.assertIsNone(self.probe(stray)["module_ok"])
+
+    def test_the_flags_never_raise(self) -> None:
+        # Same standard as the walk beside them, and a STRONGER requirement: the flags
+        # are computed before the walk's try/except, so an exception escaping them
+        # escapes `probe_appliance_list` itself and takes a config entry down with it.
+        # `_HostileGetDict` is the input that decides it -- the flags reach the
+        # response through `.get`, which the walk's own hostile double never touches.
+        for response in (
+            _HostileDict({"modules": {}}),
+            _HostileGetDict({"modules": {}}),
+            {"modules": _HostileGetDict({"applianceList": {}})},
+            {"modules": _HostileDict({"applianceList": {}})},
+            {"modules": {"applianceList": _HostileGetDict({"success": True})}},
+            _deep(200),
+            {str(i): i for i in range(10_000)},
+        ):
+            with self.subTest(response=type(response).__name__):
+                probe = self.probe(response)
+                for key in ("envelope_ok", "module_ok"):
+                    self.assertIn(probe[key], (True, False, None))
+                self.assertIn(type(probe["auth_keys"]), (int, type(None)))
+        # ...and what it managed to read before the raise is KEPT rather than thrown
+        # away with it: `envelope_ok` was already established when the module level
+        # exploded, and it is the half that says whether the cloud declared success.
+        partial = self.probe(
+            {"success": True, "modules": _HostileGetDict({"applianceList": {}})}
+        )
+        self.assertIs(True, partial["envelope_ok"])
+        self.assertIsNone(partial["module_ok"])
 
     def test_parse_appliance_list_return_type_is_unchanged(self) -> None:
         # The probe was added beside the parser, not inside it. This is the whole

--- a/tests/test_transport_parse.py
+++ b/tests/test_transport_parse.py
@@ -100,6 +100,50 @@ class ParseApplianceListTest(unittest.TestCase):
                 self.assertEqual(self.parse(result), [])
 
 
+    def test_a_mapping_that_fights_back_is_still_zero_appliances(self) -> None:
+        """The docstring promised "any unexpected shape -> []" and a subclass broke it.
+
+        `isinstance(x, dict)` is True for a subclass, so a hostile one walks past the
+        type guard and into `.get`, where it raises. Before the guard that TypeError
+        left `parse_appliance_list` and took the config entry down from inside
+        `NativeHon.setup()` -- with a bare exception naming nothing a reporter can act
+        on, which is the opposite of what a fail-safe parser is for.
+
+        Only `get` is a door HERE, and that asymmetry is worth stating: this function
+        walks with `node.get(key)` while `probe_appliance_list` walks with `key in node`
+        followed by `node[key]`, so a subclass raising from `__contains__` stops the
+        probe and leaves this one untouched. The two are pinned to agree on the OUTCOME
+        of a healthy response, never on which hostile input reaches them -- which is why
+        the probe's guard is not evidence that this one was unnecessary.
+        """
+        for level, hostile in (
+            ("top", _HostileGetDict(_REAL_ENVELOPE)),
+            ("modules", {"modules": _HostileGetDict({"applianceList": {}})}),
+            ("applianceList",
+             {"modules": {"applianceList": _HostileGetDict({"payload": {}})}}),
+            ("payload",
+             {"modules": {"applianceList": {"payload": _HostileGetDict({"appliances": []})}}}),
+        ):
+            with self.subTest(level=level):
+                self.assertEqual([], self.parse(hostile))
+
+    def test_a_contains_that_raises_is_not_this_function_s_door(self) -> None:
+        # Documents the asymmetry rather than leaving it to be rediscovered: the same
+        # object that drives the probe to `outcome: "other"` is answered normally here.
+        self.assertEqual(_REAL, self.parse(_HostileDict(_REAL_ENVELOPE)))
+
+    def test_the_healthy_shape_is_untouched_by_the_guard(self) -> None:
+        # The guard must not turn a real answer into a fail-safe one: same object,
+        # not a copy and not an empty list.
+        self.assertIs(
+            _REAL_ENVELOPE["modules"]["applianceList"]["payload"]["appliances"],
+            self.parse(_REAL_ENVELOPE),
+        )
+
+
+_REAL_ENVELOPE = {"modules": {"applianceList": {"payload": {"appliances": _REAL}}}}
+
+
 # (response, "does this payload carry a list at the path") -- the truth is STATED
 # here, not computed from the probe, so the equivalence below compares the probe
 # against an author's claim instead of against itself.

--- a/tests/test_transport_parse.py
+++ b/tests/test_transport_parse.py
@@ -360,12 +360,52 @@ class ProbeApplianceListTest(unittest.TestCase):
         self.assertEqual("other", foreign["node_type"])
 
     def test_the_envelope_flags_survive_every_branch_of_the_walk(self) -> None:
-        # The reason `_envelope_flags` runs BEFORE the try and is spread into all five
-        # returns. A failure branch is exactly where a reader needs to know whether the
-        # cloud declared the call a success: "our walk stopped at `payload`" and "the
-        # module said false, so there was no payload" are the same picture otherwise.
-        # Computing them on the happy path only would have left the field null in every
-        # dump that needed it, and every test asserting the ok branch would still pass.
+        """All FIVE outcomes, as a table, not the two that were easy to reach.
+
+        The reason `_envelope_flags` runs BEFORE the try and is spread into every
+        return. A failure branch is exactly where a reader needs to know whether the
+        cloud declared the call a success: "our walk stopped at `payload`" and "the
+        module said false, so there was no payload" are the same picture otherwise.
+        Computing them on the happy path only would leave the field null in every dump
+        that needed it, and every test asserting the ok branch would still pass.
+
+        Enumerated rather than sampled because that is exactly how the gap got in: the
+        earlier version of this test carried this name while asserting two branches out
+        of five, so `not_a_dict` and `not_a_list` could both drop all three flags with
+        the whole suite green. Each case below breaks the walk BELOW the module level,
+        so the flags stay readable and their loss is a defect rather than an absence.
+        """
+        def _break(mutate) -> dict:
+            envelope = healthy()
+            mutate(envelope)
+            return envelope
+
+        def _payload(envelope) -> dict:
+            return envelope["modules"]["applianceList"]
+
+        cases = (
+            # outcome        stopped_at     response
+            ("ok", None, healthy()),
+            ("missing_key", "appliances",
+             _break(lambda e: _payload(e)["payload"].pop("appliances"))),
+            ("not_a_dict", "appliances",
+             _break(lambda e: _payload(e).__setitem__("payload", "not a mapping"))),
+            ("not_a_list", None,
+             _break(lambda e: _payload(e)["payload"].__setitem__("appliances", {"a": 1}))),
+        )
+        for outcome, stopped_at, response in cases:
+            with self.subTest(outcome=outcome):
+                probe = self.probe(response)
+                self.assertEqual(outcome, probe["outcome"])
+                self.assertEqual(stopped_at, probe["stopped_at"])
+                # The three flags describe the ENVELOPE, which every one of these
+                # responses still carries intact: none of them may go null.
+                self.assertIs(True, probe["envelope_ok"])
+                self.assertIs(True, probe["module_ok"])
+                self.assertEqual(0, probe["auth_keys"])
+
+        # A false module flag has to survive too, or the one branch where the cloud
+        # TOLD us why the payload is missing is the branch that discards the answer.
         broken = healthy()
         del broken["modules"]["applianceList"]["payload"]
         broken["modules"]["applianceList"]["success"] = False
@@ -375,12 +415,14 @@ class ProbeApplianceListTest(unittest.TestCase):
         self.assertIs(True, probe["envelope_ok"])
         self.assertIs(False, probe["module_ok"])
         self.assertEqual(0, probe["auth_keys"])
-        # ...and on the branch that reaches nothing at all, including the reserved
-        # `other` one, which is reached through the guard rather than through a return.
+
+        # ...and the reserved `other` branch, reached through the guard rather than
+        # through a return, which is why it can lose the flags in its own way.
         hostile = _HostileDict(healthy())
         self.assertEqual("other", self.probe(hostile)["outcome"])
         self.assertIs(True, self.probe(hostile)["envelope_ok"])
         self.assertIs(True, self.probe(hostile)["module_ok"])
+        self.assertEqual(0, self.probe(hostile)["auth_keys"])
 
     def test_every_branch_emits_the_same_key_set(self) -> None:
         # The census this returns IS the diagnostics block's key set (the reader spreads

--- a/tests/test_transport_tokens.py
+++ b/tests/test_transport_tokens.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 tis24dev
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Contract test of the transport's OAuth token parser: parse_token_fragment.
+"""Contract test of the transport's OAuth token readers.
 
 Oracle = the OAuth2 implicit-flow redirect contract (RFC 6749 sec4.2.2), documented
 in docs/protocol/HAIER-HON-TRANSPORT.md sec6 -- NOT a transcription of pyhOn's
@@ -12,10 +12,17 @@ a matrix of redirects, including the deliberate, cloud-safe divergences from a n
 parse_qs: access/id kept RAW, only refresh percent-decoded once, an empty value still
 counts as "present", and -- unlike pyhOn -- a final field with NO trailing `&` IS
 captured (a real fragment need not end in one).
+
+The second half covers the two CLAIM readers, `token_expiry` (RFC 7519 sec4.1.4) and
+`token_person_account_id`, which share one decoder. `token_expiry` shipped without
+tests of its own; it governs when every request in the transport refreshes its token,
+so the extraction of that decoder needed a pin before it could be made -- these are it.
 """
 from __future__ import annotations
 
+import base64
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -164,6 +171,165 @@ class ParseTokenFragmentTest(unittest.TestCase):
         t = self.parse(page)
         self.assertEqual(t.access_token, "DECOY_A")  # first match wins (documented)
         self.assertEqual(t.id_token, "DECOY_I")
+
+
+def _jwt(claims, *, header="eyJhbGciOiJIUzI1NiJ9", signature="sig") -> str:
+    """A JWT whose payload section carries `claims`, built the way the IdP does.
+
+    Base64URL with the padding STRIPPED (RFC 7515 sec2), because that is the form the
+    readers have to restore and the one a hand-written fixture would quietly get
+    right. The header and signature are inert: nothing under test verifies either.
+    """
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{body}.{signature}"
+
+
+class TokenExpiryTest(unittest.TestCase):
+    """`token_expiry` reads the token's OWN stated lifetime (RFC 7519 sec4.1.4).
+
+    Untested until now, and load-bearing: `HonAuth` stores its result as
+    `_access_expiry` and `token_expires_soon` decides from it whether every request in
+    the transport refreshes first. A None here does not fail loudly -- it falls back to
+    a conservative window -- so a decoder that quietly stopped working would look like
+    a slightly chattier integration and nothing else.
+    """
+
+    def setUp(self) -> None:
+        self.module = _load(_OUR_TOKENS, "addhon_transport_tokens")
+        self.expiry = self.module.token_expiry
+
+    def test_reads_the_exp_claim_as_epoch_seconds(self) -> None:
+        self.assertEqual(1_800_000_000.0, self.expiry(_jwt({"exp": 1_800_000_000})))
+        self.assertIsInstance(self.expiry(_jwt({"exp": 1_800_000_000})), float)
+        # A fractional exp is legal (sec4.1.4 says NumericDate, not integer).
+        self.assertEqual(1.5, self.expiry(_jwt({"exp": 1.5})))
+
+    def test_padding_is_restored_for_every_payload_length(self) -> None:
+        # THE regression this file exists for. Base64URL strips `=` (RFC 7515 sec2), so
+        # the reader has to add it back; the bug only appears at payload lengths whose
+        # remainder mod 4 is not 0, so a single fixture proves nothing. Padding claims
+        # of growing length walks through all three remainders several times over.
+        for filler in range(24):
+            with self.subTest(filler=filler):
+                claims = {"exp": 1_800_000_000, "pad": "x" * filler}
+                self.assertEqual(1_800_000_000.0, self.expiry(_jwt(claims)))
+
+    def test_anything_that_is_not_a_readable_exp_is_none(self) -> None:
+        for junk, why in (
+            (_jwt({}), "no exp claim"),
+            (_jwt({"exp": "1800000000"}), "exp as text"),
+            (_jwt({"exp": None}), "exp null"),
+            (_jwt([1, 2, 3]), "payload is a JSON array, not an object"),
+            (_jwt("plain"), "payload is a JSON string"),
+            ("not-a-jwt", "no dot-separated sections"),
+            ("", "empty"),
+            ("aaa.!!!not-base64!!!.ccc", "payload is not base64"),
+            (f"aaa.{base64.urlsafe_b64encode(b'{not json').decode()}.ccc", "not JSON"),
+            (None, "not a string at all"),
+            (["a.b.c"], "a list"),
+        ):
+            with self.subTest(why=why):
+                self.assertIsNone(self.expiry(junk))
+
+    def test_a_boolean_exp_is_not_an_expiry(self) -> None:
+        # isinstance(True, int) is True, so without the explicit bool refusal an `exp`
+        # of `true` becomes 1.0 -- the epoch -- and the transport would treat the token
+        # as permanently stale and re-authenticate on every single request.
+        self.assertIsNone(self.expiry(_jwt({"exp": True})))
+        self.assertIsNone(self.expiry(_jwt({"exp": False})))
+
+
+class TokenPersonAccountIdTest(unittest.TestCase):
+    """`token_person_account_id` reads the account id OUR id_token claims.
+
+    Its one consumer compares it against the `sfPersonAccountId` the cloud stamps on
+    every appliance, so that a session which silently resolved to a different account
+    stops looking exactly like an account that owns nothing (ADDHON-210). The claim is
+    an identifier: it is compared in the transport and never emitted.
+    """
+
+    def setUp(self) -> None:
+        self.module = _load(_OUR_TOKENS, "addhon_transport_tokens")
+        self.claim = self.module.token_person_account_id
+
+    def test_reads_the_claim_from_the_live_shape(self) -> None:
+        # The claim set of a real id_token of this integration, as captured on
+        # 2026-08-24 (apk/analysis/addhon210-healthy-envelope-baseline.md). The nine
+        # neighbours are not decoration: the reader must find PersonAccountId among
+        # them, and among the top-level claims that also travel in the same payload.
+        token = _jwt({
+            "sub": "SYNTHETIC-SUB", "email": "user@example.com", "iss": "https://idp",
+            "exp": 1_800_000_000,
+            "custom_attributes": {
+                "Country": "IT", "EulaUpdateRequired": "false",
+                "ExternalSource": "hOn", "ExternalSubSource": "app",
+                "OemAppId": "haier", "PersonAccountId": "ACCOUNT-OURS",
+                "PersonContactId": "CONTACT-OURS", "PrivacyUpdated": "true",
+                "UserLanguage": "it",
+            },
+        })
+        self.assertEqual("ACCOUNT-OURS", self.claim(token))
+        # The two readers share a decoder and must not interfere: the same token still
+        # yields its expiry.
+        self.assertEqual(1_800_000_000.0, self.module.token_expiry(token))
+
+    def test_a_missing_or_unreadable_claim_is_none(self) -> None:
+        # None is a DIAGNOSIS, not a failure: "we hold no identity to compare with",
+        # which the census publishes as `no_claim` and which is a different finding
+        # from "the comparison ran and disagreed".
+        for junk, why in (
+            (_jwt({"custom_attributes": {}}), "no PersonAccountId"),
+            (_jwt({"custom_attributes": {"PersonAccountId": ""}}), "empty claim"),
+            (_jwt({"custom_attributes": {"PersonAccountId": 42}}), "claim is a number"),
+            (_jwt({"custom_attributes": {"PersonAccountId": None}}), "claim is null"),
+            (_jwt({"custom_attributes": "ACCOUNT-OURS"}), "attributes is a string"),
+            (_jwt({"custom_attributes": ["ACCOUNT-OURS"]}), "attributes is a list"),
+            (_jwt({"PersonAccountId": "ACCOUNT-OURS"}), "claim at the top level"),
+            (_jwt({}), "no attributes at all"),
+            ("not-a-jwt", "not a token"),
+            ("", "empty"),
+            (None, "not a string at all"),
+        ):
+            with self.subTest(why=why):
+                self.assertIsNone(self.claim(junk))
+
+    def test_the_claim_is_not_searched_for_anywhere_in_the_payload(self) -> None:
+        # A `flat = json.dumps(payload); "PersonAccountId" in flat` shortcut is the
+        # obvious cheap implementation (the investigation probe used one), and it would
+        # find the name inside an unrelated nested object -- reading someone else's id
+        # as ours and turning a mismatch into a match. Only the ONE documented location
+        # counts.
+        decoy = _jwt({
+            "custom_attributes": {"Country": "IT"},
+            "app_metadata": {"custom_attributes": {"PersonAccountId": "ACCOUNT-DECOY"}},
+        })
+        self.assertIsNone(self.claim(decoy))
+
+    def test_a_string_subclass_claim_is_refused(self) -> None:
+        # `json.loads` cannot produce one, but this value is about to be compared for
+        # equality against a string chosen by the cloud, and a subclass with a custom
+        # __eq__ equals whatever it likes. The guard is `type(v) is str`, so a future
+        # caller handing this a claims-shaped object cannot smuggle one through.
+        class Sneaky(str):
+            def __eq__(self, other):  # pragma: no cover - only if the guard fails
+                return True
+
+            def __hash__(self):
+                return hash(str(self))
+
+        # The guard lives in the READER, and `json.loads` will not hand it a subclass,
+        # so the decoder is stood in for over this one call. Standing in for the whole
+        # reader instead would test the double.
+        claims = {"custom_attributes": {"PersonAccountId": Sneaky("ACCOUNT-OURS")}}
+        original = self.module._jwt_claims
+        try:
+            self.module._jwt_claims = lambda _text: claims
+            self.assertIsNone(self.claim("irrelevant"))
+            # The premise: this object satisfies the isinstance check the guard
+            # deliberately does not use.
+            self.assertIsInstance(claims["custom_attributes"]["PersonAccountId"], str)
+        finally:
+            self.module._jwt_claims = original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An account that shows no appliances (`ADDHON-210`) is the hardest report this project
gets. The cloud answers `200`, the envelope is well formed, the list is empty, and every
field of the dump reads like a legitimately empty account. Five hypotheses collapsed into
one line, and the evidence that separates them lived behind a toggle nobody could set in
time.

This branch makes that report answer itself.

## What changed

**The service device answers account questions.** The per-account device ("addhOn
diagnostica") carries its own *Download diagnostics* button, and it could only ever
return `{"generated_at": ...}` — its identifier is never a key of `coordinator.data`, so
the lookup could only miss. It hits hardest in the install it matters most for: with zero
appliances that device is the only one that exists, so the only button reachable is the
one that could never answer. It is how the current field report arrived as a dated empty
object instead of the self-contained dump 5.17.0 shipped for exactly that case. The route
now delegates to the config-entry dump, on exact identifier equality.

**`last_fetch` gained four fields**, each separating a diagnosis the dump used to fold
together:

| field | domain | separates |
|---|---|---|
| `envelope_ok` | true / false / null | the top-level `success` |
| `module_ok` | true / false / null | `modules.applianceList.success` — a failed module from an empty account |
| `auth_keys` | bounded int / null | how many keys `authInfo` carries. `0` on a healthy session, so anything else is a signal |
| `account` | closed-domain token | our id_token's `PersonAccountId` against each appliance's `sfPersonAccountId` |

Six distinct dumps where there was one.

**The empty-list warning now carries the whole diagnosis, at `WARNING`.** The
appliance-list call happens *once*, during setup, so a reporter who enables debug
afterwards captures nothing — the poll that follows reads the cached list. We asked for
that capture roughly ten times and never got it, and the instruction was ours to get
wrong. `ADDHON-210` now prints the four census fields beside the key names, and `hOn raw
appliance response` moves from `DEBUG` to `WARNING`. A reporter who can copy one log line
hands over a finished answer without touching a switch.

**A hostile body can no longer abort the load.** `parse_appliance_list` promised "any
unexpected shape → `[]`" and the promise was false: `isinstance` accepts a dict subclass,
and a subclass may raise from `get`. The logging block was worse — it read `.keys()` on
the response while building the very message that exists to explain the failure.

## Why raising the log level is safe

Not by hope, by the branch it sits in. Both promoted lines print **only when the list came
back empty**: a working install never reaches that code, and an empty body is a small one.
Everything the summary prints is a closed-domain token or a bounded int produced by *our*
code (`probe_appliance_list`, `account_match`) — never a value chosen by the cloud — so the
line is leak-proof by the same construction the dump block relies on, and pasteable into a
public issue unedited. The raw response keeps its `redact_identity` pass.

## Evidence

The design is not deduced from the decompiled app alone. A live capture was taken on a
real account on 2026-08-24 (`apk/analysis/addhon210-healthy-envelope-baseline.md`,
gitignored) and it corrected two earlier readings: the module envelope has **four** keys,
not the two the decomp mock suggested, and the id_token carries `PrivacyUpdated` /
`EulaUpdateRequired` rather than the CIAM names the analysis had been searching for. The
reporter's envelope is identical to the healthy one at both levels his log records, which
is what pushed "the API changed" down to very low.

## Notes for review

- `mismatch` and `mixed` are **not faults on their own**: family sharing puts appliances a
  member does not own into that member's own list, so a group member reads `mismatch` on a
  healthy install. The verdict states an account *boundary*; only the reported symptom says
  whether crossing it is the bug. This was caught in adversarial review and the docstrings
  say so now.
- Drift guards pin the new closed domains against the code that produces them, in both
  directions, and were verified red under mutation in six directions.
- `tests/test_setup_budgets.py` is a real-time file that flakes intermittently in the full
  suite and passes in isolation. It is untouched here and pre-dates this branch.

Suite: **2403 passed**, 3 skipped, 7 xfailed, 856 subtests.

## Summary by Sourcery

Make empty appliance reports self-diagnosing by returning complete account diagnostics, capturing bounded response census data, and hardening parsing and logging against malformed or sensitive cloud responses.

New Features:
- Make the per-account diagnostics device return the complete config-entry diagnostics dump.
- Add appliance-fetch census fields for envelope status, module status, authentication-key count, and account ownership.
- Emit self-contained empty-appliance diagnostics and response structure at warning level.

Bug Fixes:
- Prevent malformed or hostile appliance-list responses from aborting setup.
- Prevent cloud-supplied identity values used as mapping keys from appearing in diagnostic logs.

Enhancements:
- Harden JWT claim handling and compare authenticated account ownership using closed-domain verdicts.
- Expand diagnostics validation and drift guards for the new census data.

Tests:
- Add shared appliance-list envelope fixtures and comprehensive tests for diagnostics routing, census fields, malformed responses, token claims, and log privacy.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes empty-appliance reports self-diagnosing while hardening the associated parsing and logging paths.
- Routes account-service-device diagnostic downloads to config-entry diagnostics.
- Adds bounded envelope, authentication, and account-boundary census fields.
- Replaces raw empty-list response logging with structure-only warnings and sanitized key names.
- Makes malformed appliance-list parsing and diagnostic logging failure-safe.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/transport/api.py | Adds bounded account and envelope diagnostics, sanitizes empty-list warnings, and contains failures from hostile diagnostic inputs. |
| custom_components/addhon/client/transport/parse.py | Makes appliance-list extraction failure-safe and adds closed-domain envelope census fields. |
| custom_components/addhon/debug_utils.py | Adds credential-key matching, sanitized key-name summaries, and structure-only rendering without copying response leaf values. |
| custom_components/addhon/diagnostics.py | Exposes the new bounded census and correctly delegates the account service device to config-entry diagnostics. |
| custom_components/addhon/client/transport/tokens.py | Reuses guarded JWT decoding to obtain the account claim without emitting the identifier. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cloud appliance-list response] --> B[Probe bounded census]
    A --> C[Parse appliance list defensively]
    B --> D[Store last_fetch diagnostics]
    C --> E{Appliances found?}
    E -- Yes --> F[Continue setup]
    E -- No --> G[Log sanitized keys and response shape]
    H[Account diagnostics device] --> I[Config-entry diagnostics]
    D --> I
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(logs): the summary key names get the..."](https://github.com/tis24dev/addhon/commit/565f4764eee9d3fa64adc8e55b1e1a37883f70c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56372283)</sub>

**Context used:**

- Knowledge Base — [Diagnostics and safe observability](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/diagnostics-and-safe-observability.md)
- Knowledge Base — [API transport and protocol handling](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/api-transport-and-protocols.md)

<!-- /greptile_comment -->