### PR TITLE
Release v5.22.1

### DIFF
--- a/custom_components/addhon/CHANGELOG.md
+++ b/custom_components/addhon/CHANGELOG.md
@@ -112,6 +112,16 @@ the notes were generated automatically carry a link to their diff instead of a s
 
 **Fixes**
 
+- **A washer-dryer's wash-and-dry programmes no longer start as wash-only** (#99). The
+  drying level was being forced to zero, and locked there, before you ever saw the
+  control: every wash-and-dry programme carries a rule that reads "with the dry option
+  off, the dry level is zero", and addhOn was applying it while it built the command
+  rather than when something actually switched the dry option. The official app never
+  applies that rule -- it ships on the programmes that CAN dry, and it describes where
+  the dry switch starts, not what the programme is allowed to do. Rules now apply when a
+  value changes, which is what they are for. Setting a dry level that the appliance
+  accepts no longer fails with "Allowed values: ['0']", and a wash-and-dry cycle runs the
+  drying it was asked for.
 - **The My Zone mode sensor is removed from the registry** where the writable select
   replaced it, instead of being left behind unavailable under the same name as its
   replacement. Only there: a fridge that gets the mode switches but has no drawer

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -98,12 +98,33 @@ class HonParameter:
         return self._group
 
     def add_trigger(self, value: str, func: Callable[[Any], None], data: Any) -> None:
-        # Normalize both sides like `check_trigger` does: `_value` may be numeric
-        # (range/int) while the trigger value is always a string, so a raw `==`
-        # would miss `1 == "1"` and skip the immediate-fire for a param whose
-        # default already equals the trigger value.
-        if str(self._value).lower() == str(value).lower():
-            func(data)
+        """Register `func` to run when this parameter is SET to `value`. Never fires here.
+
+        pyhOn also fired the rule on registration whenever the parameter's default
+        already equalled the trigger value, so a rule could apply at COMMAND-BUILD time,
+        before anything had changed. The app has no such step: its only generic
+        `programRules` pass is `updateProgramRulesParameters` (decomp.txt:1028648), it
+        runs while building the program list, it reads the trigger value off the
+        APPLIANCE RECORD (`activeAppliance[getMappedParamName(trigger)]`,
+        decomp.txt:1028738-1028740), and it only assigns a value -- it never narrows a
+        parameter's value set.
+
+        That build-time fire broke every wash-and-dry program of every washer-dryer
+        (issue #99). `dryOption` is an ancillary descriptor that defaults to "0" and
+        carries the rule `dryLevel <- dryOption==0 -> "0"`; the app never reads it (it is
+        not a field of the appliance record), while we flatten ancillaryParameters into
+        the same `parameters` dict, so the rule fired on construction and collapsed
+        `dryLevel` from its real enum to ["0"] before the user ever saw an entity -- the
+        cycle then started as wash-only. In the app's own bundled catalogue all 72
+        categories carrying that rule are W+D or W+D+S, i.e. exactly the programs that
+        CAN dry: it is the starting position of the dry switch, not a ban.
+
+        Rules that depend on the device's current state still apply: the shadow sync and
+        every entity write go through the value setters, and `check_trigger` runs on each
+        accepted write. Static device config keeps its own build-time pass in
+        `HonRuleSet._apply_config_rules` ($installationType), which is the record-keyed
+        mechanism the app actually has.
+        """
         self._triggers.setdefault(value, []).append((func, data))
 
     def check_trigger(self, value: str | float) -> None:

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -227,13 +227,13 @@ class HonRuleSet:
                     self._apply_enum(param, rule)
             except (ValueError, TypeError) as err:
                 # A malformed rule (non-numeric or off-grid `fixedValue`, bad enum
