### PR TITLE
Release v5.23.0

### DIFF
--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -80,6 +80,7 @@ from .const import (
 )
 from .debug_utils import _MAC_RE, redact_id
 from .hon_commands import SETTINGS_COMMANDS, param_range, param_values
+from .ref_programs import program_categories
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -641,6 +642,118 @@ def _command_schema(appliance) -> dict:
         else:
             out[str(cmd_name)] = {}
     return out
+
+
+def _program_option_matrix(appliance) -> dict:
+    """Which options each PROGRAM of ``startProgram`` really supports (issue #98).
+
+    ``_command_schema`` above prints the ACTIVE category only -- ONE program out of the
+    ~90 a washer carries -- so no dump could answer "does the delicate cycle offer a
+    prewash", which is the whole question of #98. The per-program schema is already in
+    memory: ``HonCommand.categories`` holds one command object per program, each with its
+    own ``parameters``, and this is the only section that reads it. It is also what the
+    hOn app rebuilds its own option set from (``normalize`` @decomp.txt:1773682, see
+    apk/analysis/issue98-99-program-options-and-wd-dry.md).
+
+    Emitted as a DELTA against the union of parameter names rather than as ~90 full
+    parameter schemas. The actionable datum is presence and settability, and a full dump
+    of every category would add megabytes to a file a maintainer reads by eye:
+
+      ``absent``   -- in the union, not in THIS program: the option does not exist for it
+      ``fixed``    -- present but pinned (fixed, or a single reachable value): the program
+                      dictates it, and the map's value is what it dictates
+      ``settable`` -- present with >= 2 reachable values: a real choice for this program
+
+    Settability is decided by ``program_options.is_settable_option``, the SAME predicate
+    the entity gate uses, so a reader comparing this section against the entities cannot
+    be misled by two different definitions of "settable".
+
+    Favourites and the ``{"_": self}`` placeholder are dropped by
+    ``ref_programs.program_categories``: a favourite is keyed by text the USER typed, and
+    keeping that out of a file destined for a public issue tracker is that function's own
+    load-bearing rule. The consequence is stated in ``categories_total`` vs the length of
+    ``per_program``, so a reader can see that some categories were withheld rather than
+    guess the appliance has fewer programs than it does.
+
+    Empty ``{}`` for an appliance whose ``startProgram`` carries no categories (every
+    non-program type), which keeps the section absent instead of emitting a shape a
+    reader would try to interpret.
+    """
+    # Imported HERE, not at module scope: `program_options` pulls in `base_entity` and
+    # with it the whole Home Assistant entity stack, and a diagnostics dump has no reason
+    # to depend on it just to reuse one pure predicate. Same reason (and the same shape) as
+    # `ref_programs`' own function-local import of `program_code_for_fixed_value`.
+    #
+    # GUARDED for the reason `_mapped_sets` guards each of its seven: an unimportable
+    # platform module must cost its own section and never the dump. Degrading to silence
+    # rather than to a section built on a second, local definition of "settable" is the
+    # same trade this module makes elsewhere -- silence is unhelpful, a figure the reader
+    # cannot line up against the entity gate is wrong.
+    try:
+        from .program_options import STARTPROGRAM_COMMAND, is_settable_option
+    except Exception:  # pragma: no cover - defensive, mirrors _mapped_sets
+        _LOGGER.debug("Diagnostics: program_options unavailable, program_options section skipped")
+        return {}
+
+    commands = getattr(appliance, "commands", None)
+    command = commands.get(STARTPROGRAM_COMMAND) if isinstance(commands, Mapping) else None
+    if command is None:
+        return {}
+    categories = program_categories(appliance)
+    if not categories:
+        return {}
+    # The union of parameter NAMES over the CATALOGUE categories. Deliberately not
+    # `command.setting_keys`, which is the same union taken over ALL categories including
+    # the favourites: a favourite carries the engine's own `favourite` marker parameter,
+    # so its name would enter the union and then be reported as `absent` from every real
+    # program -- a row about our own bookkeeping, in a section about the appliance.
+    # `available_settings` is the wrong tool for a different reason: it measures each range
+    # by its `.values` (min..max enumeration) just to pick the richest variant, and only
+    # names are needed here.
+    # `program` is dropped: it is the SELECTOR (the categories are keyed by its very
+    # values), it is a parameter of every category, and it would report as settable in
+    # every single row -- noise in a section named for the options. The other member of
+    # `PROGRAM_PARAM_NAMES`, `prCode`, is deliberately KEPT: on a washer it is a per-program
+    # fixed identity, and it is the field a reader matches `programName` in a log against.
+    union = sorted(
+        {
+            str(name)
+            for category in categories.values()
+            for name in (getattr(category, "parameters", None) or {})
+            if str(name) != "program"
+        }
+    )
+    if not union:
+        return {}
+    per_program: dict[str, dict] = {}
+    for code, category in sorted(categories.items()):
+        params = getattr(category, "parameters", None)
+        params = params if isinstance(params, dict) else {}
+        absent: list[str] = []
+        fixed: dict[str, str] = {}
+        settable: list[str] = []
+        for name in union:
+            param = params.get(name)
+            if param is None:
+                absent.append(name)
+            elif is_settable_option(param):
+                settable.append(name)
+            else:
+                fixed[name] = str(getattr(param, "value", ""))
+        row: dict = {}
+        if settable:
+            row["settable"] = settable
+        if fixed:
+            row["fixed"] = fixed
+        if absent:
+            row["absent"] = absent
+        per_program[str(code)] = row
+    return {
+        "command": STARTPROGRAM_COMMAND,
+        "categories_total": len(getattr(command, "categories", {}) or {}),
+        "union_params": union,
+        "per_program": per_program,
+    }
 
 
 def _read_chain(key) -> list[str]:
