### PR TITLE
Release v5.21.1

### DIFF
--- a/custom_components/addhon/__init__.py
+++ b/custom_components/addhon/__init__.py
@@ -508,18 +508,20 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
       where none of those can be built, so the id must also be one this session
       really superseded (`_superseded_ref_program_ids`). Scoped to the select
       domain for the same reason the panel light is: nothing else may match.
-    - The My Zone mode SENSOR (unique_id '<id>_my_zone_mode'), shipped in 5.20.0 and
-      replaced in #93 by a writable select of the same name. Conditional too, and on
-      a NARROWER predicate than the select above: the sensor steps aside only where
-      the drawer select is really built, so a fridge with the mode switches and no
-      drawer programs keeps its sensor. Scoped to the sensor domain, since the select
-      that replaces it carries the same unique_id suffix.
     - Everything that belonged to a per-zone CLONE of an induction hob
       ('<base>_z<N>_<key>'), which the session no longer creates. Double-anchored:
       the id must have the clone shape AND its base must be a hob in the current
       snapshot, so a genuinely zoned appliance of another type keeps its entities.
 
     Without this cleanup there would be orphan 'unavailable' entities with the '?' badge.
+
+    Deliberately NOT a rule here: the My Zone mode SENSOR ('<id>_my_zone_mode'). 5.21.0
+    removed it wherever the writable select could be built; it is now created there and
+    merely disabled at first registration (`sensor.async_setup_entry`), like the fridge
+    flag readings the mode switches duplicate. Removal was the wrong answer because the
+    reading is not a strict duplicate: it reports the panel-set drawer modes -- chiller,
+    cool drink, cheese -- that no drawer PROGRAM pins, and for which the select, which
+    may only report its own options, has to answer unknown (#93).
     """
     from homeassistant.helpers import entity_registry as er
 
@@ -538,7 +540,6 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
     }
     hob_ids = _hob_ids(coord_data)
     superseded_refs = _superseded_ref_program_ids(coord_data)
-    superseded_my_zones = _superseded_my_zone_ids(coord_data)
 
     registry = er.async_get(hass)
     checked = 0
@@ -578,18 +579,6 @@ def _remove_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
             removed_ref_programs += 1
             _LOGGER.info(
                 "Removed the fridge program select replaced by the per-mode controls: "
-                "id=%s",
-                redact_id(reg_entry.unique_id),
-            )
-        elif (
-            domain == "sensor"
-            and unique_id.endswith("_my_zone_mode")
-            and unique_id.removesuffix("_my_zone_mode") in superseded_my_zones
-        ):
-            registry.async_remove(reg_entry.entity_id)
-            removed += 1
-            _LOGGER.info(
-                "Removed the My Zone mode sensor replaced by the writable select: "
                 "id=%s",
                 redact_id(reg_entry.unique_id),
             )
@@ -643,39 +632,6 @@ def _raise_ref_program_repair(hass: HomeAssistant, entry: ConfigEntry) -> None:
         )
     except Exception:  # noqa: BLE001 - a notice must never cost a setup
         _LOGGER.debug("Setup debug: could not raise the ref_program repair", exc_info=True)
-
-
-def _superseded_my_zone_ids(coord_data) -> set[str]:
-    """Appliance ids whose My Zone mode SENSOR was replaced by the writable select (#93).
-
-    A sibling of `_superseded_ref_program_ids`, and deliberately NOT the same predicate.
-    `has_replacement_controls` is true as soon as the flag switches can be built, but the
-    read-only sensor steps aside only where the DRAWER select really appears -- so a
-    fridge with the four switches and no drawer programs keeps its sensor, and reusing
-    the broader predicate here would delete a live entity on the next start.
-
-    The condition is `my_zone_codes`, which is exactly what `sensor.async_setup_entry`
-    consults to skip creating it. One question, answered once, for the same reason the
-    program select's gate was folded into that function.
-    """
-    from .ref_programs import my_zone_codes
-
-    superseded: set[str] = set()
-    for appliance_id, device in (coord_data or {}).items():
-        if not isinstance(device, dict):
-            continue
-        if device.get("type") not in (APPLIANCE_REF, APPLIANCE_FR, APPLIANCE_FRE):
-            continue
-        try:
-            if my_zone_codes(device.get("appliance")):
-                superseded.add(appliance_id)
-        except Exception:  # noqa: BLE001 - a degraded schema must not cost a setup
-            _LOGGER.debug(
-                "Setup debug: My Zone supersession check failed for id=%s",
-                redact_id(appliance_id),
-                exc_info=True,
-            )
-    return superseded
 
 
 def _superseded_ref_program_ids(coord_data) -> set[str]:

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.21.0"
+  "version": "5.21.1"
 }

--- a/custom_components/addhon/sensor.py
+++ b/custom_components/addhon/sensor.py
@@ -1351,6 +1351,10 @@ async def async_setup_entry(
         # Resolved once per appliance, and only when a description actually asks for it:
         # every type but the fridge has no `requires_zone` row at all.
         zones: frozenset[str] | None = None
+        # Per APPLIANCE, never per description row: the same reading is a duplicate on a
+        # fridge whose catalogue carries drawer programs and the only thing to watch on
+        # one whose does not. Answered where the row is gated, used where it is built.
+        my_zone_hidden = False
         for description in descriptions:
             # Inferred from incomplete evidence: absent unless explicitly enabled.
             if description.experimental and not experimental:
@@ -1362,16 +1366,17 @@ async def async_setup_entry(
                     zones = _model_zones(data.get("appliance"))
                 if description.requires_zone not in zones:
                     continue
-                # The drawer's mode became WRITABLE where its programs exist (#93), and
-                # `select.my_zone_mode` reports the same value under the same label. Two
-                # identically-named entities on one device is the noise this release set
-                # out to remove, so the read-only half steps aside exactly where the
-                # writable one appears -- and stays everywhere it does not, which is
-                # every fridge whose catalogue carries no drawer program.
-                if description.key == MY_ZONE_MODE_KEY and my_zone_codes(
-                    data.get("appliance")
-                ):
-                    continue
+                # The drawer's mode became WRITABLE where its programs exist (#93), so
+                # on those fridges `select.my_zone_mode` reports the same register. The
+                # reading is still BUILT there -- it is hidden, exactly like the four
+                # flag readings the mode switches duplicate (`binary_sensor`, same
+                # issue). 5.21.0 suppressed and then purged it instead, which was the
+                # one place this repo answered the question with a deletion, and it
+                # costs the two things this class can say and a select cannot: the
+                # static table's `chiller` / `cool_drink` / `cheese`, i.e. the modes set
+                # from the fridge's own panel, for which the select must report unknown.
+                if description.key == MY_ZONE_MODE_KEY:
+                    my_zone_hidden = bool(my_zone_codes(data.get("appliance")))
             # Capability-gating (Tier 2 only): skip the sensors whose attribute
             # is not exposed by the device. The historic types (gated=False) stay
             # always created, as before.
@@ -1399,7 +1404,14 @@ async def async_setup_entry(
                 entity_class = HonAirPurifierSensor
             else:
                 entity_class = HonSensor
-            entities.append(entity_class(coordinator, appliance_id, description))
+            if entity_class is HonMyZoneModeSensor:
+                entities.append(
+                    entity_class(
+                        coordinator, appliance_id, description, hidden=my_zone_hidden
+                    )
+                )
+            else:
+                entities.append(entity_class(coordinator, appliance_id, description))
             created.append(description.key)
         # Derived sensors combine MULTIPLE attributes, so they cannot be a
         # description-table row (those read a single attr_key). Mean water per
@@ -1633,8 +1645,17 @@ class HonMyZoneModeSensor(HonSensor):
     state outside its options.
     """
 
-    def __init__(self, coordinator, appliance_id, description) -> None:
+    def __init__(
+        self, coordinator, appliance_id, description, hidden: bool = False
+    ) -> None:
         super().__init__(coordinator, appliance_id, description)
+        # Set only when this DEVICE also got the writable select for the same register
+        # (#93), the same way the four fridge flag readings step behind their switches.
+        # On the instance and not on the shared description row, because the answer is
+        # per appliance; Home Assistant reads the flag at FIRST registration only, so
+        # nobody who already has the entity loses it.
+        if hidden:
+            self._attr_entity_registry_enabled_default = False
         # Always assigned, even when the appliance declares no pinning program: the
         # widening is the only writer, and `native_value` reads the list on every
         # refresh to keep itself inside its own options. Leaving it to the platform

--- a/custom_components/addhon/strings.json
+++ b/custom_components/addhon/strings.json
@@ -584,7 +584,7 @@
         "name": "Timer minutes"
       },
       "my_zone_mode": {
-        "name": "My Zone mode",
+        "name": "My Zone mode (reading)",
         "state": {
           "zero_fresh": "0 °C fresh",
           "quick_cool": "Quick cool",

--- a/custom_components/addhon/translations/en.json
+++ b/custom_components/addhon/translations/en.json
@@ -584,7 +584,7 @@
         "name": "Timer minutes"
       },
       "my_zone_mode": {
-        "name": "My Zone mode",
+        "name": "My Zone mode (reading)",
         "state": {
           "zero_fresh": "0 °C fresh",
           "quick_cool": "Quick cool",

--- a/custom_components/addhon/translations/it.json
+++ b/custom_components/addhon/translations/it.json
@@ -584,7 +584,7 @@
         "name": "Timer minuti"
       },
       "my_zone_mode": {
-        "name": "Modalità My Zone",
+        "name": "Modalità My Zone (lettura)",
         "state": {
           "zero_fresh": "Fresco 0 °C",
           "quick_cool": "Raffreddamento rapido",

--- a/tests/test_legacy_cleanup.py
+++ b/tests/test_legacy_cleanup.py
@@ -431,51 +431,44 @@ class LegacyCleanupTest(unittest.TestCase):
         self.assertEqual(1, len(calls))
         self.assertEqual(removed, ["select.fridge_ref_program"])
 
-    # --- #93: the My Zone mode sensor, replaced by the writable select.
+    # --- #93: the My Zone mode sensor is HIDDEN where the select appears, never removed.
 
-    def test_the_superseded_my_zone_sensor_is_removed(self) -> None:
-        # Shipped in 5.20.0 and suppressed here wherever the writable select is built,
-        # so on those fridges it would otherwise sit unavailable under the same name as
-        # the control that replaced it.
-        removed, _detached = _run(
-            [FakeRegEntry("sensor.fridge_my_zone_mode", "refid_my_zone_mode")],
-            coord_data={
-                "refid": {
-                    "type": "REF",
-                    "appliance": self._fridge_appliance(flags=False, drawer=True),
-                }
-            },
-        )
-        self.assertEqual(removed, ["sensor.fridge_my_zone_mode"])
+    def test_no_my_zone_entity_is_ever_removed(self) -> None:
+        """5.21.0 purged `sensor.<id>_my_zone_mode` wherever the drawer select could be
+        built. It is not purged any more, and the reversal is the point: the reading is
+        still created there, merely disabled at first registration
+        (`sensor.async_setup_entry`), exactly like the four flag readings behind their
+        mode switches. It has to survive because it answers where the select cannot --
+        `chiller`, `cool_drink`, `cheese` are register values no drawer PROGRAM pins, so
+        a mode set from the fridge's own panel leaves the select on unknown (#93,
+        reported by rmxs).
 
-    def test_the_my_zone_sensor_survives_without_drawer_programs(self) -> None:
-        # A NARROWER predicate than the select's, and this is the case that proves it:
-        # the four mode switches supersede `select.ref_program`, but nothing replaces
-        # the sensor unless the DRAWER select is really built.
-        removed, _detached = _run(
-            [FakeRegEntry("sensor.fridge_my_zone_mode", "refid_my_zone_mode")],
-            coord_data={"refid": {"type": "REF", "appliance": self._fridge_appliance()}},
-        )
-        self.assertEqual(removed, [])
+        Both domains, both catalogue shapes: the select carries the SAME unique_id
+        suffix as the sensor, so a rule reintroduced without a domain scope would take
+        the control with the reading.
+        """
+        for drawer in (True, False):
+            for entity_id in (
+                "sensor.fridge_my_zone_mode",
+                "select.fridge_my_zone_mode",
+            ):
+                removed, _detached = _run(
+                    [FakeRegEntry(entity_id, "refid_my_zone_mode")],
+                    coord_data={
+                        "refid": {
+                            "type": "REF",
+                            "appliance": self._fridge_appliance(
+                                flags=False, drawer=drawer
+                            ),
+                        }
+                    },
+                )
+                self.assertEqual(removed, [], f"{entity_id}, drawer={drawer}")
 
-    def test_the_my_zone_select_that_replaces_it_is_never_removed(self) -> None:
-        # The select carries the SAME unique_id suffix in another domain, which is why
-        # the rule is scoped -- removing by suffix alone would delete the replacement.
-        removed, _detached = _run(
-            [FakeRegEntry("select.fridge_my_zone_mode", "refid_my_zone_mode")],
-            coord_data={
-                "refid": {
-                    "type": "REF",
-                    "appliance": self._fridge_appliance(flags=False, drawer=True),
-                }
-            },
-        )
-        self.assertEqual(removed, [])
-
-    def test_the_my_zone_removal_raises_no_repair(self) -> None:
-        # The sensor was read-only: nothing could have called a service on it, so there
-        # is nothing to warn about. The notice is reserved for the control whose loss
-        # breaks automations silently.
+    def test_the_my_zone_sensor_raises_no_repair(self) -> None:
+        # The notice belongs to `select.ref_program` alone, whose loss makes
+        # `select.select_option` succeed while doing nothing. A registry holding only
+        # the drawer reading loses nothing and must stay silent.
         issues: list = []
         _run(
             [FakeRegEntry("sensor.fridge_my_zone_mode", "refid_my_zone_mode")],

--- a/tests/test_tier2_sensors.py
+++ b/tests/test_tier2_sensors.py
@@ -959,28 +959,50 @@ class Tier2GatingTest(unittest.IsolatedAsyncioTestCase):
             )
             self.assertIs(expected, entity.is_on, repr(raw))
 
-    async def test_the_sensor_steps_aside_where_the_select_is_built(self) -> None:
-        """One drawer, one entity with that name (#93).
+    async def test_the_sensor_is_built_but_hidden_where_the_select_is(self) -> None:
+        """One drawer, one VISIBLE entity with that name -- and still two entities (#93).
 
         `select.my_zone_mode` reports the same register under the same label, so on an
-        appliance whose catalogue lets the writable control be built the read-only half
-        must not also appear -- two identically-named entities on one device is the noise
-        this release set out to remove. Untested until now: every other fixture in this
-        class declares no `zone` ancillary, so `my_zone_codes` is empty there and the
-        suppression branch is never reached.
+        appliance whose catalogue lets the writable control be built the reading steps
+        behind it: created, and disabled at first registration, exactly like the four
+        flag readings the mode switches duplicate. 5.21.0 skipped creating it and purged
+        it from the registry instead; that cost the states only this class can report --
+        the static table's `chiller` / `cool_drink` / `cheese`, i.e. the modes set from
+        the fridge's own panel, for which the select must answer unknown.
+
+        Home Assistant reads the flag at FIRST registration only, so hiding takes
+        nothing away from a user who already has the entity enabled.
         """
         added = await _build_sensors(
             "REF", {"tempSelZ3": "0"}, appliance=_drawer_capable_fridge()
         )
-        self.assertNotIn("x-1_my_zone_mode", {e._attr_unique_id for e in added})
-        # ...and only that one: the suppression is keyed on the description, so a
-        # careless gate would take the whole `requires_zone` branch with it.
+        by_id = {e._attr_unique_id: e for e in added}
+        self.assertIn("x-1_my_zone_mode", by_id)
+        self.assertFalse(
+            by_id["x-1_my_zone_mode"]._attr_entity_registry_enabled_default
+        )
+        # ...and only that one: the decision is keyed on the description, so a careless
+        # gate would take the whole `requires_zone` branch with it.
         added_all = await _build_sensors(
             "REF",
             {"tempSelZ3": "0", "tempZ1": "5"},
             appliance=_drawer_capable_fridge(),
         )
         self.assertIn("x-1_temp_zone1", {e._attr_unique_id for e in added_all})
+
+    async def test_the_sensor_stays_visible_where_no_select_can_be_built(self) -> None:
+        """The other side of the same gate, and the reason it is answered per DEVICE and
+        not on the shared description row: a fridge whose catalogue carries no drawer
+        PROGRAM gets no select, so its reading is the only thing to watch and must be
+        enabled. A static flag on the row would have hidden it there too, permanently.
+        """
+        entity = await self._my_zone_state("0")
+        self.assertTrue(
+            getattr(entity, "_attr_entity_registry_enabled_default", True)
+        )
+        self.assertTrue(
+            getattr(entity.entity_description, "entity_registry_enabled_default", True)
+        )
 
     async def test_the_sensor_stays_where_no_select_can_be_built(self) -> None:
         """The other side of the same gate: a fridge whose catalogue carries no drawer


### PR DESCRIPTION
Automated release PR for `v5.21.1`.

<!-- release-tag: v5.21.1 -->

## Summary by Sourcery

Preserve the My Zone mode sensor while preventing duplicate default-visible entities when the writable select is available.

Bug Fixes:
- Preserve the My Zone mode sensor so it continues reporting panel-selected modes that the writable select cannot represent.

Enhancements:
- Hide the My Zone mode sensor by default when the corresponding writable select is available, while keeping it created and available for users who already enabled it.
- Remove obsolete registry cleanup logic that deleted My Zone mode sensors during startup.

Build:
- Update the integration version to 5.21.1.

Tests:
- Update legacy cleanup and sensor setup tests to verify the sensor is never removed, is hidden only when the select exists, and remains enabled when no select can be built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * My Zone mode readings are now retained for appliances with a writable My Zone control, but disabled by default to avoid duplicate active controls.
  * Read-only My Zone sensors are clearly labeled as “reading.”
  * Existing My Zone sensors are preserved during cleanup.

* **Bug Fixes**
  * Prevented valid My Zone mode entities from being removed.

* **Chores**
  * Updated the integration to version 5.21.1.
  * Improved English and Italian labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release restores the read-only My Zone sensor instead of deleting it, while disabling it by default when the writable My Zone select is available.
- Removes the legacy cleanup rule that purged the My Zone sensor.
- Applies per-appliance default visibility using the same capability predicate that creates the writable select.
- Distinguishes the sensor with a “My Zone mode (reading)” translation while retaining the select’s control-oriented label.
- Adds migration and entity-gating coverage and bumps the integration version to 5.21.1.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security failures identified.

The restored sensor preserves its stable identity, uses the same capability predicate as select creation for default visibility, and retains distinct platform-specific translations.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/__init__.py | Stops deleting the My Zone sensor during legacy cleanup so the restored reading can retain its registry identity. |
| custom_components/addhon/sensor.py | Restores the My Zone sensor and disables it by default per appliance when the matching writable select exists. |
| custom_components/addhon/manifest.json | Bumps the integration release version from 5.21.0 to 5.21.1. |
| custom_components/addhon/strings.json | Renames only the sensor translation to distinguish the reading from the separately translated writable select. |
| tests/test_legacy_cleanup.py | Verifies that neither the sensor nor select is removed across supported catalogue shapes. |
| tests/test_tier2_sensors.py | Covers hidden-by-default behavior when the select exists and visible behavior when it does not. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Cooling appliance snapshot] --> B{Drawer zone exposed?}
  B -->|No| C[Do not create My Zone sensor]
  B -->|Yes| D[Create My Zone sensor]
  D --> E{Writable drawer programs available?}
  E -->|No| F[Sensor enabled by default]
  E -->|Yes| G[Create writable My Zone select]
  G --> H[Sensor disabled by default]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.21.1"](https://github.com/tis24dev/addhon/commit/3b3c423e0b84b4fe508e3af1379ef2c3852656c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58066526)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Home Assistant integration lifecycle](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/integration-lifecycle.md)
- Knowledge Base — [Entity platforms and availability](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/entity-platform-lifecycle.md)
- Knowledge Base — [Quality and release controls](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/quality-and-release-controls.md)
</details>


<!-- /greptile_comment -->