### PR TITLE
Release v5.24.0

### DIFF
--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -75,6 +75,18 @@ class HonParameter:
         against `values`. None means the node declared neither field -- which is a real
         shape (an enum that lists `enumValues` purely so a client can render a control) and
         must not be confused with the "0" the subclasses fabricate to keep `value` non-None.
+
+        The fixed-before-default order can in principle disagree with what THIS engine would
+        send: `HonParameterEnum` seeds its value from `defaultValue` alone and ignores
+        `fixedValue`, so an enum declaring both would be reported here as the former and
+        transmitted as the latter (PR #104 review, sourcery-ai). It is left as it is, and
+        the reason is evidence rather than preference: across every schema this repository
+        holds -- 5348 parameter nodes in apk/dump/, tests/fixtures/ and diagnostics/ --
+        `fixedValue` appears on `typology: fixed` nodes and on nothing else. Zero enum and
+        zero range nodes carry it, and zero fixed nodes carry a `defaultValue`, so the
+        conflicting shape has never been produced by the cloud. Branching on it would add an
+        untestable path to hide a value from a case that does not occur; if one ever does,
+        the divergence belongs in the enum's own seeding, not here.
         """
         for name in ("fixedValue", "defaultValue"):
             declared = self._attributes.get(name)

--- a/custom_components/addhon/client/engine/parameter/base.py
+++ b/custom_components/addhon/client/engine/parameter/base.py
@@ -49,10 +49,38 @@ class HonParameter:
         A declared "0" counts, hence the comparison against None/"" rather than a
         truthiness test -- a numeric 0 default is a value the schema asked for.
         """
-        return any(
-            self._attributes.get(name) not in (None, "")
-            for name in ("defaultValue", "fixedValue")
-        )
+        return self.schema_value is not None
+
+    @property
+    def schema_value(self) -> Any | None:
+        """What the SCHEMA prescribes for this parameter, or None if it prescribes nothing.
+
+        `fixedValue` first, then `defaultValue`, which is the hOn app's own order: its
+        `setValue` reads `dictionaryParameter.fixedValue ?? dictionaryParameter.defaultValue`
+        off the selected program's schema node (decomp.txt:1778771-1778793, analysed in
+        apk/analysis/issue98-99-program-options-and-wd-dry.md section 8).
+
+        This is deliberately NOT `value`, and the difference is the whole point. `value` is
+        LIVE state: the Start path writes the user's chosen options straight into the
+        selected category's parameters and never undoes them on success (button.py), the
+        command-history recovery seeds the last-started category from the cloud, and a
+        favourite category is loaded from the values the user saved. So `value` answers
+        "what does this parameter currently hold", which for a program the user has run
+        before is their own past choice. Only the untouched `_attributes` node still answers
+        "what does this PROGRAM prescribe" -- it is the schema as received and nothing ever
+        writes to it.
+
+        Returns the RAW schema value, uninterpreted: subclasses that normalize `value`
+        normalize this the same way (see HonParameterEnum), so the two stay comparable
+        against `values`. None means the node declared neither field -- which is a real
+        shape (an enum that lists `enumValues` purely so a client can render a control) and
+        must not be confused with the "0" the subclasses fabricate to keep `value` non-None.
+        """
+        for name in ("fixedValue", "defaultValue"):
+            declared = self._attributes.get(name)
+            if declared not in (None, ""):
+                return declared
+        return None
 
     @property
     def value(self) -> str | float:

--- a/custom_components/addhon/client/engine/parameter/enum.py
+++ b/custom_components/addhon/client/engine/parameter/enum.py
@@ -72,6 +72,14 @@ class HonParameterEnum(HonParameter):
         return str(self._value) if self._value is not None else str(self.values[0])
 
     @property
+    def schema_value(self) -> Any | None:
+        # Normalized exactly as `value` and `values` are, so a schema-declared code stays
+        # comparable against the option list: a cloud-cased "Ropa mixta" or a bracketed
+        # "[fridge|freezer]" is only ever found in `values` in its clean form.
+        declared = super().schema_value
+        return None if declared is None else clean_value(declared)
+
+    @property
     def value(self) -> str | float:
         return clean_value(self._value) if self._value is not None else self.values[0]
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -736,7 +736,23 @@ def _program_option_matrix(appliance) -> dict:
       ``absent``   -- in the union, not in THIS program: the option does not exist for it
       ``fixed``    -- present but pinned (fixed, or a single reachable value): the program
                       dictates it, and the map's value is what it dictates
-      ``settable`` -- present with >= 2 reachable values: a real choice for this program
+      ``settable`` -- present with >= 2 reachable values: a real choice for this program,
+                      and the map's value is the DEFAULT this program starts it at
+
+    ``settable`` carries its value for the same reason ``fixed`` does, and the reason is
+    the second half of #98 rather than symmetry for its own sake: the reporter's actual
+    request is that picking a program should preset the options that program calls for, and
+    the official app does exactly that -- on a program change it displays
+    ``fixedValue ?? defaultValue`` of the selected category (``setValue``
+    @decomp.txt:1778757, analysed in apk/analysis/issue98-99-program-options-and-wd-dry.md
+    section 8). A section that printed the pinned values but not the settable defaults could show
+    that an option is available and never what the program would set it to, which is the
+    half the feature is about.
+
+    Both maps carry ``HonParameter.schema_value`` -- the schema node -- and NOT the live
+    ``value``, which is mutable state an earlier cycle may have moved (see the comment at
+    the read below). A ``null`` means the schema prescribes nothing for that parameter in
+    that program.
 
     Settability is decided by ``program_options.is_settable_option``, the SAME predicate
     the entity gate uses AND with the same sentinel tuples (``_option_drops``), so a reader
@@ -813,17 +829,37 @@ def _program_option_matrix(appliance) -> dict:
         params = params if isinstance(params, dict) else {}
         absent: list[str] = []
         fixed: dict[str, str] = {}
-        settable: list[str] = []
+        settable: dict[str, str] = {}
         for name in union:
             param = params.get(name)
             if param is None:
                 absent.append(name)
-            elif is_settable_option(param, drops.get(name, ())):
-                settable.append(name)
+                continue
+            # The SCHEMA node, not the live value. `value` is mutable state -- the Start
+            # path writes the user's buffered options into the selected category and never
+            # undoes them on success, the command history seeds the last-started category,
+            # and a favourite category is loaded from what the user saved -- so a dump taken
+            # after a cycle would report a user's own past choice as the program's
+            # prescription. `schema_value` is the untouched node the app itself reads.
+            #
+            # `null` when the schema prescribes nothing, and NOT the engine's `value`. The
+            # subclasses fabricate a "0" to keep reads non-None, and for a descriptor-only
+            # node -- one that lists `enumValues` purely so a client can render a control --
+            # that "0" is not even among its own values and is deliberately never
+            # transmitted (`_send_parameters` filters the ancillary group on
+            # `declares_value`). Printing it would assert a starting value the program never
+            # stated, which is the one thing this section may not do; `null` says "this
+            # program prescribes nothing here", which is the truth.
+            declared = getattr(param, "schema_value", None)
+            value = (
+                None
+                if declared is None
+                else str(declared)[:_PROGRAM_MATRIX_VALUE_MAX_CHARS]
+            )
+            if is_settable_option(param, drops.get(name, ())):
+                settable[name] = value
             else:
-                fixed[name] = str(getattr(param, "value", ""))[
-                    :_PROGRAM_MATRIX_VALUE_MAX_CHARS
-                ]
+                fixed[name] = value
         row: dict = {}
         if settable:
             row["settable"] = settable

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -660,11 +660,12 @@ def _command_schema(appliance) -> dict:
 _PROGRAM_MATRIX_MAX_PROGRAMS = 256
 
 # The bound on the one CLOUD-CONTROLLED string this section prints: the value a program
-# pins an option to. Real ones are a temperature, a spin speed, a flag or a single word
-# (`dashboard`, `download`, `series`), so 64 characters is already several times more than
-# any of them needs. No truncation flag, and for the same reason `_CONN_CATEGORY_MAX_CHARS`
-# needs none: a pinned value long enough to be cut is not a value, it is a payload, and the
-# cap exists to stop it becoming one rather than to summarise it.
+# prescribes for an option. Real ones are a temperature, a spin speed, a flag or a single
+# word (`dashboard`, `download`, `series`), so 64 characters is already several times more
+# than any of them needs. No truncation flag, and for the same reason
+# `_CONN_CATEGORY_MAX_CHARS` needs none: a prescribed value long enough to be cut is not a
+# value, it is a payload, and the cap exists to stop it becoming one rather than to
+# summarise it. Applied through `_bounded_text`, which masks before it cuts.
 _PROGRAM_MATRIX_VALUE_MAX_CHARS = 64
 
 
@@ -828,8 +829,11 @@ def _program_option_matrix(appliance) -> dict:
         params = getattr(category, "parameters", None)
         params = params if isinstance(params, dict) else {}
         absent: list[str] = []
-        fixed: dict[str, str] = {}
-        settable: dict[str, str] = {}
+        # `str | None`: a null says the schema prescribes nothing for that parameter (see
+        # the read below), so the value type is genuinely optional and saying so keeps the
+        # annotation honest against the JSON this emits.
+        fixed: dict[str, str | None] = {}
+        settable: dict[str, str | None] = {}
         for name in union:
             param = params.get(name)
             if param is None:
@@ -850,11 +854,18 @@ def _program_option_matrix(appliance) -> dict:
             # `declares_value`). Printing it would assert a starting value the program never
             # stated, which is the one thing this section may not do; `null` says "this
             # program prescribes nothing here", which is the truth.
+            # `_bounded_text`, never a bare slice: it MASKS and only then cuts, which is the
+            # order that keeps a MAC straddling the cap from arriving as a readable
+            # three-and-a-half-octet fragment (measured on a 64-char cap: `...3c:71:bf:`
+            # cut-first vs `...***` mask-first). That helper exists precisely so a new
+            # bounded cloud string does not have to rediscover this, and reviewing it is
+            # meant to be a matter of checking the call site uses it at all -- this one did
+            # not (PR #104 review, coderabbitai).
             declared = getattr(param, "schema_value", None)
             value = (
                 None
                 if declared is None
-                else str(declared)[:_PROGRAM_MATRIX_VALUE_MAX_CHARS]
+                else _bounded_text(declared, _PROGRAM_MATRIX_VALUE_MAX_CHARS)
             )
             if is_settable_option(param, drops.get(name, ())):
                 settable[name] = value

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.23.0"
+  "version": "5.24.0"
 }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -253,9 +253,21 @@ class Opaque:
         return "opaque-str"
 
 
