### PR TITLE
Release v5.25.0

### DIFF
--- a/custom_components/addhon/CHANGELOG.md
+++ b/custom_components/addhon/CHANGELOG.md
@@ -9,29 +9,80 @@ the notes were generated automatically carry a link to their diff instead of a s
 
 ## [Unreleased]
 
-**New Features**
+**Changes**
 
-- **A fridge's modes are no longer one dropdown** (#93). Super Cool, Super Freeze,
-  Auto-set and Holiday are four separate settings on the appliance, not four values of
-  one setting: the reporter pointed out that the app lets My Zone sit at 0 °C while
-  Super Cool runs, and the appliance's own command catalogue agrees -- each mode writes
-  exactly one register and clears nothing else. They are now four switches, one per
-  mode, that can be on together. Turning one off clears only that mode, which is what
-  the official app does and what the single dropdown did not: its "off" sent the reset
-  that clears all four at once, so switching Super Cool off also switched Auto-set,
-  Super Freeze and Holiday off.
-- The **My Zone drawer's mode is now settable** on the fridges whose catalogue carries
-  it -- 0 °C fresh, Quick cool, Fruit and vegetables. It has no "off" because the
-  appliance has none: the drawer is always in one of its own modes.
-- The fridge's **downloaded presets** (Daily use, Extra cold, Extra ice, High
-  efficiency, Special food) each get a **button** that sends the preset. They are
-  buttons and not switches because the appliance keeps no record of which one ran: the
-  official app can only show the last one you sent from that phone.
-- **Zone temperatures are set with a slider** instead of a free-text box, over exactly
-  the degrees the appliance allows -- 1 to 9 for the fridge zone, -24 to -14 for the
-  freezer on the reported model. The wine cooler, the oven and the cooker hood keep the
-  box, and so does a zone whose temperatures the appliance publishes as a fixed list of
-  choices.
+- **Picking a programme now presets the options that programme calls for** (#98). With a
+  programme selected and an option you have not touched, the switches, the dropdowns and
+  the delayed start show what THAT programme prescribes instead of the settings the last
+  cycle finished with: choosing a programme that calls for an extra rinse turns the extra
+  rinse on. Anything you set yourself still wins, and with no programme selected nothing
+  changes at all.
+- **Starting a programme you have just re-selected no longer repeats your last cycle.**
+  The options of a programme were kept from the last time you ran it and sent again on
+  every later start, whatever the programme itself says, because nothing ever put them
+  back. Re-selecting a programme now starts it at its own settings. The two ways to
+  repeat a cycle are unchanged and are the ones the official app has: press start
+  WITHOUT re-selecting the programme, or use a favourite, which is never rebuilt.
+
+## [5.24.0] - 2026-09-09
+
+**Changes**
+
+- **The device diagnostics now report what each programme would START an option at**,
+  not just whether the option exists. The section shipped in 5.23.0 printed a value only
+  for the options a programme pins, so for a settable one it said the control is there
+  and never what the programme would set it to -- which is the half that matters for
+  #98. Both lists now carry a value, and both read it from the appliance's own catalogue
+  rather than from the running command: a dump taken after a cycle would otherwise report
+  your own past choice as the programme's prescription. An option the catalogue says
+  nothing about is reported as nothing, instead of the placeholder the engine keeps
+  internally so its readings are never empty.
+
+**Fixes**
+
+- A MAC address sitting exactly on the length limit of a reported value could be cut
+  before it was masked, and travel in the clear. It is masked first now.
+
+## [5.23.0] - 2026-09-08
+
+**Fixes**
+
+- **The washer's option controls described the wrong programme** (#98). Selecting
+  "Delicati" and then "Intensivo 40 C" left every spin speed, temperature, soil level and
+  delayed-start bound exactly as it was: none of the three control types looked at the
+  programme you had picked. Selecting a programme stores your choice and swaps nothing --
+  the swap happens when you press start -- and on every load addhOn re-points the start
+  command at the programme the cloud last accepted, so the controls were describing the
+  cycle that had FINISHED. Proven in the debug log attached to the issue: the appliance
+  reported the same finished programme on all seven polls while the pending choice moved
+  through five different ones, and the delayed-start bounds offered for the whole session
+  were the finished cycle's. Each control now reads the schema of the programme you
+  selected, which the appliance publishes per programme and addhOn already held in
+  memory -- and which is where the official app rebuilds its own option list from on
+  every programme change.
+
+**Changes**
+
+- The device diagnostics gained a section listing, per programme, which options that
+  programme exposes, which it pins and which it leaves settable. It is what made the
+  above provable on a real appliance instead of on a fixture.
+
+## [5.22.1] - 2026-09-05
+
+**Fixes**
+
+- **A washer-dryer's wash-and-dry programmes no longer start as wash-only** (#99). The
+  drying level was being forced to zero, and locked there, before you ever saw the
+  control: every wash-and-dry programme carries a rule that reads "with the dry option
+  off, the dry level is zero", and addhOn was applying it while it built the command
+  rather than when something actually switched the dry option. The official app never
+  applies that rule -- it ships on the programmes that CAN dry, and it describes where
+  the dry switch starts, not what the programme is allowed to do. Rules now apply when a
+  value changes, which is what they are for. Setting a dry level that the appliance
+  accepts no longer fails with "Allowed values: ['0']", and a wash-and-dry cycle runs the
+  drying it was asked for.
+
+## [5.22.0] - 2026-09-05
 
 **Changes**
 
@@ -58,6 +109,8 @@ the notes were generated automatically carry a link to their diff instead of a s
   code, its firmware and series identifiers and the catalogue itself.
 - Failing to write the catalogue cache no longer discards a catalogue that was fetched
   successfully, and an unchanged cache is no longer re-serialized on every poll.
+- A Hong Kong installation asks the catalogue endpoint for `zh-hk` instead of having its
+  language truncated to `zh`.
 - **A fridge's drawer is recognised from the setting the app itself reads.** Some
   refrigerators describe the My Zone drawer only through the `tempSelZ3` setting -- as a
   list of choices, which is exactly where the official app takes the drawer's mode list
@@ -85,55 +138,11 @@ the notes were generated automatically carry a link to their diff instead of a s
   same appliance also gets a control for them. That was written once and never revisited,
   so an appliance that later started up without its command catalogue lost the control
   and kept the reading hidden -- both gone, with nothing said. The reading is now given
-  back whenever its control is missing. A reading you disabled yourself stays disabled.
-- The single fridge **program dropdown is no longer created** where the per-mode
-  controls above can be built, which is every fridge we have seen a diagnostics dump
-  for. Automations calling `select.select_option` on it must move to the new switches,
-  to the My Zone select, or to the preset buttons. It stays, unchanged, on a fridge
-  whose catalogue offers only downloaded presets.
-- The four fridge mode **readings** (`binary_sensor`) stay, and are **hidden by default
-  on a new install only where a switch really replaces them** — a fridge whose appliance
-  cannot clear a given mode on its own keeps that reading visible, because nothing there
-  took its place. Nobody loses one either way: a reading already in your registry keeps
-  working, and a hidden one is one click away in the entity settings.
-- The four readings are also **renamed** — "Super cool (reading)" and so on — so the
-  reading and the switch that acts on the same mode are no longer two entities with one
-  name on the same device.
-- The zone **setpoint controls are renamed** to say what they are ("Zone 1 target
-  temperature"), which they previously shared word for word with the measured-temperature
-  sensor beside them.
-- **The old program dropdown is removed from the entity registry** where it was replaced,
-  instead of being left behind as an unavailable entity with a "?" badge, and a **repair
-  notice** tells you it happened and what replaced it. Worth reading if you automated it:
-  a call to an entity that no longer exists does not fail — Home Assistant logs a warning
-  and reports the service call as successful, so the automation keeps running and does
-  nothing. The removal is deliberate and cannot be undone: the entity's history ends
-  there. On a fridge that keeps the dropdown, nothing is touched.
+  back whenever its control is missing. A reading you disabled yourself stays disabled,
+  and one given back keeps the name your own registry row carries.
 
 **Fixes**
 
-- **A washer-dryer's wash-and-dry programmes no longer start as wash-only** (#99). The
-  drying level was being forced to zero, and locked there, before you ever saw the
-  control: every wash-and-dry programme carries a rule that reads "with the dry option
-  off, the dry level is zero", and addhOn was applying it while it built the command
-  rather than when something actually switched the dry option. The official app never
-  applies that rule -- it ships on the programmes that CAN dry, and it describes where
-  the dry switch starts, not what the programme is allowed to do. Rules now apply when a
-  value changes, which is what they are for. Setting a dry level that the appliance
-  accepts no longer fails with "Allowed values: ['0']", and a wash-and-dry cycle runs the
-  drying it was asked for.
-- **The My Zone mode sensor is removed from the registry** where the writable select
-  replaced it, instead of being left behind unavailable under the same name as its
-  replacement. Only there: a fridge that gets the mode switches but has no drawer
-  programs keeps its sensor, because nothing took its place.
-- **A four-door fridge now gets its fourth door** (discussion #94). The zone was already
-  reporting its temperature; only the door was missing, on an appliance that publishes it.
-- **My Zone mode no longer reports a whole-appliance preset as the drawer's state.** On
-  a fridge whose downloaded presets also write the drawer's register, the mode sensor
-  answered with the first preset that happened to write the same number.
-- **A drawer that has modes no longer also offers a target temperature.** On the models
-  that declare both, two controls wrote one register and the temperature one published
-  0, 2 or 5 as degrees Celsius — "a drawer set to 0 °C fresh reads 0 °C".
 - **A zone temperature is no longer accepted and then silently undone.** Auto set, Super
   cool and Holiday each pin the fridge zone to a temperature of the appliance's choosing;
   a value sent from Home Assistant was taken by the cloud and overwritten by the
@@ -148,6 +157,109 @@ the notes were generated automatically carry a link to their diff instead of a s
 - **A refused fridge command is reported in your language.** Starting a mode that the
   cloud rejected produced an untranslated "Can't send command"; switching one off, on the
   same appliance, produced a proper message. Both now answer the same way.
+
+## [5.21.1] - 2026-08-28
+
+**Fixes**
+
+- **The My Zone mode reading is kept, hidden, instead of being deleted** (#93). 5.21.0
+  removed it from the registry wherever the new writable selector replaced it, which ends
+  its history and cannot be undone. It is now hidden instead: the duplicate disappears
+  from the dashboard just the same, the recorded history survives, and one click in the
+  entity settings brings it back.
+
+## [5.21.0] - 2026-08-28
+
+**New Features**
+
+- **A fridge's modes are no longer one dropdown** (#93). Super Cool, Super Freeze,
+  Auto-set and Holiday are four separate settings on the appliance, not four values of
+  one setting: the reporter pointed out that the app lets My Zone sit at 0 °C while
+  Super Cool runs, and the appliance's own command catalogue agrees -- each mode writes
+  exactly one register and clears nothing else. They are now four switches, one per
+  mode, that can be on together. Turning one off clears only that mode, which is what
+  the official app does and what the single dropdown did not: its "off" sent the reset
+  that clears all four at once, so switching Super Cool off also switched Auto-set,
+  Super Freeze and Holiday off.
+- The **My Zone drawer's mode is now settable** on the fridges whose catalogue carries
+  it -- 0 °C fresh, Quick cool, Fruit and vegetables. It has no "off" because the
+  appliance has none: the drawer is always in one of its own modes.
+- The fridge's **downloaded presets** (Daily use, Extra cold, Extra ice, High
+  efficiency, Special food) each get a **button** that sends the preset. They are
+  buttons and not switches because the appliance keeps no record of which one ran: the
+  official app can only show the last one you sent from that phone.
+- **Zone temperatures are set with a slider** instead of a free-text box, over exactly
+  the degrees the appliance allows -- 1 to 9 for the fridge zone, -24 to -14 for the
+  freezer on the reported model. The wine cooler, the oven and the cooker hood keep the
+  box, and so does a zone whose temperatures the appliance publishes as a fixed list of
+  choices.
+
+**Changes**
+
+- The single fridge **program dropdown is no longer created** where the per-mode
+  controls above can be built, which is every fridge we have seen a diagnostics dump
+  for. Automations calling `select.select_option` on it must move to the new switches,
+  to the My Zone select, or to the preset buttons. It stays, unchanged, on a fridge
+  whose catalogue offers only downloaded presets.
+- The four fridge mode **readings** (`binary_sensor`) stay, and are **hidden by default
+  on a new install only where a switch really replaces them** -- a fridge whose appliance
+  cannot clear a given mode on its own keeps that reading visible, because nothing there
+  took its place. Nobody loses one either way: a reading already in your registry keeps
+  working, and a hidden one is one click away in the entity settings.
+- The four readings are also **renamed** -- "Super cool (reading)" and so on -- so the
+  reading and the switch that acts on the same mode are no longer two entities with one
+  name on the same device.
+- The zone **setpoint controls are renamed** to say what they are ("Zone 1 target
+  temperature"), which they previously shared word for word with the measured-temperature
+  sensor beside them.
+- **The old program dropdown is removed from the entity registry** where it was replaced,
+  instead of being left behind as an unavailable entity with a "?" badge, and a **repair
+  notice** tells you it happened and what replaced it. Worth reading if you automated it:
+  a call to an entity that no longer exists does not fail -- Home Assistant logs a warning
+  and reports the service call as successful, so the automation keeps running and does
+  nothing. The removal is deliberate and cannot be undone: the entity's history ends
+  there. On a fridge that keeps the dropdown, nothing is touched.
+
+**Fixes**
+
+- **A four-door fridge now gets its fourth door** (discussion #94). The zone was already
+  reporting its temperature; only the door was missing, on an appliance that publishes it.
+- **My Zone mode no longer reports a whole-appliance preset as the drawer's state.** On
+  a fridge whose downloaded presets also write the drawer's register, the mode sensor
+  answered with the first preset that happened to write the same number.
+- **A drawer that has modes no longer also offers a target temperature.** On the models
+  that declare both, two controls wrote one register and the temperature one published
+  0, 2 or 5 as degrees Celsius -- "a drawer set to 0 °C fresh reads 0 °C".
+- A favourite you saved on the appliance is no longer mistaken for one of its standard
+  programs by the classifiers that decide which controls to build.
+
+## [5.20.0] - 2026-08-27
+
+**New Features**
+
+- **A fridge reports its fault register and its My Zone drawer mode** (#93), two values
+  the appliance publishes and addhOn had never read.
+
+**Changes**
+
+- **The two debug switches are now admin-only** (#92, raised in the HACS default review).
+  They write the same process-wide log level the debug services do, and those services
+  were already admin-only, so the two routes to one capability disagreed about who may
+  use it. The Reset debug button stays open on purpose: it only turns the logging off.
+- **The diagnostics no longer accuse your appliance of hiding fields addhOn itself
+  wrote** (#93). The reporter's fridge dump listed five values as "returned by the API
+  and unmapped", and three of them were addhOn's own output, written into the same
+  dictionary a moment before the dump read it. Those names are now reported separately
+  and kept out of the coverage ratio, so the one list the section calls its gold signal
+  measures the device again.
+- Two of those three, a per-zone mode addhOn derived itself, are **gone** (#93). Haier
+  publishes no such field -- it appears nowhere in the official app -- nothing in addhOn
+  ever read them, and the per-zone mode the app really does compute follows different
+  rules per zone and per model, so a flat two-zone table was wrong for a whole family of
+  appliances.
+- The supported-devices and tested-hardware section was removed from the README, and
+  CONTRIBUTING no longer tells contributors to bump the manifest version by hand: the
+  release automation writes it and refuses a release whose manifest and tag disagree.
 
 ## [5.19.2] - 2026-08-26
 
@@ -202,6 +314,38 @@ the notes were generated automatically carry a link to their diff instead of a s
   declaration, not a choice of this integration: its stop command pins the light to `"0"`
   as a fixed value. Stopping only the fan, with the light left alone, is what the fan
   entity now does — this note replaces the 5.18.0 one that described the old behaviour.
+
+## [5.19.0] - 2026-08-24
+
+**New Features**
+
+- **The account's own Download diagnostics button returns the account dump.** It could
+  only ever answer `{"generated_at": ...}`, on every install, and hardest in the one case
+  it matters most: on an account with no appliances that service device is the only
+  device there is, so its broken button was the only button to press. It is how an empty
+  report reached us instead of the self-contained dump 5.17.0 had shipped for exactly
+  that situation.
+- **An account that owns nothing is now told apart from a module that failed and from a
+  session that resolved to somebody else's account.** All three used to produce the same
+  sentence -- the cloud answered, the list was empty -- and an investigation open for
+  weeks could not separate them from a dump. The report now carries what the cloud itself
+  declared about the call, whether the appliance-list module reported success, whether the
+  server handed back a replacement token, and whether our own session identity matches the
+  appliances returned. No key name and no value from any of it: a count and a verdict.
+  Family sharing is not a fault, and the wording says so -- an appliance shared with you
+  is stamped with its owner's account, which is normal and is reported as a boundary, not
+  as a diagnosis.
+
+**Fixes**
+
+- **A malformed appliance list can no longer take the whole integration down.** The
+  parser promised to answer with an empty list on any unexpected shape and did not keep
+  the promise for one shape, which escaped as an error out of setup naming nothing a
+  reporter could act on.
+- **The logs describe a rejected response without quoting it.** A public warning carries
+  the shape of what arrived rather than a masked copy of the body, a value that happens to
+  be used as a key is redacted like any other value, and the summary's own key names
+  follow the same rule.
 
 ## [5.18.0] - 2026-08-24
 

--- a/custom_components/addhon/button.py
+++ b/custom_components/addhon/button.py
@@ -276,6 +276,39 @@ class HonProgramCommandButton(HonBaseEntity, ButtonEntity):
                         # Snapshot the post-swap command's params too, so options/fixed
                         # applied below are rolled back with the swap on a send failure.
                         rollback["snapshots"].append((params, snapshot_params(params)))
+                    # (a2) Rebuild the SELECTED category from its schema, which is what the
+                    # hOn app gets for free by rebuilding its parameter map on every program
+                    # opening (`openProgramEpic`, decomp.txt:3618118-3618266) and dropping it
+                    # on unmount. Our categories instead live for the whole config entry and
+                    # keep whatever an earlier Start of this same program wrote into them
+                    # (the options are applied below and `rollback.clear()` keeps them on
+                    # success), so without this a re-selected program silently repeats the
+                    # user's old choices instead of starting at what it prescribes -- issue
+                    # #98, analysis section 9.
+                    #
+                    # AFTER the snapshots above, so a refused send rolls the rebuild back
+                    # too, and BEFORE (b), so the buffered options -- the user's explicit
+                    # choice, the one thing this must never touch -- are applied on top.
+                    #
+                    # Gated on the selected code being a real CATEGORY: `HonCommand.
+                    # categories` answers `{"_": self}` for a category-less command, whose
+                    # program parameter is a plain prCode enum, and rebuilding that would
+                    # reset the very parameter carrying the choice. A favourite refuses on
+                    # its own (it IS the user's saved configuration). `getattr` because the
+                    # command doubles in the tests have no such method.
+                    if pending_program is not None and pending_program in getattr(
+                        command, "categories", {}
+                    ):
+                        rebuild = getattr(command, "rebuild_from_schema", None)
+                        if callable(rebuild):
+                            # Called on its own line and NOT inside the debug arguments:
+                            # this rebuild is what the Start transmits, not a diagnostic.
+                            rebuilt = rebuild()
+                            _LOGGER.debug(
+                                "Button debug: program '%s' rebuilt from schema: %s",
+                                pending_program,
+                                rebuilt,
+                            )
                     # (b) Apply the buffered program options to the POST-SWAP command
                     # (#35): selecting the program swaps the active startProgram command,
                     # so the options must land on the new one. apply_pending_options skips

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -364,3 +364,43 @@ class HonCommand:
     def reset(self) -> None:
         for parameter in self._parameters.values():
             parameter.reset()
+
+    @property
+    def is_favourite(self) -> bool:
+        """True if this category is a saved favourite.
+
+        Reads the `favourite="1"` marker `HonCommandLoader._add_favourites` injects into
+        the copy -- the same one `HonParameterProgram._is_favourite` uses to tell a schema
+        slug apart from a user-typed name."""
+        favourite = self._parameters.get("favourite")
+        return favourite is not None and str(getattr(favourite, "value", "")) == "1"
+
+    def rebuild_from_schema(self) -> bool:
+        """Put every parameter back to what its schema declares. True if it ran.
+
+        This is `openProgramEpic` (@3618118-3618266), which the hOn app runs on every
+        program opening: it rebuilds the whole parameter map from `dictionaryParameters`
+        and drops it on unmount, so its display and its payload cannot drift apart. Our
+        categories instead live for the whole config entry and are written by the Start
+        path (`apply_pending_options`, kept on success), by `_recover_last_command_states`
+        and by the favourites, with nothing ever putting them back -- which is why a
+        program the user has run before starts at their old choice rather than at what it
+        prescribes. Analysis: apk/analysis/issue98-99-program-options-and-wd-dry.md section 9.
+
+        A FAVOURITE is refused: it IS the user's saved configuration, so rebuilding it
+        would erase the thing they asked for. The app agrees -- opening a favourite feeds
+        the saved values into `setValue`'s highest-precedence slot instead of reading the
+        schema (@3617979).
+
+        The program parameter is left alone by its own no-op `reset()`, and the static
+        `$...` config rules go back on afterwards (see `HonRuleSet.reapply_static_rules`,
+        which deliberately is not `patch()`). `_category_name`, `_selected_explicitly` and
+        `_data` are not touched: they are identity and transport, not schema.
+        """
+        if self.is_favourite:
+            return False
+        for parameter in self._parameters.values():
+            parameter.reset()
+        for rule in self._rules:
+            rule.reapply_static_rules()
+        return True

--- a/custom_components/addhon/client/engine/commands.py
+++ b/custom_components/addhon/client/engine/commands.py
@@ -366,6 +366,14 @@ class HonCommand:
             parameter.reset()
 
     @property
+    def rule_targets(self) -> set[str]:
+        """Names of the parameters this command's rules can write (see `HonRuleSet`)."""
+        targets: set[str] = set()
+        for ruleset in self._rules:
+            targets |= ruleset.rule_targets
+        return targets
+
+    @property
     def is_favourite(self) -> bool:
         """True if this category is a saved favourite.
 

--- a/custom_components/addhon/client/engine/parameter/enum.py
+++ b/custom_components/addhon/client/engine/parameter/enum.py
@@ -37,8 +37,6 @@ class HonParameterEnum(HonParameter):
         self._value: str | float = ""
         self._values: list[str] = []
         self._set_attributes()
-        if self._default and clean_value(self._default) not in self.values:
-            self._values.append(str(self._default))
 
     def _set_attributes(self) -> None:
         super()._set_attributes()
@@ -55,6 +53,15 @@ class HonParameterEnum(HonParameter):
             self._values = [str(v) for v in raw_values]
         else:
             self._values = []
+        # A `defaultValue` the schema does not repeat in `enumValues` is still selectable:
+        # it is what `_set_attributes` just seeded `_value` with, and a value outside its
+        # own `values` is refused by this class's own setter. Real shape, 23 nodes in the
+        # corpus: the washing machine's `startProgram.programFamily` declares
+        # `['dashboard','smart']` with `defaultValue` `'[dashboard|smart]'`.
+        # It lives HERE and not in `__init__` so `reset()` -- which re-runs this method
+        # alone -- reproduces construction exactly (issue #98's per-program rebuild).
+        if self._default and clean_value(self._default) not in self.values:
+            self._values.append(str(self._default))
 
     def __repr__(self) -> str:
         return f"{self.__class__} (<{self.key}> {self.values})"

--- a/custom_components/addhon/client/engine/parameter/program.py
+++ b/custom_components/addhon/client/engine/parameter/program.py
@@ -51,6 +51,17 @@ class HonParameterProgram(HonParameterEnum):
         else:
             raise ValueError(f"Allowed values: {self.values} But was: {value}")
 
+    def reset(self) -> None:
+        """No-op: this parameter has no schema to go back to.
+
+        It is a VIEW over the command's categories and is built on an EMPTY attributes dict
+        (`super().__init__(key, {}, group)`), so the inherited `reset()` -- which re-runs
+        `_set_attributes()` -- would seed `_value` with the enum's fabricated "0" and blank
+        `_typology`, and `name_for_code` trusts both. The selected program is not a value
+        the schema prescribes: it is the choice the rebuild happens BECAUSE of
+        (`HonCommand.rebuild_from_schema`).
+        """
+
     @property
     def values(self) -> list[str]:
         values = [v for v in self._programs if all(f not in v for f in self._FILTER)]

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -296,6 +296,19 @@ class HonRuleSet:
         self._attach_triggers()
         self._apply_config_rules()
 
+    def reapply_static_rules(self) -> None:
+        """Re-apply ONLY the `$...` (static device config) rules.
+
+        For `HonCommand.rebuild_from_schema`: a reset hands every parameter back the value
+        its schema declares, which undoes a pin that describes the DEVICE rather than a
+        user's choice (`$installationType` -> `remoteVisible`). Those must go back on.
+
+        The runtime triggers must NOT be re-attached, which is why this is not `patch()`:
+        `reset()` does not clear the trigger tables, so re-running the whole patch would
+        register every rule a second time and a single write would then cascade twice.
+        """
+        self._apply_config_rules()
+
     def _attach_triggers(self) -> None:
         """Register every (already-expanded) rule as a trigger on its command's params."""
         for name, parameter in self._command.parameters.items():

--- a/custom_components/addhon/client/engine/rules.py
+++ b/custom_components/addhon/client/engine/rules.py
@@ -296,6 +296,21 @@ class HonRuleSet:
         self._attach_triggers()
         self._apply_config_rules()
 
+    @property
+    def rule_targets(self) -> set[str]:
+        """Names of the parameters any rule in this set can WRITE.
+
+        Both kinds: the runtime triggers (`_rules` is keyed by the TRIGGER parameter, so
+        the target is each rule's own `param_key`) and the static `$...` config rules.
+
+        A parameter in here is not described by its schema node -- a rule moves it, at
+        build time or when its trigger fires -- so a reader that wants to report what a
+        program prescribes must leave it alone (`HonProgramOptionEntity._prescribed_raw`).
+        """
+        targets = {rule.param_key for rules in self._rules.values() for rule in rules}
+        targets.update(param_key for param_key, _, _ in self._config_rules)
+        return targets
+
     def reapply_static_rules(self) -> None:
         """Re-apply ONLY the `$...` (static device config) rules.
 

--- a/custom_components/addhon/diagnostics.py
+++ b/custom_components/addhon/diagnostics.py
@@ -871,6 +871,20 @@ def _program_option_matrix(appliance) -> dict:
                 settable[name] = value
             else:
                 fixed[name] = value
+        # Which parameters this program's RULES can write. The prescription above is the
+        # schema node and nothing moves it; a rule does, when the options are applied at
+        # Start, so a reader comparing this section against what the machine actually
+        # started needs to know which rows the cascade can overrule. The rule BODY is not
+        # printable here -- it is a nested dict, and `schema_value` answers `null` for it,
+        # which is exactly what an empty node answers too, so the two are indistinguishable
+        # from the value alone. The targets are the part that is both small and decisive.
+        #
+        # Reachable, not hypothetical: on the HW80 and HD100 dumped on 2026-09-11
+        # (`apk/dump/roberto_2026-09-11/`) `programRules` sits in `union_params` of both,
+        # on 8 washer programs -- the Ariel and Dash partner cycles -- and on the dryer's
+        # `hqd_i_refresh`. `getattr` because the command doubles in the tests, and any
+        # engine older than the property, have none.
+        rule_targets = sorted(getattr(category, "rule_targets", None) or ())
         row: dict = {}
         if settable:
             row["settable"] = settable
@@ -878,6 +892,8 @@ def _program_option_matrix(appliance) -> dict:
             row["fixed"] = fixed
         if absent:
             row["absent"] = absent
+        if rule_targets:
+            row["rule_targets"] = rule_targets
         per_program[str(code)] = row
     return {
         "command": STARTPROGRAM_COMMAND,

--- a/custom_components/addhon/manifest.json
+++ b/custom_components/addhon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "awsiotsdk>=1.21.0"
   ],
-  "version": "5.24.0"
+  "version": "5.25.0"
 }

--- a/custom_components/addhon/number.py
+++ b/custom_components/addhon/number.py
@@ -1026,6 +1026,19 @@ class HonProgramOptionNumber(HonProgramOptionEntity, NumberEntity):
     def native_step(self) -> float:
         return self._live_range[2]
 
+    def _renderable(self, raw) -> bool:
+        # Same bounds and the same 1e-6 grid tolerance `async_set_native_value` enforces:
+        # a prescription this box could not accept from the user must not be shown as its
+        # value either.
+        try:
+            value = float(raw)
+        except (ValueError, TypeError):
+            return False
+        lo, hi, step = self._live_range
+        if not lo <= value <= hi or step <= 0:
+            return False
+        return abs((value - lo) / step - round((value - lo) / step)) < 1e-6
+
     @property
     def native_value(self) -> float | None:
         raw = self._current_raw()

--- a/custom_components/addhon/program_options.py
+++ b/custom_components/addhon/program_options.py
@@ -367,8 +367,65 @@ class HonProgramOptionEntity(HonBaseEntity):
         )
         self.async_write_ha_state()
 
+    def _selected_category(self):
+        """The SELECTED program's category command, or None."""
+        code = self._selected_program_code()
+        if code is None:
+            return None
+        command = startprogram_command(self._appliance)
+        categories = getattr(command, "categories", None) if command is not None else None
+        if not isinstance(categories, dict):
+            return None
+        return categories.get(code)
+
+    def _prescribed_raw(self):
+        """What the SELECTED program prescribes for this option, or None.
+
+        The hOn app shows exactly this: with a program freshly picked from the catalogue
+        its `setValue` falls through to `dictionaryParameter.fixedValue ?? defaultValue`
+        of the selected category (decomp.txt:1778771-1778793), which is
+        ``HonParameter.schema_value``. Reading the category's ``value`` instead would
+        report the user's own past choice as the program's prescription -- three writers
+        leave one in there and nothing resets it (see `schema_value`'s own docstring).
+
+        Three cases answer None, each falling the caller back to the device reading:
+
+        - the program is a FAVOURITE. It IS a saved user configuration, so its VALUE is
+          the prescription and its schema node belongs to the base program. The app
+          agrees: opening a favourite fills `setValue`'s highest-precedence slot
+          (@3617979) instead of reading the schema.
+        - a RULE can write this parameter. The cascade fires when the options are applied
+          at Start, so the wire would carry something else and the display would be a
+          promise the payload does not keep. Measured: rule `spinSpeed <- temp==20 -> 400`
+          with a schema default of 1400. No washing-group catalogue on disk carries a
+          `programRules`, so this is a guard, not a live path (analysis section 9.8).
+        - the schema prescribes nothing, or the category does not declare the option.
+        """
+        category = self._selected_category()
+        if category is None:
+            return None
+        param = self._category_option_param()
+        if param is None:
+            return None
+        if getattr(category, "is_favourite", False):
+            return getattr(param, "value", None)
+        if self._param in (getattr(category, "rule_targets", None) or ()):
+            return None
+        return getattr(param, "schema_value", None)
+
+    def _renderable(self, raw) -> bool:
+        """True if THIS control can display ``raw``; the base control always can.
+
+        A switch is a boolean by construction and never refuses. The select and the number
+        override this: a prescription outside the option map or off the live grid would
+        blank the entity, and an honest device reading beats a blank (analysis 8.5.2 --
+        on the reporter's own dump 34 programs pin `temp` and 93 pin `dirtyLevel`, several
+        to codes the merged control does not offer)."""
+        return True
+
     def _current_raw(self):
-        """Pending value if buffered, else the live device value.
+        """Pending value if buffered, else what the selected program prescribes, else the
+        live device value.
 
         Reads ``_get_attr(param)`` (the direct attribute the device reports) and then
         ``_get_attr("startProgram." + param)`` (startProgram is not shadow-synced into
@@ -376,6 +433,9 @@ class HonProgramOptionEntity(HonBaseEntity):
         pending = self._pending().get(self._param)
         if pending is not None:
             return pending
+        prescribed = self._prescribed_raw()
+        if prescribed is not None and self._renderable(prescribed):
+            return prescribed
         raw = self._get_attr(self._param)
         if raw is not None:
             return raw
@@ -425,14 +485,7 @@ class HonProgramOptionEntity(HonBaseEntity):
         Returns None when nothing is pending, when the program parameter is not
         category-backed (a ``prCode``-typed enum keys the store by code, not by category
         name, so the lookup misses), or when the category omits the param."""
-        code = self._selected_program_code()
-        if code is None:
-            return None
-        command = startprogram_command(self._appliance)
-        categories = getattr(command, "categories", None) if command is not None else None
-        if not isinstance(categories, dict):
-            return None
-        category = categories.get(code)
+        category = self._selected_category()
         params = getattr(category, "parameters", None) if category is not None else None
         if isinstance(params, dict):
             return params.get(self._param)

--- a/custom_components/addhon/select.py
+++ b/custom_components/addhon/select.py
@@ -837,6 +837,13 @@ class HonProgramOptionSelect(HonProgramOptionEntity, SelectEntity):
         self._raw_to_key = disambiguate_labels(base_keys)
         self._key_to_raw = {key: raw for raw, key in self._raw_to_key.items()}
 
+    def _renderable(self, raw) -> bool:
+        # A prescribed code this select does not offer would blank the entity; the device
+        # reading is the honest answer instead. Real on the reporter's dump: `delicati_59`
+        # pins temp to a code the merged control does not carry.
+        self._rebuild_maps()
+        return normalize_code(raw) in self._raw_to_key
+
     @property
     def options(self) -> list[str]:
         # One distinct option per exposed raw code (keys are unique; order preserved).

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8233,6 +8233,27 @@ class ProgramOptionMatrixTest(unittest.TestCase):
         matrix = self._matrix({"_": FakeCommand(params)}, active="_")
         self.assertEqual({}, matrix)
 
+    def test_a_programs_rule_targets_are_reported(self) -> None:
+        # Which parameters a program's rules can WRITE. Without it the section states a
+        # prescription the cascade may overrule at Start, and a reader cannot tell the two
+        # apart: the rule body itself is not printable here (it is a nested dict, and
+        # `schema_value` answers `null` for it, which is also what an empty node answers).
+        # Real and reachable: on the HW80 and the HD100 dumped on 2026-09-11, 8 washer
+        # programs and 1 dryer program carry a `programRules` node.
+        catalogue = self._catalogue()
+        catalogue["delicate"].rule_targets = {"spinSpeed"}
+
+        matrix = self._matrix(catalogue)
+
+        self.assertEqual(["spinSpeed"], matrix["per_program"]["delicate"]["rule_targets"])
+
+    def test_a_program_without_rules_reports_no_targets(self) -> None:
+        # Absent, not an empty list: every program of a rule-less appliance would otherwise
+        # carry a key that says nothing, in a section kept small on purpose.
+        matrix = self._matrix(self._catalogue())
+
+        self.assertNotIn("rule_targets", matrix["per_program"]["cotton"])
+
     def test_a_sentinel_only_parameter_is_not_called_settable(self) -> None:
         # PR #103 review (coderabbitai): the entity gate ignores DRY_LEVEL_SENTINELS, so a
         # dryLevel offering only ("", "0", "11") creates NO control. Reporting it as settable

--- a/tests/test_engine_cluster.py
+++ b/tests/test_engine_cluster.py
@@ -1191,6 +1191,93 @@ class ConfigRuleTest(unittest.TestCase):
         self.assertEqual(c.parameters["remoteVisible"].value, 0)
 
 
+class RebuildFromSchemaTest(unittest.TestCase):
+    """`HonCommand.rebuild_from_schema()`: put a program category back to the state it was
+    built in, which is what the hOn app gets for free.
+
+    The app rebuilds its whole parameter map from `dictionaryParameters` every time a
+    program is opened (`openProgramEpic` @3618118-3618266) and throws it away on unmount,
+    so what it displays and what it sends can never drift apart. Our categories instead
+    live for the whole config entry and are written by the Start path, by the command
+    history recovery and by the favourites, with nothing ever resetting one.
+
+    Full analysis: apk/analysis/issue98-99-program-options-and-wd-dry.md section 9.
+    """
+
+    _ATTRS = {
+        "parameters": {
+            "spinSpeed": {"typology": "enum", "category": "command", "mandatory": 0,
+                          "defaultValue": "400", "enumValues": ["0", "400", "1400"]},
+            "temp": _range(default="20", lo="16", hi="30", inc="1"),
+        },
+    }
+
+    def _command(self) -> NaCommand:
+        return NaCommand("startProgram", json.loads(json.dumps(self._ATTRS)),
+                         FakeAppliance(), category_name="PROGRAMS.WM.DELICATE")
+
+    def test_a_value_a_previous_start_left_behind_is_put_back(self) -> None:
+        # The section 8.5.3 repro: the user ran this program at 1400 once, and every later
+        # Start carried 1400 because nothing resets the category.
+        command = self._command()
+        command.parameters["spinSpeed"].value = "1400"
+        self.assertTrue(command.rebuild_from_schema())
+        self.assertEqual("400", command.parameters["spinSpeed"].intern_value)
+
+    def test_the_rebuild_keeps_the_category_identity(self) -> None:
+        command = self._command()
+        command.mark_selected_explicitly()
+        command.rebuild_from_schema()
+        self.assertEqual("PROGRAMS.WM.DELICATE", command.category)
+        self.assertTrue(command.selected_explicitly)
+
+    def test_the_program_parameter_survives_the_rebuild(self) -> None:
+        # `HonParameterProgram` is a VIEW over the command's categories, built on an empty
+        # attributes dict: resetting it from its schema would blank the selected program
+        # and its typology, and `name_for_code` trusts both.
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS))
+        start = app.commands["startProgram"]
+        program = start.parameters["program"]
+        selected = program.value
+        start.rebuild_from_schema()
+        self.assertEqual(selected, program.value)
+        self.assertEqual("enum", program.typology)
+
+    def test_a_favourite_category_is_refused(self) -> None:
+        # A favourite IS the user's saved choice, so rebuilding it would erase the thing
+        # the user asked for. The app agrees: opening a favourite feeds the saved values
+        # into `setValue`'s highest-precedence slot instead of reading the schema.
+        app = _build(NaAppliance, DictApi(_RICH_COMMANDS, favourites=_RICH_FAVOURITES))
+        fav = app.commands["startProgram"].categories["MyFav"]
+        self.assertFalse(fav.rebuild_from_schema())
+        self.assertEqual(7.0, float(fav.parameters["tempSel"].value))
+
+    def test_the_static_config_pin_is_reapplied(self) -> None:
+        # `$installationType` is a persistent device property, not a user choice: a plain
+        # reset would hand back the schema default and undo the pin.
+        command = NaCommand("c", json.loads(json.dumps(_AC_SELF_CLEAN)), _ConfigApp("1toN"),
+                            category_name="PROGRAMS.AC.IOT_SELF_CLEAN")
+        self.assertEqual(0, command.parameters["remoteVisible"].value)
+        command.rebuild_from_schema()
+        self.assertEqual(0, command.parameters["remoteVisible"].value)
+
+    def test_the_rebuild_does_not_duplicate_the_triggers(self) -> None:
+        # Re-running the whole `patch()` would re-register every rule on top of the ones
+        # `__init__` already attached, so one write would fire its cascade twice.
+        attrs = {
+            "parameters": {
+                "mode": _enum("cold", ["cold", "hot"]),
+                "temp": _range(default="20", lo="16", hi="30", inc="1"),
+            },
+            "rules": {"r": _rule({"temp": {"mode": {"hot": {"typology": "fixed", "fixedValue": "28"}}}})},
+        }
+        command = NaCommand("c", json.loads(json.dumps(attrs)), FakeAppliance())
+        before = len(command.parameters["mode"]._triggers.get("hot", []))
+        self.assertEqual(1, before)
+        command.rebuild_from_schema()
+        self.assertEqual(before, len(command.parameters["mode"]._triggers.get("hot", [])))
+
+
 class _HassStub:
     async def async_add_executor_job(self, fn, *a):
         import concurrent.futures

--- a/tests/test_engine_parameters.py
+++ b/tests/test_engine_parameters.py
@@ -239,6 +239,43 @@ class SchemaValueTest(unittest.TestCase):
         self.assertEqual("3", param.schema_value)
 
 
+class EnumResetReproducesConstructionTest(unittest.TestCase):
+    """`reset()` must leave an enum exactly as construction left it.
+
+    `reset()` re-runs `_set_attributes()` and nothing else (`base.py`), so whatever
+    `__init__` does AFTER that call is not reproduced. The enum appends there a
+    `defaultValue` that is not among `enumValues`, which is the shape the real washing
+    machine ships: `startProgram.programFamily` declares `['dashboard','smart']` with
+    `defaultValue` `'[dashboard|smart]'` (23 such nodes across the JSON corpus). A reset
+    parameter therefore held a value outside its own `values`, and re-writing it raised.
+
+    Nothing calls `reset()` today, which is why this was invisible; the per-programme
+    rebuild of issue #98 is the first caller.
+    """
+
+    _PROGRAM_FAMILY = {"category": "command", "typology": "enum", "mandatory": 0,
+                       "defaultValue": "[dashboard|smart]",
+                       "enumValues": ["dashboard", "smart"]}
+
+    def test_reset_keeps_the_out_of_list_default_among_the_values(self) -> None:
+        param = NaEnum("programFamily", dict(self._PROGRAM_FAMILY), "grp")
+        self.assertEqual(["dashboard", "smart", "dashboard_smart"], param.values)
+        param.reset()
+        self.assertEqual(["dashboard", "smart", "dashboard_smart"], param.values)
+
+    def test_the_value_a_reset_leaves_is_accepted_by_its_own_setter(self) -> None:
+        # The rebuild applies the buffered options onto these same parameters immediately
+        # after resetting them, so a value the setter refuses aborts the whole Start.
+        param = NaEnum("programFamily", dict(self._PROGRAM_FAMILY), "grp")
+        param.reset()
+        # What a reset leaves on the wire is the RAW schema form, which is what the real
+        # bodies carry (`programFamily: "[dashboard|smart]"`); only an explicit write
+        # through the setter replaces it with the normalized one.
+        self.assertEqual("[dashboard|smart]", param.intern_value)
+        param.value = param.value
+        self.assertEqual("dashboard_smart", param.value)
+
+
 class RangeGridSetterTest(unittest.TestCase):
     """Regression for the x100 modulo grid-check bug: an on-grid setpoint with a
     non-zero min and a decimal step (e.g. 20.1 on 20..25 step 0.1) was wrongly

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -645,6 +645,154 @@ class ApplyOnStartTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({"washer-1": {"spinSpeed": "800"}}, coordinator.pending_options)
 
 
+class _WireApi:
+    """Records what actually leaves for the cloud, body by body."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.bodies: list[dict] = []
+        self.fail = fail
+
+    async def send_command(self, appliance, name, params, ancillary, category) -> bool:
+        if self.fail:
+            raise RuntimeError("cloud refused")
+        self.bodies.append({"name": name, "params": dict(params), "category": category})
+        return True
+
+
+class _WireAppliance:
+    zone = 0
+    options: dict = {}
+
+    def __init__(self, api) -> None:
+        self.api = api
+        self.commands: dict = {}
+        self.info: dict = {}
+
+    def sync_command_to_params(self, name: str) -> None:
+        pass
+
+
+def _real_categories(api):
+    """A REAL engine startProgram with two program categories.
+
+    Doubles cannot answer the question this class asks -- what leaves on the wire for an
+    option the user never touched -- because the answer is produced by the engine's own
+    serialisation of its own mutated state.
+    """
+    from custom_components.addhon.client.engine.commands import HonCommand
+
+    appliance = _WireAppliance(api)
+    categories: dict = {}
+
+    def _category(name: str, spin_default: str) -> None:
+        attributes = {"parameters": {
+            "spinSpeed": {"typology": "enum", "category": "command", "mandatory": 1,
+                          "defaultValue": spin_default, "enumValues": ["0", "400", "1400"]},
+            "temp": {"typology": "enum", "category": "command", "mandatory": 1,
+                     "defaultValue": "40", "enumValues": ["20", "40", "60"]},
+        }}
+        categories[name] = HonCommand(
+            "startProgram", attributes, appliance, categories=categories,
+            category_name=f"PROGRAMS.WM.{name.upper()}",
+        )
+
+    _category("cotton", "1400")
+    _category("delicate", "400")
+    appliance.commands["startProgram"] = categories["cotton"]
+    return appliance, categories
+
+
+class RebuildAtStartTest(unittest.IsolatedAsyncioTestCase):
+    """Start rebuilds the SELECTED category from its schema before applying the buffer.
+
+    Without it a program the user has run before starts at their old choice: the Start
+    path writes the buffered options into the category's parameters and `rollback.clear()`
+    keeps them, and nothing ever puts them back. The hOn app has no such state to carry --
+    it rebuilds its parameter map on every program opening (`openProgramEpic`
+    @3618118-3618266). Analysis: apk/analysis/issue98-99-program-options-and-wd-dry.md
+    section 9.
+    """
+
+    def _button(self, appliance, api, pending_program=None, pending_options=None,
+                command_name="startProgram"):
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = (
+            {"washer-1": pending_program} if pending_program is not None else {}
+        )
+        coordinator.pending_options = (
+            {"washer-1": dict(pending_options)} if pending_options else {}
+        )
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name=command_name, unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        button.hass = FakeHass()
+        return button
+
+    async def test_a_reselected_program_starts_at_what_it_prescribes(self) -> None:
+        # The section 8.5.3 repro, end to end and on the wire.
+        api = _WireApi()
+        appliance, _ = _real_categories(api)
+        await self._button(appliance, api, "delicate", {"spinSpeed": "1400"}).async_press()
+        self.assertEqual("1400", api.bodies[0]["params"]["spinSpeed"])
+        # Second cycle: the same program is picked again and nothing is touched.
+        await self._button(appliance, api, "delicate").async_press()
+        self.assertEqual("400", api.bodies[1]["params"]["spinSpeed"])
+
+    async def test_start_without_reselecting_repeats_the_last_cycle(self) -> None:
+        # No pending selection means no question about which program is meant, so the
+        # running configuration stands: this is the pre-existing behaviour and it stays.
+        api = _WireApi()
+        appliance, _ = _real_categories(api)
+        await self._button(appliance, api, "delicate", {"spinSpeed": "1400"}).async_press()
+        await self._button(appliance, api).async_press()
+        self.assertEqual("1400", api.bodies[1]["params"]["spinSpeed"])
+
+    async def test_the_buffered_options_are_applied_after_the_rebuild(self) -> None:
+        # Order is load-bearing: rebuilding AFTER the buffer would discard the user's
+        # explicit choice, which is the one thing the rebuild must never touch.
+        api = _WireApi()
+        appliance, _ = _real_categories(api)
+        await self._button(appliance, api, "delicate", {"spinSpeed": "1400"}).async_press()
+        await self._button(appliance, api, "delicate", {"temp": "60"}).async_press()
+        self.assertEqual("60", api.bodies[1]["params"]["temp"])
+        self.assertEqual("400", api.bodies[1]["params"]["spinSpeed"])
+
+    async def test_a_refused_send_leaves_the_category_as_it_was(self) -> None:
+        # The rebuild happens after the snapshot, so the rollback covers it too.
+        ok = _WireApi()
+        appliance, categories = _real_categories(ok)
+        await self._button(appliance, ok, "delicate", {"spinSpeed": "1400"}).async_press()
+        before = dict(categories["delicate"].parameter_groups["parameters"])
+        appliance.api = _WireApi(fail=True)
+        categories["delicate"]._api = appliance.api
+        with self.assertRaises(Exception):
+            await self._button(appliance, appliance.api, "delicate").async_press()
+        self.assertEqual(before, categories["delicate"].parameter_groups["parameters"])
+
+    async def test_a_command_without_categories_is_not_rebuilt(self) -> None:
+        # `HonCommand.categories` answers `{"_": self}` for a category-less command, and a
+        # program code is never "_": the selected code must be reachable as a category or
+        # the rebuild would reset the very parameter carrying the user's choice.
+        from custom_components.addhon.client.engine.commands import HonCommand
+
+        api = _WireApi()
+        appliance = _WireAppliance(api)
+        command = HonCommand("startProgram", {"parameters": {
+            "prCode": {"typology": "enum", "category": "command", "mandatory": 1,
+                       "defaultValue": "1", "enumValues": ["1", "2"]},
+        }}, appliance)
+        appliance.commands["startProgram"] = command
+        await self._button(appliance, api, "2").async_press()
+        self.assertEqual("2", api.bodies[0]["params"]["prCode"])
+
+
 class CapabilityGateSetupTest(unittest.IsolatedAsyncioTestCase):
     async def test_fixed_param_creates_no_select(self) -> None:
         # The anti-"No disponible" assertion: a fixed/single-value option creates NO

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -767,13 +767,17 @@ class RebuildAtStartTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_a_refused_send_leaves_the_category_as_it_was(self) -> None:
         # The rebuild happens after the snapshot, so the rollback covers it too.
+        from homeassistant.exceptions import HomeAssistantError
+
         ok = _WireApi()
         appliance, categories = _real_categories(ok)
         await self._button(appliance, ok, "delicate", {"spinSpeed": "1400"}).async_press()
         before = dict(categories["delicate"].parameter_groups["parameters"])
         appliance.api = _WireApi(fail=True)
         categories["delicate"]._api = appliance.api
-        with self.assertRaises(Exception):
+        # The refusal must surface as the button's own error contract, not a bare
+        # Exception -- a `TypeError` in the setup would otherwise pass unnoticed.
+        with self.assertRaises(HomeAssistantError):
             await self._button(appliance, appliance.api, "delicate").async_press()
         self.assertEqual(before, categories["delicate"].parameter_groups["parameters"])
 

--- a/tests/test_program_options.py
+++ b/tests/test_program_options.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import copy as copy_module
 import sys
 import types
 import unittest
@@ -791,6 +792,212 @@ class RebuildAtStartTest(unittest.IsolatedAsyncioTestCase):
         appliance.commands["startProgram"] = command
         await self._button(appliance, api, "2").async_press()
         self.assertEqual("2", api.bodies[0]["params"]["prCode"])
+
+
+def _prescribing_appliance(api=None, rules=None, favourite=False):
+    """A REAL engine startProgram whose two categories prescribe different things.
+
+    `delicate` PINS extraRinse1 to 1 and temp to 60 (a value its own merged control cannot
+    render); `cotton` leaves both settable. The shadow reports the finished cycle, as a real
+    machine does between programmes.
+    """
+    from custom_components.addhon.client.engine.commands import HonCommand
+
+    appliance = _WireAppliance(api or _WireApi())
+    categories: dict = {}
+
+    cotton = {"parameters": {
+        "extraRinse1": {"typology": "enum", "category": "command", "mandatory": 1,
+                        "defaultValue": "0", "enumValues": ["0", "1"]},
+        "spinSpeed": {"typology": "enum", "category": "command", "mandatory": 1,
+                      "defaultValue": "1400", "enumValues": ["0", "400", "1400"]},
+        "temp": {"typology": "enum", "category": "command", "mandatory": 1,
+                 "defaultValue": "40", "enumValues": ["20", "40"]},
+        "delayTime": {"typology": "range", "category": "command", "mandatory": 0,
+                      "defaultValue": "0", "minimumValue": "0", "maximumValue": "180",
+                      "incrementValue": "30"},
+    }}
+    delicate = {"parameters": {
+        "extraRinse1": {"typology": "fixed", "category": "command", "mandatory": 1,
+                        "fixedValue": "1"},
+        "spinSpeed": {"typology": "enum", "category": "command", "mandatory": 1,
+                      "defaultValue": "400", "enumValues": ["0", "400", "1400"]},
+        "temp": {"typology": "fixed", "category": "command", "mandatory": 1,
+                 "fixedValue": "60"},
+        "delayTime": {"typology": "range", "category": "command", "mandatory": 0,
+                      "defaultValue": "60", "minimumValue": "0", "maximumValue": "180",
+                      "incrementValue": "30"},
+    }}
+    if rules:
+        delicate["parameters"]["programRules"] = {"category": "rule", "fixedValue": rules}
+    for name, attributes in (("cotton", cotton), ("delicate", delicate)):
+        categories[name] = HonCommand(
+            "startProgram", attributes, appliance, categories=categories,
+            category_name=f"PROGRAMS.WM.{name.upper()}",
+        )
+    if favourite:
+        # What `HonCommandLoader._add_favourites` builds: a copy of the base category
+        # carrying the user's saved values and a fixed `favourite="1"` marker.
+        from custom_components.addhon.client.engine.parameter.fixed import HonParameterFixed
+
+        saved = copy_module.copy(categories["cotton"])
+        saved.parameters["favourite"] = HonParameterFixed(
+            "favourite", {"typology": "fixed", "category": "command", "fixedValue": "1"},
+            "parameters",
+        )
+        saved.parameters["extraRinse1"].value = "1"
+        categories["MyFav"] = saved
+    appliance.commands["startProgram"] = categories["cotton"]
+    return appliance, categories
+
+
+class PrescribedReadTest(unittest.IsolatedAsyncioTestCase):
+    """With a programme selected and an option untouched, the controls show what THAT
+    programme prescribes instead of the finished cycle's reading.
+
+    This is the half issue #98 asks for, and the reason it could not ship before: the
+    payload carried whatever an earlier Start had left in the category, so displaying the
+    schema would have promised something the wire did not keep. The Start path now rebuilds
+    the selected category from its schema, so the two agree again.
+    """
+
+    def _switch(self, appliance, attributes, pending=None, options=None):
+        from custom_components.addhon import switch
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": attributes, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": pending} if pending else {}
+        coordinator.pending_options = {"washer-1": dict(options)} if options else {}
+        desc = switch.HonProgramOptionSwitchDescription(
+            key="extra_rinse_1", param="extraRinse1", types=("WM", "WD")
+        )
+        entity = switch.HonProgramOptionSwitch(coordinator, "washer-1", desc, FakeClient())
+        entity.hass = FakeHass()
+        return entity
+
+    def _select(self, appliance, attributes, param, pending=None):
+        from custom_components.addhon import select as select_mod
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": attributes, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": pending} if pending else {}
+        coordinator.pending_options = {}
+        desc = select_mod.HonProgramOptionSelectDescription(
+            key=param, param=param, translation_key=param, types=("WM", "WD")
+        )
+        entity = select_mod.HonProgramOptionSelect(coordinator, "washer-1", desc, FakeClient())
+        entity.hass = FakeHass()
+        return entity
+
+    def _number(self, appliance, attributes, pending=None):
+        from custom_components.addhon import number as number_mod
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": attributes, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": pending} if pending else {}
+        coordinator.pending_options = {}
+        desc = number_mod.HonProgramOptionNumberDescription(
+            key="delay_time", param="delayTime", translation_key="delay_time",
+            types=("WM", "WD")
+        )
+        entity = number_mod.HonProgramOptionNumber(coordinator, "washer-1", desc, FakeClient())
+        entity.hass = FakeHass()
+        return entity
+
+    async def test_a_pinned_option_reads_as_the_programme_prescribes(self) -> None:
+        appliance, _ = _prescribing_appliance()
+        entity = self._switch(appliance, {"extraRinse1": "0"}, pending="delicate")
+        self.assertTrue(entity.is_on)
+
+    async def test_the_buffer_still_wins_over_the_prescription(self) -> None:
+        appliance, _ = _prescribing_appliance()
+        entity = self._switch(appliance, {"extraRinse1": "0"}, pending="delicate",
+                              options={"extraRinse1": "0"})
+        self.assertFalse(entity.is_on)
+
+    async def test_without_a_selection_the_device_reading_stands(self) -> None:
+        appliance, _ = _prescribing_appliance()
+        entity = self._switch(appliance, {"extraRinse1": "0"})
+        self.assertFalse(entity.is_on)
+
+    async def test_a_favourite_shows_the_value_it_saved(self) -> None:
+        # A favourite IS the user's configuration; its schema node is the base programme's
+        # and would report something the favourite never meant.
+        appliance, _ = _prescribing_appliance(favourite=True)
+        entity = self._switch(appliance, {"extraRinse1": "0"}, pending="MyFav")
+        self.assertTrue(entity.is_on)
+
+    async def test_a_settable_option_reads_the_programmes_default(self) -> None:
+        appliance, _ = _prescribing_appliance()
+        entity = self._select(appliance, {"spinSpeed": "1400"}, "spinSpeed", pending="delicate")
+        self.assertEqual("400", entity.current_option)
+
+    async def test_the_prescription_is_the_schema_and_not_a_past_choice(self) -> None:
+        # The load-bearing distinction (analysis 8.5.1). A previous Start of this same
+        # programme left 1400 inside the category and nothing resets it outside the Start
+        # path, so reading `value` would report the user's own past choice as the
+        # programme's prescription -- a subtler version of the bug #98 reports.
+        appliance, categories = _prescribing_appliance()
+        categories["delicate"].parameters["spinSpeed"].value = "1400"
+        entity = self._select(appliance, {"spinSpeed": "0"}, "spinSpeed", pending="delicate")
+        self.assertEqual("400", entity.current_option)
+
+    async def test_a_prescription_the_control_cannot_render_falls_back(self) -> None:
+        # `delicate` pins temp to 60, which its merged control does not offer: showing it
+        # would blank the entity, which is worse than the honest device reading.
+        appliance, _ = _prescribing_appliance()
+        entity = self._select(appliance, {"temp": "40"}, "temp", pending="delicate")
+        self.assertEqual("40", entity.current_option)
+
+    async def test_a_rule_target_falls_back_to_the_device(self) -> None:
+        # A parameter a rule can move is not described by its schema node: the cascade
+        # fires at Start and the wire would carry something else.
+        appliance, _ = _prescribing_appliance(
+            rules={"spinSpeed": {"temp": {"20": {"typology": "fixed", "fixedValue": "0"}}}}
+        )
+        entity = self._select(appliance, {"spinSpeed": "1400"}, "spinSpeed", pending="delicate")
+        self.assertEqual("1400", entity.current_option)
+
+    async def test_what_the_control_shows_is_what_the_start_transmits(self) -> None:
+        # The invariant the whole design exists for, and the one the withdrawn first
+        # attempt broke: for an option the user never touched, display and payload must
+        # agree. A previous Start left 1400 in the category; the control says 400 and the
+        # wire must carry 400, not the two disagreeing (analysis 8.5.3).
+        from custom_components.addhon.button import HonProgramCommandButton
+
+        api = _WireApi()
+        appliance, categories = _prescribing_appliance(api)
+        categories["delicate"].parameters["spinSpeed"].value = "1400"
+        entity = self._select(appliance, {"spinSpeed": "1400"}, "spinSpeed", pending="delicate")
+        shown = entity.current_option
+
+        coordinator = FakeCoordinator(
+            {"washer-1": {"type": "WM", "name": "W", "appliance": appliance,
+                          "attributes": {}, "settings": {}}}
+        )
+        coordinator.pending_programs = {"washer-1": "delicate"}
+        coordinator.pending_options = {}
+        button = HonProgramCommandButton(
+            coordinator, "washer-1", FakeClient(),
+            command_name="startProgram", unique_suffix="start_program",
+            translation_key="start_program", icon="mdi:play-circle",
+        )
+        button.hass = FakeHass()
+        await button.async_press()
+
+        self.assertEqual("400", shown)
+        self.assertEqual(shown, api.bodies[0]["params"]["spinSpeed"])
+
+    async def test_a_number_reads_the_prescription_when_its_range_holds_it(self) -> None:
+        appliance, _ = _prescribing_appliance()
+        entity = self._number(appliance, {"delayTime": "0"}, pending="delicate")
+        self.assertEqual(60.0, entity.native_value)
 
 
 class CapabilityGateSetupTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Automated release PR for `v5.25.0`.

<!-- release-tag: v5.25.0 -->

## Summary by Sourcery

Release version 5.25.0 with schema-driven program rebuilding, accurate pending-program option states, and expanded diagnostics.

New Features:
- Display each selected washer/dryer program’s prescribed option defaults in compatible Home Assistant entities.
- Add program rule targets to diagnostics output.

Bug Fixes:
- Rebuild reselected programs from their schemas before applying pending options so starts no longer reuse stale values from prior cycles.
- Preserve explicit pending options, favourites, static rules, and rollback behavior during program rebuilding.

Enhancements:
- Align switch, select, and number states with pending program prescriptions when those values are renderable.

Documentation:
- Update the changelog with release notes covering program defaults and reselected-program behavior.

Tests:
- Add regression coverage for schema rebuilding, option precedence, favourites, rule targets, payload consistency, reset behavior, and failed-send rollback.

Chores:
- Bump the integration manifest version to 5.25.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Program options now reflect the selected programme’s prescribed settings, including appropriate defaults and rule-driven values.
  * Diagnostics now report which options can be controlled by programme rules.
* **Bug Fixes**
  * Starting a previously used programme now restores its schema-defined defaults instead of reusing settings from an earlier cycle.
  * Programme option controls no longer display invalid or unavailable values.
  * Preset and favourite programme settings remain protected from unintended resets.
* **Chores**
  * Updated the integration to version 5.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release updates programme selection so re-selected programmes rebuild their command parameters from catalogue defaults before pending user choices are applied. It also displays programme-prescribed option values, exposes rule targets in diagnostics, preserves favourites and rollback behavior, restores enum defaults consistently, expands regression coverage, and bumps the integration to 5.25.0.

- Rebuilds selected programme categories from schema at Start while preserving favourites and explicit pending options.
- Displays renderable schema prescriptions for select, switch, and numeric programme options.
- Reports parameters targeted by programme rules in diagnostics.
- Adds payload, rollback, repeat-cycle, favourite, rendering, and enum-reset tests.
- The previous changelog finding remains outstanding: the 5.25.0 notes are still under `Unreleased`.

<h3>Confidence Score: 5/5</h3>

The code changes appear safe to merge; the only remaining concern is the non-blocking previous finding that the 5.25.0 changelog entry is still marked as unreleased.

No new actionable defect was introduced since the previous review. The previous changelog finding remains outstanding because the 5.25.0 notes still appear under `Unreleased` rather than a dated `5.25.0` heading, but this documentation issue does not block merge.

**Files Needing Attention:** custom_components/addhon/CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/addhon/button.py | Rebuilds a re-selected category after rollback snapshots and before applying explicit pending options. |
| custom_components/addhon/client/engine/commands.py | Adds schema rebuilding, favourite protection, and aggregated rule-target reporting. |
| custom_components/addhon/client/engine/rules.py | Exposes rule targets and reapplies static configuration rules without duplicating runtime triggers. |
| custom_components/addhon/program_options.py | Displays selected-programme prescriptions while preserving pending-value precedence and safe fallbacks. |
| custom_components/addhon/client/engine/parameter/enum.py | Makes reset reproduce construction for defaults omitted from the declared enum list. |
| custom_components/addhon/CHANGELOG.md | Restores older version headings, but the current 5.25.0 release notes remain under Unreleased. |
| tests/test_program_options.py | Adds broad regression coverage and narrows the rollback failure assertion to the public Home Assistant error contract. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Select programme] --> B[Pending programme code]
    C[Choose explicit options] --> D[Pending option values]
    B --> E[Press Start]
    E --> F[Select programme category]
    F --> G[Rebuild parameters from schema]
    G --> H[Reapply static rules]
    D --> I[Apply pending user options]
    H --> I
    I --> J[Send startProgram command]
    J -->|Accepted| K[Clear consumed pending state]
    J -->|Rejected| L[Restore parameter snapshots]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(program-options): assert HomeAssist..."](https://github.com/tis24dev/addhon/commit/3a22965aaff55b2cd1905eb899fe61630e930873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63062260)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Program selection and options](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/program-selection-and-options.md)
- Knowledge Base — [Command and parameter engine](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/command-and-parameter-engine.md)
- Knowledge Base — [Device control workflows](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/device-control-workflows.md)
- Knowledge Base — [Quality and release controls](https://app.greptile.com/tis24dev/-/custom-context/knowledge-base/tis24dev/addhon/-/docs/quality-and-release-controls.md)
</details>


<!-- /greptile_comment -->