@@ -2169,6 +2282,7 @@ def _appliance_block(
     now = _as_utc(now, True) or _utcnow()
 
     commands = _command_schema(appliance)
+    program_options_matrix = _program_option_matrix(appliance)
     model_attributes = _model_attributes(appliance)
     # ONE walk of the per-type tables, ONE lazy-import decision, shared by both
     # consumers -- which is what the `_mapped_sets` docstring claims and what
@@ -2246,6 +2360,12 @@ def _appliance_block(
         "attributes_last_update": stamps,
         **({"attributes_last_update_truncated": True} if stamps_truncated else {}),
         "commands": commands,
+        # Directly after `commands`, which prints the ACTIVE program only: this is
+        # the same schema read per PROGRAM, and reading the two together is what
+        # tells a per-model gap apart from a per-program one. Omitted entirely for
+        # an appliance whose startProgram carries no categories, rather than
+        # emitting an empty shape a reader would try to interpret.
+        **({"program_options": program_options_matrix} if program_options_matrix else {}),
         "coverage": coverage,
         # Next to coverage on purpose: one says what the code could map for this
         # type, the other what Home Assistant actually holds. Reading them together

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -51,6 +51,7 @@ appliance id): only the entity domain and the code-authored unique_id suffix.
 """
 from __future__ import annotations
 
+import importlib
 import logging
 import re
 from collections.abc import Mapping
@@ -644,6 +645,79 @@ def _command_schema(appliance) -> dict:
     return out
 
 
+# The two bounds on `program_options`. Placed here rather than in the bounds block near
+# the top of the module for the same reason `_CONN_CATEGORY_MAX_CHARS` is: they are only
+# meaningful next to the section that reads them.
+#
+# The PROGRAM cap is a malformed-catalogue backstop and not a summary. The largest real
+# catalogue this repository has measured is 154 categories on a washer, so 256 cannot
+# truncate any appliance seen so far and still stops a runaway schema from turning a
+# support artifact into something nobody can open. When it does bite, the sibling
+# `per_program_truncated` flag says so -- silence about a dropped row would read as an
+# appliance that simply has fewer programs, which is exactly the wrong conclusion for the
+# section a maintainer uses to decide what a program supports. Sorted order is kept so the
+# programs retained are deterministic and two dumps stay diffable.
+_PROGRAM_MATRIX_MAX_PROGRAMS = 256
+
+# The bound on the one CLOUD-CONTROLLED string this section prints: the value a program
+# pins an option to. Real ones are a temperature, a spin speed, a flag or a single word
+# (`dashboard`, `download`, `series`), so 64 characters is already several times more than
+# any of them needs. No truncation flag, and for the same reason `_CONN_CATEGORY_MAX_CHARS`
+# needs none: a pinned value long enough to be cut is not a value, it is a payload, and the
+# cap exists to stop it becoming one rather than to summarise it.
+_PROGRAM_MATRIX_VALUE_MAX_CHARS = 64
+
+
+def _option_drops() -> dict[str, tuple[str, ...]]:
+    """`param name -> sentinel values the entity gate ignores`, from the real tables.
+
+    The gate does not ask "has this parameter >= 2 values" but "has it >= 2 values that
+    are not SENTINELS": `dryLevel` ships `("", "0", "11")` as `DRY_LEVEL_SENTINELS`, so a
+    parameter offering only those creates no entity. `_program_option_matrix` calling
+    `is_settable_option(param)` with no `drop` therefore reported such a parameter as
+    `settable` while no control existed for it -- breaking the one property that section
+    promises, that its verdict is the entity gate's verdict (PR #103 review, coderabbitai).
+
+    Read off the description tables rather than re-declaring the sentinel tuple here, so
+    there is nothing to keep in sync: a description that gains a `drop` is honoured with no
+    change to this module. `getattr` because only the select descriptions carry the field
+    today.
+
+    Guarded per import exactly as `_mapped_sets` is, and degrading the same way: a platform
+    module that will not import costs its own drops, which can only make the section
+    LOOSER (a sentinel-only parameter reads as settable) and never invent a restriction.
+
+    Drops are unioned when two descriptions name the same parameter -- the WM and TD
+    `dryLevel` rows do. Today they carry the identical tuple, so the union is exact; if
+    they ever diverge it would make this section stricter than the looser of the two, which
+    is the safe direction for a report a maintainer reads as "no control here".
+    """
+    drops: dict[str, tuple[str, ...]] = {}
+    tables: list = []
+    for module, names in (
+        ("select", ("_PROGRAM_OPTION_SELECTS",)),
+        ("switch", ("_PROGRAM_OPTION_SWITCHES",)),
+        ("number", ("_PROGRAM_OPTION_NUMBERS",)),
+    ):
+        try:
+            imported = importlib.import_module(f".{module}", __package__)
+            tables.extend(getattr(imported, name, ()) for name in names)
+        except Exception:  # noqa: BLE001 - a dump must degrade, never raise
+            continue
+    for table in tables:
+        for desc in table:
+            drop = tuple(getattr(desc, "drop", ()) or ())
+            if not drop:
+                continue
+            param = str(getattr(desc, "param", "") or "")
+            if not param:
+                continue
+            merged = dict.fromkeys(drops.get(param, ()))
+            merged.update(dict.fromkeys(drop))
+            drops[param] = tuple(merged)
+    return drops
+
+
 def _program_option_matrix(appliance) -> dict:
     """Which options each PROGRAM of ``startProgram`` really supports (issue #98).
 
@@ -665,8 +739,11 @@ def _program_option_matrix(appliance) -> dict:
       ``settable`` -- present with >= 2 reachable values: a real choice for this program
 
     Settability is decided by ``program_options.is_settable_option``, the SAME predicate
-    the entity gate uses, so a reader comparing this section against the entities cannot
-    be misled by two different definitions of "settable".
+    the entity gate uses AND with the same sentinel tuples (``_option_drops``), so a reader
+    comparing this section against the entities cannot be misled by two different
+    definitions of "settable". Passing the predicate without the sentinels was enough to
+    break that: a sentinel-only ``dryLevel`` read as settable while no control for it
+    existed (PR #103 review).
 
     Favourites and the ``{"_": self}`` placeholder are dropped by
     ``ref_programs.program_categories``: a favourite is keyed by text the USER typed, and
@@ -725,8 +802,13 @@ def _program_option_matrix(appliance) -> dict:
     )
     if not union:
         return {}
+    # The sentinel tuples the entity gate ignores, so `settable` here means what it means
+    # there (see `_option_drops`).
+    drops = _option_drops()
+    ordered = sorted(categories.items())
+    truncated = len(ordered) > _PROGRAM_MATRIX_MAX_PROGRAMS
     per_program: dict[str, dict] = {}
-    for code, category in sorted(categories.items()):
+    for code, category in ordered[:_PROGRAM_MATRIX_MAX_PROGRAMS]:
         params = getattr(category, "parameters", None)
         params = params if isinstance(params, dict) else {}
         absent: list[str] = []
@@ -736,10 +818,12 @@ def _program_option_matrix(appliance) -> dict:
             param = params.get(name)
             if param is None:
                 absent.append(name)
-            elif is_settable_option(param):
+            elif is_settable_option(param, drops.get(name, ())):
                 settable.append(name)
             else:
-                fixed[name] = str(getattr(param, "value", ""))
+                fixed[name] = str(getattr(param, "value", ""))[
+                    :_PROGRAM_MATRIX_VALUE_MAX_CHARS
+                ]
         row: dict = {}
         if settable:
             row["settable"] = settable
@@ -753,6 +837,11 @@ def _program_option_matrix(appliance) -> dict:
         "categories_total": len(getattr(command, "categories", {}) or {}),
         "union_params": union,
         "per_program": per_program,
+        # Emitted only when true, and a SIBLING of the map rather than a key inside it, for
+        # the reason `attributes_last_update_truncated` is: every key of `per_program` is a
+        # cloud-chosen program code, so a reserved `truncated` entry could not be told apart
+        # from a program actually named that.
+        **({"per_program_truncated": True} if truncated else {}),
     }
 
 

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.22.1"
+  "version": "5.23.0"
 }

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -1002,15 +1002,16 @@ class HonProgramOptionNumber(HonProgramOptionEntity, NumberEntity):
 
     @property
     def _live_range(self) -> tuple[float, float, float]:
-        # Read live min/max/step from the ACTIVE startProgram command first, so the range
-        # tracks the SELECTED program (the cached _option_param is the merged superset across
-        # categories, which would validate too permissively after a program swap -- PR #38).
-        # Both are cheap single-object reads (no available_settings). Fall back to the cached
-        # merged param, then to the static fallback range.
-        active = self._active_option_param()
-        rng = option_range(active) if active is not None else None
-        if rng is None and self._option_param is not None:
-            rng = option_range(self._option_param)
+        # Read live min/max/step from the SELECTED program's category, so the range really
+        # tracks the program the user picked (the cached _option_param is the merged superset
+        # across categories, which would validate too permissively -- PR #38). Reading the
+        # ACTIVE command instead, as this did until now, tracked the last STARTED program:
+        # the select buffers its choice and swaps no category, so on a machine idle after a
+        # cycle the bounds offered were the finished program's (issue #98, verified in the
+        # 2026-09-08 debug log: programName='rapid_30_min' on all 7 polls while the pending
+        # program moved through four others). _selected_option_param walks
+        # category -> active -> merged and is a cheap single-object read at each step.
+        rng = option_range(self._selected_option_param())
         return rng or self._fallback_range
 
     @property

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -441,21 +441,39 @@ class HonProgramOptionEntity(HonBaseEntity):
     def _selected_option_param(self, drop: tuple[str, ...] = ()):
         """This param as the SELECTED program declares it, else the widest fallback.
 
-        Order: the pending program's category, then the active command, then the cached
-        merged superset. A candidate is taken only when it is genuinely SETTABLE there
-        (``is_settable_option``); otherwise the walk continues. That last clause is the
-        load-bearing one and it is deliberate: a program that pins the option leaves this
-        returning the merged param, so the control keeps the value set it has today
-        instead of degenerating into an empty select or a zero-width number. HIDING such a
-        control is issue #98's own request and belongs to the ``available`` gate, which is
-        a separate, user-visible decision -- not something to smuggle in through a
-        resolver.
+        A program IS pending -> its own category, and on failure the merged superset. The
+        active command is deliberately NOT consulted in this branch: it describes the last
+        program STARTED (see ``_active_option_param``), so preferring it over the merged
+        param would answer a question about the selected program with a different
+        program's narrower value set -- the very substitution this resolver exists to
+        remove (PR #103 review, sourcery-ai + greptile).
+
+        NOTHING is pending -> the active command, then the merged superset. Here the
+        active command is the right answer rather than a stale one: with no selection to
+        honour, the program whose category is loaded is what the machine last ran or is
+        running, which is the PR #38 behaviour this preserves.
+
+        A candidate is taken only when it is genuinely SETTABLE there
+        (``is_settable_option``); otherwise the walk falls through to the merged param.
+        That clause is load-bearing and deliberate: a program that pins or omits the
+        option leaves the control on the merged param, keeping the value set it has today
+        instead of degenerating into an empty select or a zero-width number. It does mean
+        the control stays writable with values that program will not take -- HIDING it is
+        issue #98's own request and belongs to the ``available`` gate, a separate and
+        user-visible decision (an unavailable entity breaks the automations that write it)
+        and not something to smuggle in through a resolver. Until then the two outcomes
+        are the documented ones: an absent option is skipped by
+        ``apply_pending_options`` at Start, and a pinned one is refused by the engine
+        setter with ``command_error``.
 
         ``drop`` is the description's sentinel tuple, passed through so a sentinel-only
         candidate is not mistaken for a usable one."""