-                # value) must NOT abort the whole appliance's command-load. The
-                # immediate-fire in `HonParameter.add_trigger` runs at construction
-                # time, so an escaping ValueError from `_apply_fixed` (e.g. float("x")
-                # or an off-step value rejected by the range setter) would fail setup
-                # for every entity of the device. Roll the param back (a partial
-                # mutation is worse than an untouched one) then log and skip the bad
-                # rule; the runtime path already tolerates this via the entity write-path.
+                # value) must NOT take down the write that triggered it. This callback
+                # runs from `HonParameter.check_trigger`, i.e. inside a value setter on
+                # the entity write-path, so an escaping ValueError from `_apply_fixed`
+                # (e.g. float("x") or an off-step value rejected by the range setter)
+                # would surface as a failed user action against a parameter that is
+                # perfectly valid. Roll the param back (a partial mutation is worse than
+                # an untouched one) then log and skip the bad rule.
                 self._rollback(param, snapshot)
                 _LOGGER.debug(
                     "addhOn: skipping unapplicable rule for '%s' (trigger %s=%s): %s",

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.22.0"
+  "version": "5.22.1"
 }

--- a/tests/golden/engine_cluster.json
+++ b/tests/golden/engine_cluster.json
@@ -5593,7 +5593,7 @@
         "temp": {
           "category": "command",
           "group": "parameters",
-          "intern_value": "30",
+          "intern_value": "20",
           "key": "temp",
           "mandatory": 0,
           "max": 40,
@@ -5601,7 +5601,7 @@
           "step": 1,
           "triggers": {},
           "typology": "range",
-          "value": 30,
+          "value": 20,
           "values": [
             "10",
             "11",

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -286,6 +286,36 @@ _AC_IOT_COOL = {
 }
 
 
+# REAL washer-dryer category (apk/decomp.txt:3496065-3496305,
+# `PROGRAMS.WM_WD.IOT_WASH_RESISTANT_COLORED`, trimmed to the keys under test).
+# `programType` is W+D+S -- a WASH AND DRY program -- and it still ships the
+# `dryLevel <- dryOption==0 -> '0'` rule. In the app bundle ALL 72 categories carrying
+# that rule are W+D or W+D+S; not one plain-W program has it. So the rule is the
+# starting position of the dry switch, NOT a ban on drying: the app decides the
+# zeroing from `programType` (`mapCommandParameters` @decomp.txt:1009466-1009483,
+# W / W+S only) and leaves dryLevel at its defaultValue for everything else. Issue #99.
+_WD_WASH_DRY_REAL = {
+    "parameters": {
+        "dryLevel": {"typology": "enum", "category": "command", "mandatory": 0,
+                     "defaultValue": "1", "enumValues": [0, 1, 3, 4]},
+        "dryTime": {"typology": "range", "category": "command", "mandatory": 0,
+                    "minimumValue": "1", "maximumValue": "4", "incrementValue": "1"},
+        "temp": {"typology": "enum", "category": "command", "mandatory": 1,
+                 "defaultValue": "60", "enumValues": [0, 20, 30, 40, 60, 90]},
+    },
+    "ancillaryParameters": {
+        "dryOption": {"typology": "range", "category": "general", "mandatory": 1,
+                      "defaultValue": "0", "minimumValue": "0", "maximumValue": "1",
+                      "incrementValue": "1"},
+        "dryType": {"typology": "fixed", "category": "general", "mandatory": 1, "fixedValue": "C"},
+        "programType": {"typology": "fixed", "category": "general", "mandatory": 1,
+                        "fixedValue": "W+D+S"},
+        "programRules": {"category": "rule", "mandatory": 0, "typology": "fixed", "fixedValue": {
+            "dryLevel": {"dryOption": {"0": {"typology": "fixed", "fixedValue": "0"}}},
+        }},
+    },
+}
+
 _RULES = {
     # real AC: ecoMode=1 (with machMode fixed at 1) MUST constrain tempSel/windDir/windSpeed
     "ac_eco_nested": (_AC_IOT_COOL, [("ecoMode", "1")]),
@@ -304,6 +334,9 @@ _RULES = {
     "fixed_on_enum": ({"parameters": {"mode": _enum("cold", ["cold", "hot"]), "fan": _enum("low", ["low", "mid", "high"])},
                        "rules": {"r": _rule({"fan": {"mode": {"hot": {"typology": "fixed", "fixedValue": "high"}}}})}},
                       [("mode", "hot")]),
+    # `mode` DEFAULTS to "cold", one of the two trigger values. Step 0 (construction)
+    # therefore leaves temp at 20: rules apply when a value is SET, never on registration
+    # (`HonParameter.add_trigger`; issue #99). Step 1 sets mode and pins temp to 30.
     "pipe_split": ({"parameters": {"mode": _enum("cold", ["cold", "hot"]), "temp": _range()},
                     "rules": {"r": _rule({"temp": {"mode": {"cold|hot": {"typology": "fixed", "fixedValue": "30"}}}})}},
                    [("mode", "hot")]),
@@ -779,19 +812,23 @@ class ClusterBehaviorTest(unittest.TestCase):
         cmd.parameters["mode"].value = "hot"  # fires the bad rule -> must be swallowed
         self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
 
-    def test_malformed_fixed_value_rule_skipped_at_construction(self) -> None:
-        # Same malformed rule, but the trigger value equals the param DEFAULT, so the
-        # immediate-fire runs during construction (patch()). Building the command must
-        # not raise -- the ValueError from _apply_fixed used to abort the whole load.
+    def test_a_trigger_value_equal_to_the_default_is_not_applied_at_construction(self) -> None:
+        # The trigger value equals the parameter's DEFAULT. pyhOn applied the rule right
+        # there, while building the command; the app has no build-time programRules pass
+        # at all (its one generic pass reads the trigger off the appliance record,
+        # `updateProgramRulesParameters` @decomp.txt:1028648). Constructing must leave
+        # the target alone -- and an explicit write must still pin it. Issue #99.
         attrs = {
             "parameters": {
                 "mode": _enum("hot", ["cold", "hot"]),  # default already == trigger
                 "temp": _range(default="20", lo="16", hi="30", inc="1"),
             },
-            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "not-a-number"}}}})},
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "26"}}}})},
         }