+_UNSET = object()
+
+
 class FakeParam:
-    def __init__(self, value=None, values=None, typology=None, category=None, mandatory=None, rng=None):
+    def __init__(self, value=None, values=None, typology=None, category=None, mandatory=None,
+                 rng=None, schema=_UNSET):
         self.value = value
+        # Duck-types `HonParameter.schema_value`: what the SCHEMA prescribes, which the
+        # engine keeps separate from the mutable `value`. DEFAULTS to `value`, because that
+        # is the well-formed case the real engine produces -- a node that declares a
+        # default has both, equal, until something writes to the parameter. The two shapes
+        # that matter are then stated explicitly: `schema=<other>` for a parameter an
+        # earlier cycle moved, and `schema=None` for a descriptor-only node the schema
+        # says nothing about.
+        self.schema_value = value if schema is _UNSET else schema
         self.typology = typology
         self.category = category
         self.mandatory = mandatory
@@ -8138,15 +8150,61 @@ class ProgramOptionMatrixTest(unittest.TestCase):
         self.assertEqual(2, matrix["categories_total"])
         self.assertEqual(["prewash", "spinSpeed", "temp"], matrix["union_params"])
 
+        # `settable` carries the DEFAULT this program starts the option at, which is the
+        # half issue #98 actually asks for -- knowing an option is available says nothing
+        # about what the program would set it to.
         self.assertEqual(
-            {"settable": ["prewash", "spinSpeed"], "fixed": {"temp": "40"}},
+            {
+                "settable": {"prewash": "0", "spinSpeed": "1000"},
+                "fixed": {"temp": "40"},
+            },
             matrix["per_program"]["cotton"],
         )
         # The delicate cycle: prewash does not exist for it, temp is dictated at 30.
         self.assertEqual(
-            {"settable": ["spinSpeed"], "fixed": {"temp": "30"}, "absent": ["prewash"]},
+            {
+                "settable": {"spinSpeed": "400"},
+                "fixed": {"temp": "30"},
+                "absent": ["prewash"],
+            },
             matrix["per_program"]["delicate"],
         )