-        for candidate in (self._category_option_param(), self._active_option_param()):
-            if candidate is not None and is_settable_option(candidate, drop):
-                return candidate
+        if self._selected_program_code() is not None:
+            candidate = self._category_option_param()
+        else:
+            candidate = self._active_option_param()
+        if candidate is not None and is_settable_option(candidate, drop):
+            return candidate
         return self._option_param
 
     @property

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -36,10 +36,21 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .base_entity import HonBaseEntity
 from .client.engine.parameter.range import HonParameterRange
-from .const import DOMAIN, PROGRAM_PARAM_NAMES, PROGRAM_PENDING_OPTIONS
+from .const import (
+    DOMAIN,
+    PROGRAM_PARAM_NAMES,
+    PROGRAM_PENDING_OPTIONS,
+    PROGRAM_PENDING_STORE,
+)
 from .client.engine.exceptions import ApiError
 from .debug_utils import redact_id
-from .hon_commands import get_command, get_commands, param_range, param_values
+from .hon_commands import (
+    SYNTHETIC_CATEGORY,
+    get_command,
+    get_commands,
+    param_range,
+    param_values,
+)
 from .param_rollback import restore_params, snapshot_params
 
 _LOGGER = logging.getLogger(__name__)
@@ -373,16 +384,79 @@ class HonProgramOptionEntity(HonBaseEntity):
     def _active_option_param(self):
         """Resolve this param off the ACTIVE startProgram command's parameters only.
 
-        Program-accurate (and cheap) vs the cached ``_option_param`` (the merged-across-
-        categories superset): selecting a program SWAPS the active ``startProgram`` command,
-        so a per-program range/value must come from the current command, not the merged
-        cache (PR #38 / Greptile P2). Never calls ``available_settings`` (no range
-        enumeration). Returns None if the command/param is absent."""
+        The ACTIVE command is the LAST STARTED program, not the selected one: the category
+        swap happens in button.py at Start, and `HonCommandLoader._set_last_category`
+        re-points it from the command history on every load. Selecting a program in the
+        select writes the pending store and nothing else, so this reflects the user's
+        choice only after they have actually started it. `_selected_option_param` is the
+        program-accurate resolver; this stays as its second-best fallback (it IS the right
+        answer while a cycle runs, when no program is pending).
+
+        Never calls ``available_settings`` (no range enumeration). Returns None if the
+        command/param is absent."""
         command = startprogram_command(self._appliance)
         params = getattr(command, "parameters", None) if command is not None else None
         if isinstance(params, dict):
             return params.get(self._param)
         return None
+
+    def _selected_program_code(self) -> str | None:
+        """The BUFFERED program code -- the one the user has actually picked -- or None.
+
+        ``select.async_select_option`` writes ONLY ``PROGRAM_PENDING_STORE`` (no send, no
+        category swap), so this store is the only place the current choice exists before
+        Start. ``SYNTHETIC_CATEGORY`` is refused: it is the ``{"_": self}`` placeholder a
+        category-less command reports and never a program code."""
+        code = self._coordinator_store(PROGRAM_PENDING_STORE).get(self._appliance_id)
+        if code is None or str(code) in ("", SYNTHETIC_CATEGORY):
+            return None
+        return str(code)
+
+    def _category_option_param(self):
+        """Resolve this param off the SELECTED program's startProgram CATEGORY, or None.
+
+        ``HonCommand.categories`` holds one command object per program, each with its OWN
+        ``parameters`` -- the schema the hOn app itself rebuilds its option set from
+        (``normalize`` @decomp.txt:1773682, see apk/analysis/issue98-99-program-options-
+        and-wd-dry.md). A program that does not expose this option simply has no such key,
+        and one that pins it carries a ``HonParameterFixed``. Cheap: one dict lookup per
+        read, no ``available_settings``, no range enumeration.
+
+        Returns None when nothing is pending, when the program parameter is not
+        category-backed (a ``prCode``-typed enum keys the store by code, not by category
+        name, so the lookup misses), or when the category omits the param."""
+        code = self._selected_program_code()
+        if code is None:
+            return None
+        command = startprogram_command(self._appliance)
+        categories = getattr(command, "categories", None) if command is not None else None
+        if not isinstance(categories, dict):
+            return None
+        category = categories.get(code)
+        params = getattr(category, "parameters", None) if category is not None else None
+        if isinstance(params, dict):
+            return params.get(self._param)
+        return None
+
+    def _selected_option_param(self, drop: tuple[str, ...] = ()):
+        """This param as the SELECTED program declares it, else the widest fallback.
+
+        Order: the pending program's category, then the active command, then the cached
+        merged superset. A candidate is taken only when it is genuinely SETTABLE there
+        (``is_settable_option``); otherwise the walk continues. That last clause is the
+        load-bearing one and it is deliberate: a program that pins the option leaves this
+        returning the merged param, so the control keeps the value set it has today
+        instead of degenerating into an empty select or a zero-width number. HIDING such a
+        control is issue #98's own request and belongs to the ``available`` gate, which is
+        a separate, user-visible decision -- not something to smuggle in through a
+        resolver.
+
+        ``drop`` is the description's sentinel tuple, passed through so a sentinel-only
+        candidate is not mistaken for a usable one."""
+        for candidate in (self._category_option_param(), self._active_option_param()):
+            if candidate is not None and is_settable_option(candidate, drop):
+                return candidate
+        return self._option_param
 
     @property
     def available(self) -> bool:

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -776,40 +776,67 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
         self._attr_unique_id = f"{appliance_id}_opt_{description.key}"
         if description.icon:
             self._attr_icon = description.icon
-        label_map = description.label_map or {}
-        # The param is resolved + cached once by the mixin; materialize its codes here.
-        choices = (
-            option_choices(self._option_param, description.drop)
-            if self._option_param is not None
-            else []
-        )
-        # raw schema value -> base label (label map, raw value as fallback).
-        base_keys = {raw: label_map.get(raw, raw) for raw in choices}
-        # Collision-aware disambiguation (PR #38 / Greptile P2): when two EXPOSED raw codes
-        # share a label (DRY_LEVEL_LABELS_TD maps e.g. 1 & 12 both to "iron_dry"), suffixing
-        # ONLY the colliding ones with their raw code keeps every code selectable and keeps
-        # the reverse map injective. Non-colliding labels keep their translatable
-        # `state.<key>`; a suffixed colliding key renders literally (rare-model-only).
-        self._raw_to_key: dict[str, str] = disambiguate_labels(base_keys)
-        self._key_to_raw: dict[str, str] = {key: raw for raw, key in self._raw_to_key.items()}
-        # One distinct option per exposed raw code (keys are now unique; order preserved).
-        self._attr_options = list(self._raw_to_key.values())
+        self._label_map = description.label_map or {}
+        # The option set is rebuilt whenever the resolved parameter changes -- which is what
+        # selecting another program does, since each startProgram category carries its own
+        # parameter object (issue #98). Built eagerly here so a construction-time schema
+        # error surfaces at setup rather than on the first frontend read.
+        self._raw_to_key: dict[str, str] = {}
+        self._key_to_raw: dict[str, str] = {}
+        self._maps_param = None
+        self._maps_built = False
+        self._rebuild_maps()
         _LOGGER.debug(
             "Select debug: init option select '%s' id=%s param=%s options=%s",
             redact_id(self._attr_unique_id, appliance_id),
             redact_id(appliance_id),
             description.param,
-            self._attr_options,
+            list(self._raw_to_key.values()),
         )
+
+    def _rebuild_maps(self) -> None:
+        """Rebuild the raw<->label maps from the parameter of the SELECTED program.
+
+        Memoized on the resolved parameter OBJECT (compared with ``is``, so no id() reuse
+        can alias two categories, and the reference keeps the object alive to guarantee
+        it): a program change resolves to a different category's parameter and rebuilds,
+        while a program that does not narrow this option resolves to the same merged
+        parameter and costs one identity check."""
+        param = self._selected_option_param(self._desc.drop)
+        if self._maps_built and param is self._maps_param:
+            return
+        self._maps_param = param
+        self._maps_built = True
+        choices = option_choices(param, self._desc.drop) if param is not None else []
+        # raw schema value -> base label (label map, raw value as fallback).
+        base_keys = {raw: self._label_map.get(raw, raw) for raw in choices}
+        # Collision-aware disambiguation (PR #38 / Greptile P2): when two EXPOSED raw codes
+        # share a label (DRY_LEVEL_LABELS_TD maps e.g. 1 & 12 both to "iron_dry"), suffixing
+        # ONLY the colliding ones with their raw code keeps every code selectable and keeps
+        # the reverse map injective. Non-colliding labels keep their translatable
+        # `state.<key>`; a suffixed colliding key renders literally (rare-model-only).
+        self._raw_to_key = disambiguate_labels(base_keys)
+        self._key_to_raw = {key: raw for raw, key in self._raw_to_key.items()}
+
+    @property
+    def options(self) -> list[str]:
+        # One distinct option per exposed raw code (keys are unique; order preserved).
+        self._rebuild_maps()
+        return list(self._raw_to_key.values())
 
     @property
     def current_option(self) -> str | None:
         raw = self._current_raw()
         if raw is None:
             return None
+        self._rebuild_maps()
+        # None when the live device value is outside what the SELECTED program offers (the
+        # machine still reports the finished cycle's setting). HA renders that as unknown,
+        # which is honest: the value is not one the pending program would accept.
         return self._raw_to_key.get(normalize_code(raw))
 
     async def async_select_option(self, option: str) -> None:
+        self._rebuild_maps()
         raw = self._key_to_raw.get(option)
         if raw is None:
             raise HomeAssistantError(
@@ -817,7 +844,7 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
                 translation_key="invalid_setpoint",
                 translation_placeholders={
                     "value": option,
-                    "allowed": ", ".join(self._attr_options),
+                    "allowed": ", ".join(self._raw_to_key.values()),
                 },
             )
         self._buffer(raw)

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -756,7 +756,26 @@ class HonProgramSelect(HonBaseEntity, SelectEntity):
                 sorted(cleared) if isinstance(cleared, dict) else None,
             )
         _LOGGER.debug("Select debug: after selection store=%s", redact_store(store))
-        self.async_write_ha_state()
+        # Re-render the WHOLE coordinator, not just this select. The option entities now
+        # derive their value set, range and on/off tokens from the pending program
+        # (`HonProgramOptionEntity._selected_option_param`), and their buffered values were
+        # just cleared above -- neither is visible until something writes their state, so a
+        # bare `self.async_write_ha_state()` left every option control showing the previous
+        # program's choices until the next poll, up to a whole scan interval later. A user
+        # picking one of those stale values would then be refused by the write-time check
+        # (PR #103 review, greptile P1).
+        #
+        # The coordinator broadcast is deliberately preferred over a dispatcher signal: it
+        # is exactly what every poll already does, costs one state write per entity and no
+        # I/O, and needs no per-entity subscribe/unsubscribe bookkeeping. It is wider than
+        # this appliance (the account's other appliances re-render too), which is the price
+        # paid for not introducing a signal layer for a single caller.
+        #
+        # This select's own state rides along: a CoordinatorEntity registers
+        # `_handle_coordinator_update` as a listener when it is added to hass, so the
+        # broadcast covers it and a separate `async_write_ha_state()` would only write it
+        # twice.
+        self.coordinator.async_update_listeners()
 
 
 class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):

--- a/custom_components/addhon/switch.py
+++ b/custom_components/addhon/switch.py
@@ -1221,12 +1221,16 @@ class HonProgramOptionSwitch(HonProgramOptionEntity, SwitchEntity):
         self._attr_unique_id = f"{appliance_id}_opt_{description.key}"
         if description.icon:
             self._attr_icon = description.icon
-        # Resolve on/off tokens from the device schema (the param is resolved + cached once
-        # by the mixin): off = "0" (or the lowest value), on = the first value that is not
-        # off. Handles plain 0/1 AND value-pair ranges such as antiCreaseTime[0,360].
-        choices = option_choices(self._option_param) if self._option_param is not None else []
-        self._off = "0" if "0" in choices else (choices[0] if choices else "0")
-        self._on = next((c for c in choices if c != self._off), "1")
+        # Resolve on/off tokens from the device schema: off = "0" (or the lowest value), on =
+        # the first value that is not off. Handles plain 0/1 AND value-pair ranges such as
+        # antiCreaseTime[0,360]. Re-resolved per SELECTED program (issue #98): a program that
+        # offers a different pair -- antiCreaseTime[0,360] on one, [0,180] on another -- must
+        # buffer ITS token, not the one the merged superset happened to be widest on.
+        self._off = "0"
+        self._on = "1"
+        self._tokens_param = None
+        self._tokens_built = False
+        self._refresh_tokens()
         _LOGGER.debug(
             "Switch debug: init option switch '%s' id=%s param=%s off=%s on=%s",
             redact_id(self._attr_unique_id, appliance_id),
@@ -1236,17 +1240,34 @@ class HonProgramOptionSwitch(HonProgramOptionEntity, SwitchEntity):
             self._on,
         )
 
+    def _refresh_tokens(self) -> None:
+        """Re-resolve the on/off tokens when the selected program changes the parameter.
+
+        Memoized on the resolved parameter OBJECT (``is``, not id(), and the reference keeps
+        it alive) exactly as the option select's map cache is."""
+        param = self._selected_option_param()
+        if self._tokens_built and param is self._tokens_param:
+            return
+        self._tokens_param = param
+        self._tokens_built = True
+        choices = option_choices(param) if param is not None else []
+        self._off = "0" if "0" in choices else (choices[0] if choices else "0")
+        self._on = next((c for c in choices if c != self._off), "1")
+
     @property
     def is_on(self) -> bool | None:
         raw = self._current_raw()
         if raw is None:
             return None