-        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())  # must not raise
-        self.assertEqual(cmd.parameters["temp"].value, 20)  # unchanged
+        cmd = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        self.assertEqual(cmd.parameters["temp"].value, 20)  # untouched at build
+        cmd.parameters["mode"].value = "hot"
+        self.assertEqual(cmd.parameters["temp"].value, 26)  # still pinned on a real write
 
     def test_copy_rebinds_program_param_backrefs(self) -> None:
         # A HonParameterProgram carries `_command` (the base command); its value-setter
@@ -948,6 +985,22 @@ class ClusterBehaviorTest(unittest.TestCase):
         self.assertEqual(c.parameters["tempSel"].value, 26)
         self.assertEqual(c.parameters["windDirectionHorizontal"].value, "4")
         self.assertEqual(c.parameters["windDirectionVertical"].value, "3")
+
+    def test_a_wash_and_dry_program_keeps_its_dry_levels(self) -> None:
+        # REAL washer-dryer W+D+S category (apk/decomp.txt:3496065-3496305). The app
+        # keeps dryLevel at its defaultValue here: it zeroes the dry parameters from
+        # `programType` (W / W+S only) and never runs the `dryOption` rule on its send
+        # path. We flatten ancillaryParameters into the one `parameters` dict, so
+        # `dryOption` becomes a trigger-carrying parameter and the rule fires at
+        # CONSTRUCTION (`add_trigger` fires immediately when the current value already
+        # equals the trigger value, and dryOption defaults to "0"). The enum collapses
+        # to ['0'] and a wash-and-dry program starts as wash-only. Issue #99.
+        c = NaCommand("startProgram", json.loads(json.dumps(_WD_WASH_DRY_REAL)),
+                      FakeAppliance(),
+                      category_name="PROGRAMS.WM_WD.IOT_WASH_RESISTANT_COLORED")
+        self.assertEqual(c.parameters["dryLevel"].values, ["0", "1", "3", "4"])
+        self.assertEqual(c.parameters["dryLevel"].value, "1")
+
 
 
 # REAL AC IOT_COOL ancillary block (apk/dump/ac_live), minus programRules which has its