+
+    def test_the_prescribed_value_is_the_schema_not_the_live_one(self) -> None:
+        # A dump taken after a cycle must not report the user's own past choice as the
+        # program's prescription: the Start path writes buffered options into the selected
+        # category's parameters and never undoes them on success. Mutation-proof: reading
+        # `value` reports "1400" for a program whose schema says "400".
+        categories = {
+            "cotton": FakeCommand({
+                "spinSpeed": FakeParam(value="1400", typology="enum",
+                                       values=["0", "400", "1400"], schema="400"),
+                "temp": FakeParam(value="60", typology="fixed", values=["60"], schema="40"),
+            }),
+        }
+        matrix = self._matrix(categories)
+        self.assertEqual(
+            {"settable": {"spinSpeed": "400"}, "fixed": {"temp": "40"}},
+            matrix["per_program"]["cotton"],
+        )
+
+    def test_a_parameter_the_schema_says_nothing_about_is_reported_as_null(self) -> None:
+        # A pure descriptor -- it lists `enumValues` so a client can render a control and
+        # states no value -- prescribes nothing. The engine fabricates a "0" to keep reads
+        # non-None, but that "0" is not even among the parameter's own values and
+        # `_send_parameters` deliberately never transmits it (it filters the ancillary group
+        # on `declares_value`). Printing it would assert a starting value the program never
+        # stated. The shape is real: 20 such nodes in apk/dump/ac_live/commands_raw.json,
+        # one in every AC startProgram category. Mutation-proof: falling back to
+        # `param.value` reports "0" here.
+        categories = {
+            "cotton": FakeCommand({
+                "spinSpeed": FakeParam(value="0", typology="enum", values=["2", "4", "5"],
+                                       schema=None),
+            }),
+        }
+        matrix = self._matrix(categories)
+        self.assertEqual({"settable": {"spinSpeed": None}}, matrix["per_program"]["cotton"])
 
     def test_a_favourite_is_never_named_and_never_widens_the_union(self) -> None:
         # A favourite is keyed by text the USER typed and carries the engine's own