+        self._refresh_tokens()
         return normalize_code(raw) != self._off
 
     async def async_turn_on(self, **kwargs) -> None:
+        self._refresh_tokens()
         self._buffer(self._on)
 
     async def async_turn_off(self, **kwargs) -> None:
+        self._refresh_tokens()
         self._buffer(self._off)
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8175,6 +8175,75 @@ class ProgramOptionMatrixTest(unittest.TestCase):
         matrix = self._matrix({"_": FakeCommand(params)}, active="_")
         self.assertEqual({}, matrix)
 
+    def test_a_sentinel_only_parameter_is_not_called_settable(self) -> None:
+        # PR #103 review (coderabbitai): the entity gate ignores DRY_LEVEL_SENTINELS, so a
+        # dryLevel offering only ("", "0", "11") creates NO control. Reporting it as settable
+        # broke the one property this section promises -- that its verdict is the gate's.
+        # Mutation-proof: calling is_settable_option without the drops puts dryLevel in
+        # `settable` for the sentinel category.
+        categories = {
+            "cotton": FakeCommand({
+                "dryLevel": FakeParam(value="12", typology="enum", values=["12", "13", "14"]),
+            }),
+            "sentinel_only": FakeCommand({
+                "dryLevel": FakeParam(value="0", typology="enum", values=["0", "11"]),
+            }),
+        }
+        matrix = self._matrix(categories)
+
+        self.assertEqual({"settable": ["dryLevel"]}, matrix["per_program"]["cotton"])
+        self.assertEqual(
+            {"fixed": {"dryLevel": "0"}}, matrix["per_program"]["sentinel_only"]
+        )
+
+    def test_the_drops_come_from_the_real_description_tables(self) -> None:
+        # Not a re-declared constant: the map is read off the shipped descriptions, so a
+        # description that gains a `drop` is honoured with no change to diagnostics.py.
+        from custom_components.addhon.const import DRY_LEVEL_SENTINELS
+
+        drops = diagnostics._option_drops()
+        self.assertIn("dryLevel", drops)
+        self.assertEqual(set(DRY_LEVEL_SENTINELS), set(drops["dryLevel"]))
+        # Only the parameters that really declare sentinels are in the map.
+        self.assertNotIn("spinSpeed", drops)
+
+    def test_a_runaway_catalogue_is_bounded_and_says_so(self) -> None:
+        # PR #103 review (greptile P2). The cap cannot bite on a real appliance (the largest
+        # measured catalogue is 154 categories), so the flag appearing at all means the
+        # schema is malformed -- and a dropped program must never read as a program the
+        # appliance does not have.
+        cap = diagnostics._PROGRAM_MATRIX_MAX_PROGRAMS
+        categories = {
+            f"program_{index:04d}": FakeCommand({
+                "spinSpeed": FakeParam(value="800", typology="enum", values=["0", "800"]),
+            })
+            for index in range(cap + 5)
+        }
+        matrix = self._matrix(categories, active="program_0000")
+
+        self.assertEqual(cap, len(matrix["per_program"]))
+        self.assertTrue(matrix["per_program_truncated"])
+        # The raw count is untouched, so the withholding is measurable.
+        self.assertEqual(cap + 5, matrix["categories_total"])
+        # Deterministic: the retained programs are the first in sorted order.
+        self.assertEqual("program_0000", min(matrix["per_program"]))
+
+    def test_a_catalogue_within_the_cap_carries_no_truncation_flag(self) -> None:
+        self.assertNotIn("per_program_truncated", self._matrix(self._catalogue()))
+
+    def test_a_pinned_value_is_length_bounded(self) -> None:
+        # The one cloud-controlled string the section prints.
+        cap = diagnostics._PROGRAM_MATRIX_VALUE_MAX_CHARS
+        categories = {
+            "cotton": FakeCommand({
+                "programFamily": FakeParam(
+                    value="x" * (cap * 3), typology="fixed", values=["x" * (cap * 3)]
+                ),
+            }),
+        }
+        matrix = self._matrix(categories)
+        self.assertEqual(cap, len(matrix["per_program"]["cotton"]["fixed"]["programFamily"]))
+
     def test_an_unimportable_program_options_costs_the_section_not_the_dump(self) -> None:
         # Same contract `RegistryDegradationTest` pins for the seven platform modules: a
         # module that will not import costs its own tables and never the walk. Mutation-

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8090,5 +8090,131 @@ class SetupFailureRecordTest(unittest.TestCase):
         self.assertNotIn("example.com", json.dumps(block))
 
 