### PR DESCRIPTION
Automated release PR for `v5.22.1`.

<!-- release-tag: v5.22.1 -->

## Summary by Sourcery

Release v5.22.1 with fixes for washer-dryer drying controls, stale entity registration, and runtime rule handling.

Bug Fixes:
- Prevent washer-dryer wash-and-dry programs from being reduced to wash-only by applying parameter rules only when values are explicitly changed.
- Remove the obsolete My Zone mode sensor from the registry when replaced by the writable select.

Enhancements:
- Preserve valid parameter ranges and values during command construction while continuing to apply rules on runtime writes.
- Safely roll back and skip malformed rules without failing user-initiated parameter updates.

Build:
- Bump the integration version to 5.22.1.

Tests:
- Add coverage for washer-dryer drying parameters and deferred rule application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Washer-dryer programmes now correctly honor requested drying levels instead of forcing them to zero or rejecting them.
  * Drying rules apply when settings are changed, preventing valid user actions from being blocked by malformed rules.
  * Rules no longer trigger unexpectedly while commands are being prepared.

* **Documentation**
  * Added changelog details covering washer-dryer programme fixes.

* **Chores**
  * Updated the integration version to 5.22.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release changes parameter-rule evaluation so ordinary rules are registered during command construction and applied only when their trigger parameter is subsequently assigned; static appliance-configuration rules retain their dedicated build-time evaluation. This prevents a washer-dryer’s default `dryOption=0` descriptor from collapsing valid drying levels before controls are created.

- Advances the integration version from `5.22.0` to `5.22.1`.
- Adds a real-schema regression fixture for wash-and-dry programs.
- Updates the engine golden snapshot to reflect deferred rule execution.
- Keeps runtime setter-triggered rules and static configuration rules intact.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the targeted washer-dryer fix is explicitly tested and no concrete regression was identified in other rule paths.

Runtime assignments still activate matching rules, static appliance configuration retains its build-time evaluation, and repository evidence did not reveal another real schema that depends on registration-time firing for a required initial constraint.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/parameter/base.py | Removes registration-time callback execution so ordinary dependent rules run only through parameter assignments. |
| custom_components/addhon/client/engine/rules.py | Updates documentation around malformed runtime rules while preserving the separate build-time static configuration path. |
| tests/test_engine_cluster.py | Adds explicit regression coverage for deferred default-trigger evaluation and preservation of washer-dryer drying choices. |
| tests/golden/engine_cluster.json | Records the intended unchanged target default before a trigger parameter is explicitly assigned. |
| custom_components/addhon/manifest.json | Advances release metadata to version 5.22.1. |
| custom_components/addhon/CHANGELOG.md | Documents the washer-dryer rule-evaluation fix and its user-visible effect. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Build command parameters] --> B[Register program-rule callbacks]
    B --> C[Expose original schema defaults and options]
    D[Shadow sync or user assignment] --> E[Parameter setter]
    E --> F[Evaluate matching runtime rules]
    G[Static appliance configuration] --> H[Dedicated build-time config-rule pass]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: set manifest version 5.22.1"](https://github.com/tis24dev/addhon/commit/d413f5d3488fa7e3daa532f942faa9fc879efe2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60833292)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Command and parameter engine](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/command-and-parameter-engine.md)
- Knowledge Base — [Client runtime and cloud sessions](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/client-runtime.md)
- Knowledge Base — [Quality and release controls](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/quality-and-release-controls.md)
- Knowledge Base — [Home Assistant integration lifecycle](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/integration-lifecycle.md)
</details>


<!-- /greptile_comment -->