@@ -8191,7 +8249,9 @@ class ProgramOptionMatrixTest(unittest.TestCase):
         }
         matrix = self._matrix(categories)
 
-        self.assertEqual({"settable": ["dryLevel"]}, matrix["per_program"]["cotton"])
+        self.assertEqual(
+            {"settable": {"dryLevel": "12"}}, matrix["per_program"]["cotton"]
+        )
         self.assertEqual(
             {"fixed": {"dryLevel": "0"}}, matrix["per_program"]["sentinel_only"]
         )
@@ -8280,7 +8340,11 @@ class ProgramOptionMatrixTest(unittest.TestCase):
             ["prewash", "spinSpeed", "temp"], block["program_options"]["union_params"]
         )
         self.assertEqual(
-            {"settable": ["spinSpeed"], "fixed": {"temp": "30"}, "absent": ["prewash"]},
+            {
+                "settable": {"spinSpeed": "400"},
+                "fixed": {"temp": "30"},
+                "absent": ["prewash"],
+            },
             block["program_options"]["per_program"]["delicate"],
         )
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8304,6 +8304,26 @@ class ProgramOptionMatrixTest(unittest.TestCase):
         matrix = self._matrix(categories)
         self.assertEqual(cap, len(matrix["per_program"]["cotton"]["fixed"]["programFamily"]))
 
+    def test_a_mac_straddling_the_cap_is_masked_before_it_is_cut(self) -> None:
+        # PR #104 review (coderabbitai). `_redact` walks the finished block and the only
+        # value-shaped mask, `_MAC_RE`, matches a MAC only with all six octet groups
+        # present. Slicing to the cap FIRST hands it a fragment that no longer matches, and
+        # the remains travel to a public issue in cleartext. Measured on this very value:
+        # cut-first ends "...3c:71:bf:", mask-first ends "...***".
+        # Mutation-proof: `str(declared)[:cap]` leaves the octets in the output.
+        cap = diagnostics._PROGRAM_MATRIX_VALUE_MAX_CHARS
+        straddling = "x" * (cap - 9) + "3c:71:bf:b8:11:22"
+        categories = {
+            "cotton": FakeCommand({
+                "programFamily": FakeParam(value=straddling, typology="fixed",
+                                           values=[straddling], schema=straddling),
+            }),
+        }
+        emitted = self._matrix(categories)["per_program"]["cotton"]["fixed"]["programFamily"]
+        self.assertNotIn("3c:71:bf", emitted)
+        self.assertTrue(emitted.endswith("***"), emitted)
+        self.assertLessEqual(len(emitted), cap)
+
     def test_an_unimportable_program_options_costs_the_section_not_the_dump(self) -> None:
         # Same contract `RegistryDegradationTest` pins for the seven platform modules: a
         # module that will not import costs its own tables and never the walk. Mutation-

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -167,6 +167,78 @@ class NativeEnumEdgeBehaviorTest(unittest.TestCase):
             na.value = "A|B|C"
 
 