+class ProgramOptionMatrixTest(unittest.TestCase):
+    """`program_options`: which options each PROGRAM supports (issue #98).
+
+    `commands` above prints the ACTIVE category only -- one program out of the ~90 a washer
+    carries -- so before this section a dump could not answer "does the delicate cycle offer
+    a prewash", which is exactly what #98 asks for.
+    """
+
+    class _StartProgram:
+        """Duck-types `HonCommand` for a program-bearing command."""
+
+        def __init__(self, categories, active):
+            self.categories = categories
+            self._active = active
+
+        @property
+        def parameters(self):
+            return self.categories[self._active].parameters
+
+    def _matrix(self, categories, active="cotton"):
+        appliance = FakeAppliance(
+            commands={"startProgram": self._StartProgram(categories, active)}
+        )
+        return diagnostics._program_option_matrix(appliance)
+
+    def _catalogue(self):
+        return {
+            "cotton": FakeCommand({
+                "spinSpeed": FakeParam(value="1000", typology="enum", values=["0", "800", "1000"]),
+                "prewash": FakeParam(value="0", typology="enum", values=["0", "1"]),
+                "temp": FakeParam(value="40", typology="fixed", values=["40"]),
+            }),
+            # The delicate cycle has NO prewash at all and pins the temperature -- the exact
+            # shape of the real HW80 schema (diagnostics/live-2026-06-22/device-WM.json,
+            # whose active category carries no prewash/acquaplus/extraRinse*).
+            "delicate": FakeCommand({
+                "spinSpeed": FakeParam(value="400", typology="enum", values=["0", "400"]),
+                "temp": FakeParam(value="30", typology="fixed", values=["30"]),
+            }),
+        }
+
+    def test_absent_fixed_and_settable_are_reported_per_program(self) -> None:
+        matrix = self._matrix(self._catalogue())
+
+        self.assertEqual("startProgram", matrix["command"])
+        self.assertEqual(2, matrix["categories_total"])
+        self.assertEqual(["prewash", "spinSpeed", "temp"], matrix["union_params"])
+
+        self.assertEqual(
+            {"settable": ["prewash", "spinSpeed"], "fixed": {"temp": "40"}},
+            matrix["per_program"]["cotton"],
+        )
+        # The delicate cycle: prewash does not exist for it, temp is dictated at 30.
+        self.assertEqual(
+            {"settable": ["spinSpeed"], "fixed": {"temp": "30"}, "absent": ["prewash"]},
+            matrix["per_program"]["delicate"],
+        )
+
+    def test_a_favourite_is_never_named_and_never_widens_the_union(self) -> None:
+        # A favourite is keyed by text the USER typed and carries the engine's own
+        # `favourite` marker parameter. Neither may reach a file destined for a public
+        # issue tracker. Mutation-proof: dropping the ref_programs filter puts
+        # "Il mio programma" in `per_program`, and taking the union from
+        # `command.setting_keys` puts "favourite" in `union_params`.
+        categories = self._catalogue()
+        categories["Il mio programma"] = FakeCommand({
+            "favourite": FakeParam(value="1", typology="fixed", values=["1"]),
+            "spinSpeed": FakeParam(value="1000", typology="enum", values=["0", "1000"]),
+        })
+        matrix = self._matrix(categories)
+
+        self.assertNotIn("Il mio programma", matrix["per_program"])
+        self.assertNotIn("favourite", matrix["union_params"])
+        self.assertEqual({"cotton", "delicate"}, set(matrix["per_program"]))
+        # `categories_total` still counts it, so the withholding is visible rather than
+        # looking like an appliance with fewer programs.
+        self.assertEqual(3, matrix["categories_total"])
+
+    def test_the_synthetic_placeholder_is_not_a_program(self) -> None:
+        # `HonCommand.categories` answers `{"_": self}` for a category-less command; a bare
+        # "_" must never be printed as a program name.
+        params = {"spinSpeed": FakeParam(value="1000", typology="enum", values=["0", "1000"])}
+        matrix = self._matrix({"_": FakeCommand(params)}, active="_")
+        self.assertEqual({}, matrix)
+
+    def test_an_unimportable_program_options_costs_the_section_not_the_dump(self) -> None:
+        # Same contract `RegistryDegradationTest` pins for the seven platform modules: a
+        # module that will not import costs its own tables and never the walk. Mutation-
+        # proof: without the guard the `from .program_options import ...` raises straight
+        # out of the appliance block.
+        appliance = FakeAppliance(
+            commands={"startProgram": self._StartProgram(self._catalogue(), "cotton")}
+        )
+        with _BrokenModules("program_options"):
+            self.assertEqual({}, diagnostics._program_option_matrix(appliance))
+        # And it comes back once the module does.
+        self.assertIn("per_program", diagnostics._program_option_matrix(appliance))
+
+    def test_absent_for_an_appliance_without_startprogram(self) -> None:
+        appliance = FakeAppliance(commands={"settings": FakeCommand({})})
+        self.assertEqual({}, diagnostics._program_option_matrix(appliance))
+
+    def test_the_section_is_omitted_from_a_block_that_has_no_programs(self) -> None:
+        # Regression guard on the wiring: every fixture in this module is category-less, so
+        # the key must not appear at all rather than as an empty object.
+        _, blocks = _entry_diag()
+        for block in blocks.values():
+            self.assertNotIn("program_options", block)
+
+    def test_the_section_reaches_the_appliance_block(self) -> None:
+        coord = _build_coordinator()
+        coord.data[WD_ID]["appliance"] = FakeAppliance(
+            commands={"startProgram": self._StartProgram(self._catalogue(), "cotton")}
+        )
+        hass = FakeHass(coord)
+        result = _run(diagnostics.async_get_config_entry_diagnostics(hass, FakeEntry()))
+        block = {b["type"]: b for b in result["appliances"]}["WD"]
+        self.assertEqual(
+            ["prewash", "spinSpeed", "temp"], block["program_options"]["union_params"]
+        )
+        self.assertEqual(
+            {"settable": ["spinSpeed"], "fixed": {"temp": "30"}, "absent": ["prewash"]},
+            block["program_options"]["per_program"]["delicate"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -147,6 +147,12 @@ class FakeCoordinator:
         self.refreshes = 0
         self.last_update_success = True
         self.last_exception = None
+        # `DataUpdateCoordinator.async_update_listeners`: a program change re-renders every
+        # entity of the coordinator, because the option controls read the pending program.
+        self.listener_broadcasts = 0
+
+    def async_update_listeners(self) -> None:
+        self.listener_broadcasts += 1
 
     async def async_refresh(self) -> None:
         self.refreshes += 1
@@ -817,6 +823,27 @@ class ProgramDependencyTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("washer-1", coordinator.pending_options)
         self.assertEqual({}, coordinator.pending_options)
 
+    async def test_selecting_a_program_re_renders_every_option_entity(self) -> None:
+        # PR #103 review (greptile P1): the option controls derive their value set, range and
+        # on/off tokens from the pending program, and their buffered values are cleared on a
+        # change -- neither is visible until something writes their state. Selecting used to
+        # write only THIS select, leaving every option control on the previous program's
+        # choices until the next poll. Mutation-proof: a bare `async_write_ha_state()` leaves
+        # `listener_broadcasts` at 0.
+        from custom_components.addhon.select import HonProgramSelect
+
+        start = RecordingCommand({"program": Param(values={"1": "Cotone", "2": "Sintetici"})})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = HonProgramSelect(coordinator, "washer-1", FakeClient())
+        self._attach(entity)
+
+        await entity.async_select_option("Sintetici")
+
+        self.assertEqual(1, coordinator.listener_broadcasts)
+        # Still a pure buffer write: no command, no refresh.
+        self.assertEqual(0, start.send_calls)
+        self.assertEqual(0, coordinator.refreshes)
+
     async def test_reselecting_same_program_keeps_pending_options(self) -> None:
         # FIX#1 guard: re-selecting the SAME program is not a change, so the buffered
         # options (chosen for that very program) are PRESERVED, not wiped.
@@ -1157,6 +1184,29 @@ class SelectedProgramTest(unittest.IsolatedAsyncioTestCase):
         entity = self._select(coordinator, "spinSpeed", "spin_speed")
         coordinator.pending_programs = {"washer-1": "eco"}
         self.assertEqual(["0", "400", "800"], entity.options)
+
+    async def test_a_pinning_program_never_borrows_the_last_started_value_set(self) -> None:
+        # PR #103 review (sourcery-ai + greptile P1): when the pending program cannot answer,
+        # the fallback must be the MERGED superset and never the active command. The active
+        # command is the last program STARTED, so preferring it would answer a question about
+        # the selected program with another program's narrower set -- exactly the substitution
+        # this resolver exists to remove. Mutation-proof: walking category -> active -> merged
+        # returns the active `["0", "400"]` here.
+        command, coordinator = self._appliance(
+            {
+                # The widest variant, so `available_settings` caches THIS one as merged.
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800", "1000"])},
+                "rapid_30_min": {"spinSpeed": SetParam(["0", "400"])},
+                "eco": {"spinSpeed": SetParam(["800"])},
+            },
+            active="rapid_30_min",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+        # Idle after `rapid_30_min`: with nothing pending the active command still answers.
+        self.assertEqual(["0", "400"], entity.options)
+
+        coordinator.pending_programs = {"washer-1": "eco"}
+        self.assertEqual(["0", "400", "800", "1000"], entity.options)
 
     async def test_a_program_that_omits_the_option_keeps_the_widest_value_set(self) -> None:
         # Same rule for total ABSENCE, which is how the real HW80 schema says "this

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -405,7 +405,7 @@ class BufferWriteTest(unittest.IsolatedAsyncioTestCase):
         entity = select.HonProgramOptionSelect(coordinator, "washer-1", desc, FakeClient())
         self._attach(entity)
 
-        self.assertEqual(["0", "400", "800", "1000", "1200"], entity._attr_options)
+        self.assertEqual(["0", "400", "800", "1000", "1200"], entity.options)
         await entity.async_select_option("800")
 
         self.assertEqual({"washer-1": {"spinSpeed": "800"}}, coordinator.pending_options)
@@ -709,12 +709,12 @@ class TypeGateDryLevelTest(unittest.IsolatedAsyncioTestCase):
     async def test_wm_uses_wm_label_map(self) -> None:
         entity = await self._dry_level_select("WM", RangeParam(1, 3, 1))
         # WM/WD case 300: 1=extra_dry, 2=cupboard, 3=iron_dry.
-        self.assertEqual(["extra_dry", "cupboard", "iron_dry"], entity._attr_options)
+        self.assertEqual(["extra_dry", "cupboard", "iron_dry"], entity.options)
 
     async def test_td_uses_td_label_map(self) -> None:
         entity = await self._dry_level_select("TD", RangeParam(12, 14, 1))
         # TD case 53: 12=iron_dry, 13=ready_to_wear, 14=cupboard.
-        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
+        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity.options)
 
 
 class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
@@ -722,7 +722,7 @@ class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
     label (DRY_LEVEL_LABELS_TD: 1&12->iron_dry, 3&14->cupboard, 4&15->extra_dry). When
     BOTH members are exposed the select must keep them as two DISTINCT options and
     round-trip each raw, not collapse them onto one key (which would drop a code from
-    _attr_options and make _key_to_raw buffer the wrong raw)."""
+    the option list and make _key_to_raw buffer the wrong raw)."""
 
     def _attach(self, entity) -> None:
         entity.hass = FakeHass()
@@ -744,17 +744,17 @@ class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_colliding_codes_stay_distinct_and_round_trip(self) -> None:
         # 4 and 15 both map to "extra_dry" on TD; both must survive as DISTINCT options.
-        # Mutation-proof: without FIX#4 _attr_options collapses to ["extra_dry"] (len 1)
+        # Mutation-proof: without FIX#4 the option list collapses to ["extra_dry"] (len 1)
         # and _key_to_raw is {"extra_dry": "15"} -> the first two assertions fail and the
         # raw "4" is unreachable / buffers as "15".
         entity, coordinator = self._td_dry_level(SetParam(["4", "15"]))
 
-        self.assertEqual(2, len(entity._attr_options))
-        self.assertEqual(len(entity._attr_options), len(set(entity._attr_options)))
+        self.assertEqual(2, len(entity.options))
+        self.assertEqual(len(entity.options), len(set(entity.options)))
         # Every raw code is reachable through the option keys (injective round-trip map).
         self.assertEqual({"4", "15"}, set(entity._key_to_raw.values()))
 
-        for option in entity._attr_options:
+        for option in entity.options:
             await entity.async_select_option(option)
             # Each option buffers its OWN distinct raw, not a collapsed sibling.
             self.assertEqual(
@@ -769,7 +769,7 @@ class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
         # back as a distinct option (no aliasing of 1 onto 12 or vice versa).
         entity, coordinator = self._td_dry_level(SetParam(["1", "12"]))
 
-        self.assertEqual(2, len(set(entity._attr_options)))
+        self.assertEqual(2, len(set(entity.options)))
         opt_1 = entity._raw_to_key["1"]
         opt_12 = entity._raw_to_key["12"]
         self.assertNotEqual(opt_1, opt_12)
@@ -783,7 +783,7 @@ class DuplicateLabelDisambiguationTest(unittest.IsolatedAsyncioTestCase):
         # Regression guard: erpayo's TD range [12,13,14] has NO label collision, so the
         # options stay the plain translatable keys (state.<key>), unsuffixed.
         entity, _ = self._td_dry_level(RangeParam(12, 14, 1))
-        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity._attr_options)
+        self.assertEqual(["iron_dry", "ready_to_wear", "cupboard"], entity.options)
 
 
 class ProgramDependencyTest(unittest.IsolatedAsyncioTestCase):
@@ -952,6 +952,254 @@ class OptionClearSurvivesNewerWriteTest(unittest.IsolatedAsyncioTestCase):
             coordinator.pending_options,
         )
         self.assertEqual(1, start.send_calls)
+
+
+class CategoryCommand:
+    """Duck-types ``HonCommand`` with real per-program CATEGORIES.
+
+    ``RecordingCommand`` above models a category-less command, which is all the earlier
+    tests needed. Issue #98 lives in the difference: a washer's ``startProgram`` is a dict
+    of one command PER PROGRAM, each with its own ``parameters``, and the entities are
+    built from ``available_settings`` -- the union that keeps the RICHEST variant of each
+    name (``commands.available_settings`` / ``_more_options``). Both are reproduced here so
+    a test can distinguish "the merged superset" from "what this program declares".
+    """
+
+    def __init__(self, categories: dict, active: str) -> None:
+        self.categories = {code: RecordingCommand(params) for code, params in categories.items()}
+        self._active = active
+        self.send_calls = 0
+
+    @property
+    def parameters(self) -> dict:
+        return self.categories[self._active].parameters
+
+    @property
+    def available_settings(self) -> dict:
+        merged: dict = {}
+        for command in self.categories.values():
+            for name, param in command.parameters.items():
+                current = merged.get(name)
+                if current is None or len(getattr(param, "values", []) or []) > len(
+                    getattr(current, "values", []) or []
+                ):
+                    merged[name] = param
+        return merged
+
+    async def send(self) -> None:
+        self.send_calls += 1
+
+
+class SelectedProgramTest(unittest.IsolatedAsyncioTestCase):
+    """Issue #98: every option control must read the schema of the program the user
+    SELECTED, which lives in the pending store -- not the one last STARTED.
+
+    The distinction is the whole bug. ``async_select_option`` buffers the code and swaps no
+    category, and ``HonCommandLoader._set_last_category`` re-points the active command at
+    the last program the cloud accepted, so before this change the controls described a
+    finished cycle. Proven in the 2026-09-08 debug log attached to #98:
+    ``programName='rapid_30_min'`` on all 7 polls while the pending program moved through
+    four others.
+    """
+
+    def _attach(self, entity) -> None:
+        entity.hass = FakeHass()
+
+    def _appliance(self, categories: dict, active: str):
+        command = CategoryCommand(categories, active)
+        appliance = types.SimpleNamespace(commands={"startProgram": command})
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        return command, coordinator
+
+    def _select(self, coordinator, param: str, key: str):
+        from custom_components.addhon import select
+
+        desc = select.HonProgramOptionSelectDescription(
+            key=key, param=param, translation_key=key, types=("WM", "WD")
+        )
+        entity = select.HonProgramOptionSelect(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+        return entity
+
+    def _number(self, coordinator, param: str, key: str):
+        from custom_components.addhon import number
+
+        desc = number.HonProgramOptionNumberDescription(
+            key=key, param=param, translation_key=key, types=("WM", "WD", "TD")
+        )
+        entity = number.HonProgramOptionNumber(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+        return entity
+
+    def _switch(self, coordinator, param: str, key: str):
+        from custom_components.addhon import switch
+
+        desc = switch.HonProgramOptionSwitchDescription(
+            key=key, param=param, types=("WM", "WD")
+        )
+        entity = switch.HonProgramOptionSwitch(coordinator, "washer-1", desc, FakeClient())
+        self._attach(entity)
+        return entity
+
+    async def test_select_options_follow_the_pending_program(self) -> None:
+        # Mutation-proof: reading the merged superset (or the active command) keeps 5
+        # options for the delicate cycle, so the second assertion fails.
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800", "1000", "1200"])},
+                "delicate": {"spinSpeed": SetParam(["0", "400", "600"])},
+            },
+            active="cotton",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+
+        # Nothing pending: the active command answers, exactly as before this change.
+        self.assertEqual(["0", "400", "800", "1000", "1200"], entity.options)
+
+        coordinator.pending_programs = {"washer-1": "delicate"}
+        self.assertEqual(["0", "400", "600"], entity.options)
+        # The active command is untouched -- only the pending store moved.
+        self.assertIs(command.categories["cotton"].parameters["spinSpeed"],
+                      command.parameters["spinSpeed"])
+
+        # And back: the resolver is not one-way.
+        coordinator.pending_programs = {"washer-1": "cotton"}
+        self.assertEqual(["0", "400", "800", "1000", "1200"], entity.options)
+
+    async def test_select_write_is_validated_against_the_pending_program(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800", "1000", "1200"])},
+                "delicate": {"spinSpeed": SetParam(["0", "400", "600"])},
+            },
+            active="cotton",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+        coordinator.pending_programs = {"washer-1": "delicate"}
+
+        # 1200 exists on the cotton cycle only: refused for the selected program instead
+        # of being buffered and rejected later by the engine at Start.
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await entity.async_select_option("1200")
+        self.assertEqual("invalid_setpoint", ctx.exception.translation_key)
+
+        await entity.async_select_option("600")
+        self.assertEqual("600", coordinator.pending_options["washer-1"]["spinSpeed"])
+
+    async def test_number_range_follows_the_pending_program_not_the_last_started(self) -> None:
+        # The exact shape of the #98 log: the machine is idle after `rapid_30_min`, so the
+        # ACTIVE command is that program's, while the user has selected another one.
+        # Mutation-proof: resolving off the active command keeps max at 1410.
+        from homeassistant.exceptions import HomeAssistantError
+
+        command, coordinator = self._appliance(
+            {
+                "rapid_30_min": {"delayTime": RangeParam(0, 1410, 30)},
+                "delicate": {"delayTime": RangeParam(0, 180, 30)},
+            },
+            active="rapid_30_min",
+        )
+        entity = self._number(coordinator, "delayTime", "delay_time")
+        self.assertEqual(1410, entity.native_max_value)
+
+        coordinator.pending_programs = {"washer-1": "delicate"}
+        self.assertEqual(180, entity.native_max_value)
+        self.assertEqual(0, entity.native_min_value)
+        self.assertEqual(30, entity.native_step)
+
+        with self.assertRaises(HomeAssistantError):
+            await entity.async_set_native_value(240)
+        await entity.async_set_native_value(150)
+        self.assertEqual("150", coordinator.pending_options["washer-1"]["delayTime"])
+
+    async def test_switch_tokens_follow_the_pending_program(self) -> None:
+        # A value-pair range is the case that bites: anticrease is [0,1] on one program and
+        # [0,360] on another, and buffering "1" for a program that wants "360" is a value
+        # the engine refuses at Start. Mutation-proof: the merged superset keeps on="360"
+        # for BOTH, so the first assertion fails.
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"anticrease": SetParam(["0", "1"])},
+                "delicate": {"anticrease": SetParam(["0", "360"])},
+            },
+            active="cotton",
+        )
+        entity = self._switch(coordinator, "anticrease", "anticrease")
+
+        await entity.async_turn_on()
+        self.assertEqual("1", coordinator.pending_options["washer-1"]["anticrease"])
+
+        coordinator.pending_programs = {"washer-1": "delicate"}
+        await entity.async_turn_on()
+        self.assertEqual("360", coordinator.pending_options["washer-1"]["anticrease"])
+
+        await entity.async_turn_off()
+        self.assertEqual("0", coordinator.pending_options["washer-1"]["anticrease"])
+
+    async def test_a_program_that_pins_the_option_keeps_the_widest_value_set(self) -> None:
+        # A program that declares the option FIXED must not empty the control: hiding it is
+        # issue #98's own request and belongs to the `available` gate, a separate and
+        # user-visible decision. Here the resolver walks past the unusable candidate.
+        # Mutation-proof: taking the pinned param unconditionally leaves ONE option (or
+        # none), so the assertion on the full set fails.
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800"])},
+                "eco": {"spinSpeed": SetParam(["800"])},
+            },
+            active="cotton",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+        coordinator.pending_programs = {"washer-1": "eco"}
+        self.assertEqual(["0", "400", "800"], entity.options)
+
+    async def test_a_program_that_omits_the_option_keeps_the_widest_value_set(self) -> None:
+        # Same rule for total ABSENCE, which is how the real HW80 schema says "this
+        # program has no prewash" (verified on diagnostics/live-2026-06-22/device-WM.json,
+        # whose active category carries no prewash/acquaplus/extraRinse* at all).
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800"])},
+                "spin_only": {"temp": SetParam(["0"])},
+            },
+            active="cotton",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+        coordinator.pending_programs = {"washer-1": "spin_only"}
+        self.assertEqual(["0", "400", "800"], entity.options)
+
+    async def test_an_unresolvable_pending_code_falls_back_to_the_active_command(self) -> None:
+        # A `prCode`-typed program parameter keys the pending store by CODE, not by
+        # category name, so the lookup must miss quietly rather than blank the control.
+        command, coordinator = self._appliance(
+            {
+                "cotton": {"spinSpeed": SetParam(["0", "400", "800"])},
+                "delicate": {"spinSpeed": SetParam(["0", "400"])},
+            },
+            active="cotton",
+        )
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+
+        for pending in ("115", "", None, "_"):
+            coordinator.pending_programs = {"washer-1": pending}
+            self.assertEqual(
+                ["0", "400", "800"], entity.options, f"pending={pending!r}"
+            )
+
+    async def test_a_category_less_command_is_unaffected(self) -> None:
+        # Regression guard for every non-program appliance: `HonCommand.categories`
+        # answers `{"_": self}` there, and a pending code must not resolve against that
+        # placeholder.
+        start = RecordingCommand({"spinSpeed": SetParam(["0", "400", "800"])})
+        coordinator = FakeCoordinator(_washer({"startProgram": start}))
+        entity = self._select(coordinator, "spinSpeed", "spin_speed")
+        coordinator.pending_programs = {"washer-1": "delicate"}
+        self.assertEqual(["0", "400", "800"], entity.options)
 
 
 if __name__ == "__main__":

--- a/tests/test_program_select.py
+++ b/tests/test_program_select.py
@@ -230,6 +230,12 @@ class FakeCoordinator:
         self.refreshes = 0
         self.last_update_success = True
         self.last_exception = None
+        # `DataUpdateCoordinator.async_update_listeners`: a program change re-renders every
+        # entity of the coordinator, because the option controls read the pending program.
+        self.listener_broadcasts = 0
+
+    def async_update_listeners(self) -> None:
+        self.listener_broadcasts += 1
 
     async def async_refresh(self) -> None:
         self.refreshes += 1


### PR DESCRIPTION
Automated release PR for `v5.23.0`.

<!-- release-tag: v5.23.0 -->

## Summary by Sourcery

Release version 5.23.0 with program-specific option controls and expanded diagnostics for per-program schemas.

New Features:
- Add per-program option matrices to diagnostics, showing absent, fixed, and settable options while bounding potentially oversized output.

Bug Fixes:
- Resolve program option choices, numeric ranges, and switch tokens from the pending program instead of the last-started program.
- Refresh all dependent option entities immediately when the pending program changes.

Enhancements:
- Improve option metadata handling for category-specific schemas while preserving fallback behavior for category-less appliances.

Build:
- Bump the integration version to 5.23.0.

Tests:
- Add regression coverage for pending-program option resolution, dynamic entity updates, diagnostics matrices, truncation, and degraded imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Program options now adapt to the currently selected appliance program, including program-specific selections, numeric ranges, and switch values.
  * Diagnostics now show which options are available, fixed, or configurable for each program.