+class SchemaValueTest(unittest.TestCase):
+    """`HonParameter.schema_value`: what the PROGRAM prescribes, as opposed to what the
+    parameter currently holds.
+
+    The distinction is the whole reason the property exists (issue #98): the Start path
+    writes the user's chosen options into the selected program category's parameters and
+    never undoes them on success, so `value` on a program the user has run before is their
+    own past choice, while `_attributes` is the schema as received and nothing writes to it.
+    Mirrors the hOn app, whose `setValue` reads
+    `dictionaryParameter.fixedValue ?? defaultValue` (decomp.txt:1778771-1778793).
+    """
+
+    def test_fixed_value_wins_over_default(self) -> None:
+        param = NaEnum("x", {"typology": "enum", "enumValues": ["0", "1"],
+                             "fixedValue": "1", "defaultValue": "0"}, "g")
+        self.assertEqual("1", param.schema_value)
+
+    def test_default_used_when_no_fixed(self) -> None:
+        param = NaRange("x", {"typology": "range", "minimumValue": "0",
+                              "maximumValue": "1410", "incrementValue": "30",
+                              "defaultValue": "240"}, "g")
+        self.assertEqual("240", param.schema_value)
+
+    def test_none_when_the_schema_prescribes_nothing(self) -> None:
+        # A pure descriptor: it lists enumValues so a client can render a control and states
+        # no value. Must NOT be confused with the "0" the enum fabricates to keep `value`
+        # non-None -- that "0" is not even among `values`, so surfacing it would blank the
+        # control. This shape is real: 20 such nodes in apk/dump/ac_live/commands_raw.json.
+        param = NaEnum("x", {"typology": "enum", "enumValues": ["2", "4", "5"]}, "g")
+        self.assertIsNone(param.schema_value)
+        self.assertEqual("0", param.value)
+        self.assertNotIn("0", param.values)
+        self.assertFalse(param.declares_value)
+
+    def test_a_declared_zero_counts(self) -> None:
+        param = NaEnum("x", {"typology": "enum", "enumValues": ["0", "1"],
+                             "defaultValue": "0"}, "g")
+        self.assertEqual("0", param.schema_value)
+        self.assertTrue(param.declares_value)
+
+    def test_writing_the_parameter_never_moves_the_schema_value(self) -> None:
+        # The load-bearing property. This is exactly what a previous Start of the same
+        # program leaves behind, and the reason `_prescribed_raw` may not read `value`.
+        param = NaEnum("spinSpeed", {"typology": "enum",
+                                     "enumValues": ["0", "400", "1400"],
+                                     "defaultValue": "400"}, "g")
+        param.value = "1400"
+        self.assertEqual("1400", param.value)
+        self.assertEqual("400", param.schema_value)
+
+    def test_enum_normalizes_the_schema_value_like_values(self) -> None:
+        # `values` and `value` are both clean_value()d, so a cased or bracketed schema code
+        # must be too or it could never be found in the option list.
+        param = NaEnum("zone", {"typology": "enum",
+                                "enumValues": ["[fridge|freezer]", "fridge"],
+                                "defaultValue": "[Fridge|Freezer]"}, "g")
+        self.assertEqual("fridge_freezer", param.schema_value)
+        self.assertIn(param.schema_value, param.values)
+
+    def test_fixed_reports_its_pin(self) -> None:
+        param = NaFixed("temp", {"typology": "fixed", "fixedValue": "40"}, "g")
+        self.assertEqual("40", param.schema_value)
+
+    def test_fixed_declaring_only_a_default_is_still_reported(self) -> None:
+        # `HonParameterFixed.value` reads fixedValue ONLY and answers the fabricated "0" for
+        # this shape; the schema node still carries what was declared, and reporting it is
+        # strictly more truthful than the fabrication.
+        param = NaFixed("temp", {"typology": "fixed", "defaultValue": "3"}, "g")
+        self.assertEqual("0", param.value)
+        self.assertEqual("3", param.schema_value)
+
+
 class RangeGridSetterTest(unittest.TestCase):
     """Regression for the x100 modulo grid-check bug: an on-grid setpoint with a
     non-zero min and a decimal step (e.g. 20.1 on 20..25 step 0.1) was wrongly


### PR DESCRIPTION
Automated release PR for `v5.24.0`.

<!-- release-tag: v5.24.0 -->

## Summary by Sourcery

Release version 5.24.0 with schema-aware program option diagnostics and expanded regression coverage.

New Features:
- Expose immutable schema-prescribed parameter values separately from mutable live parameter state.
- Include schema-prescribed defaults and fixed values in per-program option diagnostics, including explicit nulls when no value is prescribed.

Bug Fixes:
- Prevent diagnostics from reporting stale user-selected values as program prescriptions.
- Ensure diagnostic values are redacted before length limiting to avoid exposing partial sensitive values.

Enhancements:
- Normalize schema values consistently with enum values and live values.
- Clarify and enforce diagnostic output types for nullable option values.

Tests:
- Expand regression coverage for schema precedence, enum normalization, mutation resistance, descriptor-only parameters, nullable diagnostics, and redaction behavior.

Chores:
- Bump the integration manifest version to 5.24.0.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer reporting of parameter values prescribed by device configuration schemas.
  - Option matrices now show each adjustable setting together with its configured default value.
  - Fixed settings now report their configured values consistently, including cases where no value is specified.

- **Bug Fixes**
  - Improved handling of zero-valued and fixed parameters.
  - Normalized enumerated parameter values for more reliable matching across formatting differences.
  - Ensured reported configuration values remain based on the schema rather than changing with live runtime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release separates immutable schema-prescribed parameter values from mutable runtime values and reports those prescriptions in the diagnostic program-option matrix.
- Adds `schema_value` handling with enum normalization and fixed-before-default precedence.
- Reports schema defaults for settable options and nullable prescriptions for descriptor-only parameters.
- Masks schema values before applying diagnostic length limits.
- Adds regression coverage and updates the integration version to 5.24.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable new issue or outstanding previous finding remains.

The previous nullable-map annotation finding was manually resolved, and the current annotations now explicitly permit `None`. The subsequent masking change uses the established bounded-text path to redact cloud-controlled schema values before truncation without introducing a demonstrated contract or runtime failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/client/engine/parameter/base.py | Adds an immutable schema-value accessor and bases declared-value detection on it. |
| custom_components/addhon/client/engine/parameter/enum.py | Normalizes schema-prescribed enum values consistently with live values and choices. |
| custom_components/addhon/diagnostics.py | Reports nullable schema prescriptions for fixed and settable options while masking before truncation. |
| custom_components/addhon/manifest.json | Updates the integration release version to 5.24.0. |
| tests/test_diagnostics.py | Covers schema-derived defaults, nullable prescriptions, mutable-state isolation, and safe bounded masking. |
| tests/test_engine_parameters.py | Covers schema-value precedence, normalization, zero values, absent declarations, and immutability. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Cloud program schema] --> B[Parameter attributes]
  B --> C[schema_value]
  C --> D[Enum normalization when applicable]
  D --> E[Mask then bound text]
  E --> F{Option classification}
  F -->|Multiple reachable values| G[Settable option and schema default]
  F -->|Fixed or single value| H[Fixed option and prescribed value]
  G --> I[Diagnostic program matrix]
  H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: mask the prescribed value before bo..."](https://github.com/tis24dev/addhon/commit/7a7ccbf5a12968984bf7e7e7a6ceccfd8a943745) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62103285)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Command and parameter engine](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/command-and-parameter-engine.md)
- Knowledge Base — [Program selection and options](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/program-selection-and-options.md)
- Knowledge Base — [Diagnostics and safe observability](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/diagnostics-and-safe-observability.md)
- Knowledge Base — [Quality and release controls](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/quality-and-release-controls.md)
</details>


<!-- /greptile_comment -->