* **Bug Fixes**
  * Option controls now use the selected program instead of potentially using settings from the last-started program.
  * Improved handling of unavailable or unresolved program selections while retaining valid fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release updates program-option controls to derive select choices, numeric ranges, and switch tokens from the pending program, broadcasts program-selection changes to coordinator entities, adds bounded per-program diagnostics, and bumps the integration to version 5.23.0.

- Resolves option metadata dynamically from the selected program category.
- Re-renders option entities immediately when the pending program changes.
- Adds per-program diagnostics for settable, fixed, and absent parameters while filtering user-defined favourites.
- Adds regression coverage for category-specific controls, diagnostic bounds, and selection updates.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the selected program can still leave unsupported or fixed options writable.

The previous unsupported-options finding remains unresolved: `_selected_option_param` deliberately falls back to the merged parameter when the pending category omits or fixes an option, so Home Assistant can still accept a value that is skipped or rejected when Start prepares the selected category. The stale-entity finding was manually resolved after the coordinator-wide listener broadcast was added. The diagnostics-size finding is only partly fixed: category count and fixed-value length are bounded, but the union parameter count and repeated per-program parameter lists remain unbounded.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/program_options.py | Adds pending-program category resolution, but unsupported or fixed options still fall back to writable merged metadata. |
| custom_components/addhon/select.py | Rebuilds option maps dynamically and broadcasts program-selection state changes to coordinator entities. |
| custom_components/addhon/number.py | Uses selected-program metadata for live numeric bounds and validation. |
| custom_components/addhon/switch.py | Refreshes switch on/off tokens when the selected program changes. |
| custom_components/addhon/diagnostics.py | Adds filtered per-program option diagnostics with category and fixed-value bounds, though parameter cardinality remains unbounded. |
| custom_components/addhon/manifest.json | Bumps the integration version to 5.23.0. |
| tests/test_diagnostics.py | Covers diagnostic classification, favourite filtering, truncation, and graceful degradation. |
| tests/test_program_options.py | Covers selected-program option resolution, validation, fallback behavior, and listener broadcasts. |
| tests/test_program_select.py | Updates coordinator test instrumentation for listener broadcasts. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Program select] --> B[Pending program code]
  B --> C[Coordinator listener broadcast]
  C --> D[Resolve selected category]
  D --> E[Select choices]
  D --> F[Number range]
  D --> G[Switch tokens]
  E --> H[Pending option values]
  F --> H
  G --> H
  B --> I[Start action]
  H --> I
  I --> J[Validate selected category]
  J --> K[Send appliance command]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address the v5.23.0 review findings..."](https://github.com/tis24dev/addhon/commit/cb2a7b2ccaf2f4a2e4b1310c97f97c1b7674f90b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61791030)</sub>

**Context used:**

- Knowledge Base — [Program selection and options](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/program-selection-and-options.md)
- Knowledge Base — [Diagnostics and safe observability](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/diagnostics-and-safe-observability.md)

<!-- /greptile_comment -->